### PR TITLE
feat(main-processor): add file reading logic

### DIFF
--- a/apps/main-processor/package.json
+++ b/apps/main-processor/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "main-processor",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "vitest",
+    "build": "pnpm exec tsc"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "packageManager": "pnpm@10.33.0",
+  "devDependencies": {
+    "@types/node": "^25.6.0"
+  }
+}

--- a/apps/main-processor/src/file.ts
+++ b/apps/main-processor/src/file.ts
@@ -1,0 +1,13 @@
+import { readFile as fsReadFile } from 'node:fs/promises';
+
+export async function readFile(filePath: string): Promise<string> {
+  try {
+    const content = await fsReadFile(filePath, 'utf-8');
+    return content;
+  } catch (error: unknown) {
+    if (error instanceof Error) {
+      throw new Error(`Could not read file: ${filePath}`, error);
+    }
+    return 'Unknown error';
+  }
+}

--- a/apps/main-processor/tests/file.test.ts
+++ b/apps/main-processor/tests/file.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it, beforeAll, afterAll } from 'vitest';
+import { writeFileSync, unlinkSync, mkdirSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+
+import { readFile } from '../src/file';
+
+const test_dir = join(tmpdir(), 'markdown reader tests');
+const simple_file = join(test_dir, 'simple.md');
+const empty_file = join(test_dir, 'empty.md');
+const unicode_file = join(test_dir, 'unicode.md');
+
+//create directory
+beforeAll(() => {
+  mkdirSync(test_dir, { recursive: true });
+  writeFileSync(simple_file, '# Hello whats up\n\n This is test file', 'utf-8');
+  writeFileSync(empty_file, 'utf-8');
+  writeFileSync(unicode_file, '# こんにちは\n\nThis is emoji file', 'utf-8');
+});
+
+// clean directory
+afterAll(() => {
+  unlinkSync(simple_file);
+  unlinkSync(empty_file);
+  unlinkSync(unicode_file);
+});
+describe('readFile', () => {
+  // test-1 :- it should check the existence of file
+  it('shoul throw when the file does not exists', async () => {
+    await expect(readFile('/this/path/does/not/exist.md')).rejects.toThrow('Could not read file');
+  });
+
+  // test-2 :- if the file path is wrong
+  it('includes the file path in error message', async () => {
+    const wrongPath = '/no/any/file.md';
+    await expect(readFile(wrongPath)).rejects.toThrow(wrongPath);
+  });
+});

--- a/apps/main-processor/tsconfig.json
+++ b/apps/main-processor/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "rootDir": "./",
+    "outDir": "./dist",
+    "types": ["node", "vitest/globals"]
+  },
+  "include": ["src", "tests"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -85,9 +85,11 @@ importers:
         specifier: ^4.1.4
         version: 4.1.4(@types/node@25.6.0)(jsdom@29.0.2)(vite@8.0.8(@types/node@25.6.0)(jiti@2.6.1)(yaml@2.8.3))
 
-  apps/main-processor: {}
-
-  apps/renderer: {}
+  apps/main-processor:
+    devDependencies:
+      '@types/node':
+        specifier: ^25.6.0
+        version: 25.6.0
 
   apps/shared: {}
 

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -6,14 +6,14 @@ export default defineConfig({
   plugins: [react({})],
   test: {
     globals: true,
-    environment: 'jsdom',
+    environment: 'node',
     include: ['**/*.{test,spec}.{ts,tsx}'],
   },
   resolve: {
     alias: {
-      '@shared': resolve(__dirname, './src-shared'),
-      '@renderer': resolve(__dirname, './src-renderer'),
-      '@main': resolve(__dirname, './src-main'),
+      '@shared': resolve(__dirname, 'apps/shared/src'),
+      '@renderer': resolve(__dirname, 'apps/renderer/src'),
+      '@main': resolve(__dirname, 'apps/main-processor/src'),
     },
   },
 });


### PR DESCRIPTION
## Description
 Implement file reading functionality using Node.js fs module.

 
## Type of Change
 
- [ ] Bug fix
- [x] New feature
- [ ] Refactor (no functional change)
- [ ] Documentation update
- [ ] Style / UI change
- [ ] Build / CI change
 
## Related Issue
 
Closes #4 
 
## Changes Made
 
- Created main-processor/file.ts
- Implemented read file function using fs/promises.
 
## Checklist
 
- [x] My code follows the project's coding guidelines
- [x] I have tested my changes locally
- [x] I have used [conventional commit](https://www.conventionalcommits.org/) messages
- [ ] I have updated documentation if needed
- [x] My changes do not introduce new warnings or errors