### PR TITLE
refactor(main-processor): add IPC input and sender validations

### DIFF
--- a/apps/main-processor/src/ipc.ts
+++ b/apps/main-processor/src/ipc.ts
@@ -1,15 +1,29 @@
 import { ipcMain, dialog } from 'electron';
 import { readFile } from './file';
+import { validateMarkdownFile, validatePath, validateSender } from './utils/ipc-validation';
 
 //registers all IPC handlers for main process
 export function registerIPCHandlers(): void {
   //returns text content of the file
-  ipcMain.handle('readFile', async (_event, filePath: string) => {
+  ipcMain.handle('readFile', async (event, filePath: string) => {
+    if (!validateSender(event)) {
+      throw new Error('Untrusted sender');
+    }
+    if (!validatePath(filePath)) {
+      throw new Error('Invalid file path');
+    }
+
+    if (!validateMarkdownFile(filePath)) {
+      throw new Error('Only markdown files allowed');
+    }
     return await readFile(filePath);
   });
 
   // opens the file path
-  ipcMain.handle('openFileDialog', async () => {
+  ipcMain.handle('openFileDialog', async (event) => {
+    if (!validateSender(event)) {
+      throw new Error('Untrusted sender');
+    }
     const result = await dialog.showOpenDialog({
       title: 'Open Markdown File',
       filters: [
@@ -21,6 +35,11 @@ export function registerIPCHandlers(): void {
     if (result.canceled || result.filePaths.length === 0) {
       return null;
     }
-    return result.filePaths[0];
+    const selected = result.filePaths[0];
+    if (!selected) return null;
+    if (!validateMarkdownFile(selected)) {
+      throw new Error('Only markdown files allowed');
+    }
+    return selected;
   });
 }

--- a/apps/main-processor/src/utils/ipc-validation.ts
+++ b/apps/main-processor/src/utils/ipc-validation.ts
@@ -1,0 +1,21 @@
+import path from 'path';
+
+// production and dev urls
+const allowedOrigin = ['file://', 'http://localhost'];
+
+//validate the sender
+export function validateSender(event: Electron.IpcMainInvokeEvent): boolean {
+  const url = event.senderFrame?.url || '';
+  return allowedOrigin.some((origin) => url.startsWith(origin));
+}
+
+//validate path type
+export function validatePath(path: string) {
+  return typeof path == 'string' && path.trim().length > 0;
+}
+
+//validate file extension
+export function validateMarkdownFile(filePath: string): boolean {
+  const ext = path.extname(filePath).toLowerCase();
+  return ext === '.md' || ext === '.markdown';
+}

--- a/apps/main-processor/tests/ipc.test.ts
+++ b/apps/main-processor/tests/ipc.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect } from 'vitest';
+import { validateMarkdownFile, validatePath, validateSender } from '../src/utils/ipc-validation';
+
+// mocking the url
+function mockEvent(url: string) {
+  return {
+    senderFrame: { url },
+  } as any;
+}
+
+describe('ipc - validation test', () => {
+  // test 1:- to check blocked urls
+  it('block unknow urls', () => {
+    const event = mockEvent('http://hiii.com');
+    expect(validateSender(event)).toBe(false);
+  });
+
+  //test 2:- to check empty urls
+  it('return false when url is empty', () => {
+    const event = mockEvent('');
+    expect(validateSender(event)).toBe(false);
+  });
+
+  //test 3:- to check correct file path
+  it('returns true for a valid file path string', () => {
+    expect(validatePath('C:\\Users\\file.md')).toBe(true);
+  });
+
+  //test 4:- to check file extension
+  it('return true for .md files', () => {
+    expect(validateMarkdownFile('/docs/readme.md')).toBe(true);
+  });
+});


### PR DESCRIPTION
## Description
 
IPC handlers are not validating input coming from the renderer. Everything is getting trusted.
Like readFile accepts anything as filePath without checking if it's a valid string.
There is no sender validation
 
## Type of Change
 
- [x] Bug fix
- [ ] New feature
- [ ] Refactor (no functional change)
- [ ] Documentation update
- [ ] Style / UI change
- [ ] Build / CI change
 
## Related Issue
 
Closes #12 
 
## Changes Made
 
- Added test cases to chek the validations
- Added validateSender function to check the correct origin of the sender.
- Added validatePath to check the correct path type of the file
- Added validateMarkdown function to check that only md and markdown files are getting selected.
 
## Checklist
 
- [x] My code follows the project's coding guidelines
- [x] I have tested my changes locally
- [x] I have used [conventional commit](https://www.conventionalcommits.org/) messages
- [ ] I have updated documentation if needed
- [x] My changes do not introduce new warnings or errors