### PR TITLE
refactor: separate constants from main logic

### DIFF
--- a/apps/main-processor/package.json
+++ b/apps/main-processor/package.json
@@ -12,6 +12,7 @@
   "license": "ISC",
   "packageManager": "pnpm@10.33.0",
   "devDependencies": {
-    "@types/node": "^25.6.0"
+    "@types/node": "^25.6.0",
+    "@package/shared-constants": "workspace:*"
   }
 }

--- a/apps/main-processor/src/index.ts
+++ b/apps/main-processor/src/index.ts
@@ -1,6 +1,7 @@
 import { app, BrowserWindow } from 'electron';
-import { join } from 'node:path';
 import { registerIPCHandlers } from './ipc';
+import { WINDOW_CONSTANTS } from './utils/window-constants';
+import { PATHS } from './utils/path-constants';
 
 // register all IPC before window is created
 registerIPCHandlers();
@@ -8,12 +9,12 @@ registerIPCHandlers();
 //create electron window
 function createWindow(): void {
   const mainWindow = new BrowserWindow({
-    width: 1200,
-    height: 800,
-    minWidth: 600,
-    minHeight: 400,
+    width: WINDOW_CONSTANTS.WIDTH,
+    height: WINDOW_CONSTANTS.HEIGHT,
+    minWidth: WINDOW_CONSTANTS.MIN_WIDTH,
+    minHeight: WINDOW_CONSTANTS.MIN_HEIGHT,
     webPreferences: {
-      preload: join(__dirname, '../preload/index.js'),
+      preload: PATHS.PRELOAD,
       contextIsolation: true,
       nodeIntegration: false,
     },
@@ -22,7 +23,7 @@ function createWindow(): void {
   if (process.env.ELECTRON_RENDERER_URL) {
     mainWindow.loadURL(process.env.ELECTRON_RENDERER_URL);
   } else {
-    mainWindow.loadFile(join(__dirname, '../renderer/index.html'));
+    mainWindow.loadFile(PATHS.RENDERER_HTML);
   }
 }
 

--- a/apps/main-processor/src/ipc.ts
+++ b/apps/main-processor/src/ipc.ts
@@ -1,15 +1,16 @@
 import { ipcMain, dialog } from 'electron';
 import { readFile } from './file';
+import { IPC_CONSTANTS } from '@package/shared-constants';
 
 //registers all IPC handlers for main process
 export function registerIPCHandlers(): void {
   //returns text content of the file
-  ipcMain.handle('readFile', async (_event, filePath: string) => {
+  ipcMain.handle(IPC_CONSTANTS.READ_FILE, async (_event, filePath: string) => {
     return await readFile(filePath);
   });
 
   // opens the file path
-  ipcMain.handle('openFileDialog', async () => {
+  ipcMain.handle(IPC_CONSTANTS.OPEN_FILE_DIALOG, async () => {
     const result = await dialog.showOpenDialog({
       title: 'Open Markdown File',
       filters: [

--- a/apps/main-processor/src/utils/path-constants.ts
+++ b/apps/main-processor/src/utils/path-constants.ts
@@ -1,0 +1,6 @@
+import { join } from 'node:path';
+
+export const PATHS = {
+  PRELOAD: join(__dirname, '../preload/index.js'),
+  RENDERER_HTML: join(__dirname, '../renderer/index.html'),
+} as const;

--- a/apps/main-processor/src/utils/window-constants.ts
+++ b/apps/main-processor/src/utils/window-constants.ts
@@ -1,0 +1,6 @@
+export const WINDOW_CONSTANTS = {
+  WIDTH: 1200,
+  HEIGHT: 800,
+  MIN_WIDTH: 600,
+  MIN_HEIGHT: 400,
+} as const;

--- a/apps/preload/package.json
+++ b/apps/preload/package.json
@@ -11,6 +11,7 @@
   "license": "ISC",
   "packageManager": "pnpm@10.33.0",
   "dependencies": {
-    "@package/shared-types": "workspace:*"
+    "@package/shared-types": "workspace:*",
+    "@package/shared-constants": "workspace:*"
   }
 }

--- a/apps/preload/src/index.ts
+++ b/apps/preload/src/index.ts
@@ -1,20 +1,22 @@
 import { contextBridge, ipcRenderer } from 'electron';
 import { MarkdownReaderAPI } from '@package/shared-types';
+import { IPC_CONSTANTS } from '@package/shared-constants';
+import { BRIDGE_NAME } from '@package/shared-constants';
 
 const apiContract: MarkdownReaderAPI = {
-  readFile: (path) => ipcRenderer.invoke('readFile', path),
-  openFileDialog: () => ipcRenderer.invoke('openFileDialog'),
-  openFolderDialog: () => ipcRenderer.invoke('openFolderDialog'),
-  readFolder: (path) => ipcRenderer.invoke('readFolder', path),
-  getRecentFiles: () => ipcRenderer.invoke('getRecentFiles'),
-  addRecentFile: (path) => ipcRenderer.invoke('addRecentFile', path),
-  clearRecentFiles: () => ipcRenderer.invoke('clearRecentFiles'),
-  getSettings: () => ipcRenderer.invoke('getSettings'),
-  saveSettings: (settings) => ipcRenderer.invoke('saveSettings', settings),
-  getAppVersion: () => ipcRenderer.invoke('getAppVersion'),
-  watchFile: (path) => ipcRenderer.invoke('watchFile', path),
-  unWatchFile: (path) => ipcRenderer.invoke('unWatchFile', path),
+  readFile: (path) => ipcRenderer.invoke(IPC_CONSTANTS.READ_FILE, path),
+  openFileDialog: () => ipcRenderer.invoke(IPC_CONSTANTS.OPEN_FILE_DIALOG),
+  openFolderDialog: () => ipcRenderer.invoke(IPC_CONSTANTS.OPEN_FOLDER_DIALOG),
+  readFolder: (path) => ipcRenderer.invoke(IPC_CONSTANTS.READ_FOLDER, path),
+  getRecentFiles: () => ipcRenderer.invoke(IPC_CONSTANTS.GET_RECENT_FILES),
+  addRecentFile: (path) => ipcRenderer.invoke(IPC_CONSTANTS.ADD_RECENT_FILES, path),
+  clearRecentFiles: () => ipcRenderer.invoke(IPC_CONSTANTS.CLEAR_RECENT_FILES),
+  getSettings: () => ipcRenderer.invoke(IPC_CONSTANTS.GET_SETTINGS),
+  saveSettings: (settings) => ipcRenderer.invoke(IPC_CONSTANTS.SAVE_SETTINGS, settings),
+  getAppVersion: () => ipcRenderer.invoke(IPC_CONSTANTS.GET_APP_VERSION),
+  watchFile: (path) => ipcRenderer.invoke(IPC_CONSTANTS.WATCH_FILE, path),
+  unWatchFile: (path) => ipcRenderer.invoke(IPC_CONSTANTS.UNWATCH_FILE, path),
 };
 
 // bridge between renderer and main
-contextBridge.exposeInMainWorld('api', apiContract);
+contextBridge.exposeInMainWorld(BRIDGE_NAME.API, apiContract);

--- a/apps/renderer/package.json
+++ b/apps/renderer/package.json
@@ -13,6 +13,7 @@
   "packageManager": "pnpm@10.33.0",
   "dependencies": {
     "@package/shared-types": "workspace:*",
+    "@package/shared-constants": "workspace:*",
     "dompurify": "^3.4.0",
     "marked": "^18.0.0",
     "marked-highlight": "^2.2.4",

--- a/apps/renderer/src/config/marked.ts
+++ b/apps/renderer/src/config/marked.ts
@@ -1,6 +1,7 @@
 import { Marked } from 'marked';
 import { markedHighlight } from 'marked-highlight';
 import { shikiHighlighter } from '../renderer/shiki';
+import { THEMES } from '@package/shared-constants';
 
 let instance: Marked | null = null;
 
@@ -20,7 +21,7 @@ export function getMarkdown(): Marked {
       async: true,
       async highlight(code: string, lang: string): Promise<string> {
         const highlighter = await shikiHighlighter();
-        const theme = 'github-dark';
+        const theme = THEMES.GITHUB_DARK;
         const language = lang || 'text';
         try {
           return highlighter.codeToHtml(code, { lang: language, theme });

--- a/apps/renderer/src/renderer/shiki.ts
+++ b/apps/renderer/src/renderer/shiki.ts
@@ -1,9 +1,11 @@
 import { createHighlighterCore } from 'shiki/core';
 import { createJavaScriptRegexEngine } from 'shiki/engine/javascript';
 import type { HighlighterCore } from 'shiki';
+import { SHIKI_LANG, SHIKI_THEME } from '../utils/shiki-list';
 
-export const DEFAULT_THEME = 'github-dark';
 let highlighter: HighlighterCore | null = null;
+const themes = Object.values(SHIKI_THEME).map((fn) => fn());
+const langs = Object.values(SHIKI_LANG).map((fn) => fn());
 
 export function resetHilighter() {
   highlighter = null;
@@ -14,14 +16,9 @@ export async function shikiHighlighter(): Promise<HighlighterCore> {
   if (highlighter) {
     return highlighter;
   }
-
   highlighter = await createHighlighterCore({
-    themes: [import('shiki/themes/github-dark.mjs'), import('shiki/themes/github-light.mjs')],
-    langs: [
-      import('shiki/langs/javascript.mjs'),
-      import('shiki/langs/python.mjs'),
-      import('shiki/langs/markdown.mjs'),
-    ],
+    themes,
+    langs,
     engine: createJavaScriptRegexEngine(),
   });
 

--- a/apps/renderer/src/utils/shiki-list.ts
+++ b/apps/renderer/src/utils/shiki-list.ts
@@ -1,0 +1,10 @@
+export const SHIKI_THEME = {
+  dark: () => import('shiki/themes/github-dark.mjs'),
+  light: () => import('shiki/themes/github-light.mjs'),
+} as const;
+
+export const SHIKI_LANG = {
+  javascript: () => import('shiki/langs/javascript.mjs'),
+  python: () => import('shiki/langs/python.mjs'),
+  md: () => import('shiki/langs/markdown.mjs'),
+} as const;

--- a/packages/shared-constants/package.json
+++ b/packages/shared-constants/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "@package/shared-constants",
+  "version": "1.0.0",
+  "description": "",
+  "main": "dist/src/index.js",
+  "types": "dist/src/index.d.ts",
+  "scripts": {
+    "build": "pnpm exec tsc"
+  },
+  "type": "module",
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "packageManager": "pnpm@10.33.0"
+}

--- a/packages/shared-constants/src/bridge-constants.ts
+++ b/packages/shared-constants/src/bridge-constants.ts
@@ -1,0 +1,3 @@
+export const BRIDGE_NAME = {
+  API: 'api',
+} as const;

--- a/packages/shared-constants/src/index.ts
+++ b/packages/shared-constants/src/index.ts
@@ -1,0 +1,3 @@
+export { THEMES } from './theme-constants.js';
+export { BRIDGE_NAME } from './bridge-constants.js';
+export { IPC_CONSTANTS } from './ipc-constants.js';

--- a/packages/shared-constants/src/ipc-constants.ts
+++ b/packages/shared-constants/src/ipc-constants.ts
@@ -1,0 +1,14 @@
+export const IPC_CONSTANTS = {
+  READ_FILE: 'readFile',
+  OPEN_FILE_DIALOG: 'openFileDialog',
+  OPEN_FOLDER_DIALOG: 'openFolderDialog',
+  READ_FOLDER: 'readFolder',
+  GET_RECENT_FILES: 'getRecentFiles',
+  ADD_RECENT_FILES: 'addRecentFile',
+  CLEAR_RECENT_FILES: 'clearRecentFiles',
+  GET_SETTINGS: 'getSettings',
+  SAVE_SETTINGS: 'saveSettings',
+  GET_APP_VERSION: 'getAppVersion',
+  WATCH_FILE: 'watchFile',
+  UNWATCH_FILE: 'unWatchFile',
+} as const;

--- a/packages/shared-constants/src/theme-constants.ts
+++ b/packages/shared-constants/src/theme-constants.ts
@@ -1,0 +1,4 @@
+export const THEMES = {
+  GITHUB_LIGHT: 'github-light',
+  GITHUB_DARK: 'github-dark',
+} as const;

--- a/packages/shared-constants/tsconfig.json
+++ b/packages/shared-constants/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "rootDir": "./",
+    "outDir": "./dist",
+    "types": ["vitest/globals"]
+  },
+  "include": ["src"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -90,18 +90,27 @@ importers:
 
   apps/main-processor:
     devDependencies:
+      '@package/shared-constants':
+        specifier: workspace:*
+        version: link:../../packages/shared-constants
       '@types/node':
         specifier: ^25.6.0
         version: 25.6.0
 
   apps/preload:
     dependencies:
+      '@package/shared-constants':
+        specifier: workspace:*
+        version: link:../../packages/shared-constants
       '@package/shared-types':
         specifier: workspace:*
         version: link:../../packages/shared-types
 
   apps/renderer:
     dependencies:
+      '@package/shared-constants':
+        specifier: workspace:*
+        version: link:../../packages/shared-constants
       '@package/shared-types':
         specifier: workspace:*
         version: link:../../packages/shared-types
@@ -117,6 +126,8 @@ importers:
       shiki:
         specifier: ^4.0.2
         version: 4.0.2
+
+  packages/shared-constants: {}
 
   packages/shared-types: {}
 


### PR DESCRIPTION
## Description
 reusable constants are used in multiple places , which makes the codebase messy.

## Type of Change
 
- [ ] Bug fix
- [ ] New feature
- [x] Refactor (no functional change)
- [ ] Documentation update
- [ ] Style / UI change
- [ ] Build / CI change
 
## Related Issue
 
Closes #11 

## Changes Made
 
- Created shared constants folder in packages , to reuse the constants in more that on service.
 
## Checklist
 
- [x] My code follows the project's coding guidelines
- [x] I have tested my changes locally
- [x] I have used [conventional commit](https://www.conventionalcommits.org/) messages
- [ ] I have updated documentation if needed
- [x] My changes do not introduce new warnings or errors