### PR TITLE
Feature/multi tab

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,9 @@ on:
     
 permissions:
   contents: write
+  packages: write
+  pull-requests: write
+  actions: write
   
 jobs:
   release:

--- a/apps/main-processor/src/folder.ts
+++ b/apps/main-processor/src/folder.ts
@@ -1,0 +1,35 @@
+import { readdir } from 'node:fs/promises';
+import { basename, join } from 'node:path';
+import { FileType } from '@package/shared-types';
+import { isMarkdownFile } from './utils/helper/path-helper';
+
+export async function getFolder(folderPath: string): Promise<FileType> {
+  const entries = await readdir(folderPath, { withFileTypes: true });
+  const children: FileType[] = [];
+
+  for (const entry of entries) {
+    if (entry.name.startsWith('.')) continue;
+
+    const fullPath = join(folderPath, entry.name);
+
+    if (entry.isDirectory()) {
+      children.push(await getFolder(fullPath));
+      continue;
+    }
+
+    if (isMarkdownFile(entry.name)) {
+      children.push({
+        name: entry.name,
+        path: fullPath,
+        isDir: false,
+      });
+    }
+  }
+
+  return {
+    name: basename(folderPath),
+    path: folderPath,
+    isDir: true,
+    children,
+  };
+}

--- a/apps/main-processor/src/ipc.ts
+++ b/apps/main-processor/src/ipc.ts
@@ -1,6 +1,7 @@
 import { ipcMain, dialog } from 'electron';
 import { readFile, unWatchFile, watchFile } from './file';
 import { getRecentFiles, addRecentFile } from './recent';
+import { getFolder } from './folder';
 import { validateMarkdownFile, validatePath, validateSender } from './utils/ipc-validation';
 import { IPC_CONSTANTS } from '@package/shared-constants';
 
@@ -86,5 +87,33 @@ export function registerIPCHandlers(): void {
       throw new Error('Invalid file path');
     }
     await addRecentFile(filePath);
+  });
+
+  ipcMain.handle(IPC_CONSTANTS.OPEN_FOLDER_DIALOG, async (event) => {
+    if (!validateSender(event)) {
+      throw new Error('Untrusted sender');
+    }
+
+    const result = await dialog.showOpenDialog({
+      title: 'Open Folder',
+      properties: ['openDirectory'],
+    });
+
+    if (result.canceled || result.filePaths.length === 0) {
+      return null;
+    }
+
+    return result.filePaths[0] ?? null;
+  });
+
+  ipcMain.handle(IPC_CONSTANTS.READ_FOLDER, async (event, folderPath: string) => {
+    if (!validateSender(event)) {
+      throw new Error('Untrusted sender');
+    }
+
+    if (!validatePath(folderPath)) {
+      throw new Error('Invalid folder path');
+    }
+    return await getFolder(folderPath);
   });
 }

--- a/apps/main-processor/src/utils/helper/path-helper.ts
+++ b/apps/main-processor/src/utils/helper/path-helper.ts
@@ -3,3 +3,7 @@ import { app } from 'electron';
 export function getRecentFilePath(): string {
   return join(app.getPath('userData'), 'recent.json');
 }
+
+export function isMarkdownFile(fileName: string): boolean {
+  return /\.(md|markdown)$/i.test(fileName);
+}

--- a/apps/renderer/src/App.tsx
+++ b/apps/renderer/src/App.tsx
@@ -15,63 +15,116 @@ import { useSearch } from './hooks/useSearch';
 import { SearchBar } from './components/SearchBar';
 import { useSettings } from './hooks/useSettings';
 import { StatusBar } from './components/StatusBar';
-
-
-
+import { FileType } from '@package/shared-types';
+import { FileBrowser } from './components/FileBrowser';
+import { TabBar } from './components/TabBar';
+import { useTabStore } from './hooks/useTabStore';
+import { extractTOC } from './renderer/toc';
 
 export default function App() {
-const { html, filePath, error, isLoading, openFile, toc, reloadFile,recentFiles,loadFile } = useFile();  
-const { theme, toggleTheme,setTheme } = useTheme();
+  const { html, filePath, error, isLoading, openFile, toc, reloadFile,recentFiles,loadFile } = useFile();
+  const { state, dispatch } = useTabStore();
+  const activeTab = state.tabs.find((tab) => tab.id === state.activeTabId) ?? null;
+  const { theme, toggleTheme,setTheme } = useTheme();
   const {activeId,scrollToHeading}=useToc(toc);
-  const [sidebarOpen,setSidebarOpen]=useState(true);
-  const [showToast, setShowToast]=useState(false);
-  const {query,matchCount,currentMatch,isSearchOpen,openSearch,closeSearch,setQuery,goToNextMatch,goToPrevMatch,getHiglightedHtml}=useSearch(html);
   const {increaseFontSize,decreaseFontSize,resetFontSize,fontSize}=useSettings();
-
+  const {query,matchCount,currentMatch,isSearchOpen,openSearch,closeSearch,setQuery,goToNextMatch,goToPrevMatch,getHiglightedHtml} = useSearch(activeTab?.html ?? '');
+  const [sidebarOpen, setSidebarOpen] = useState(true);
+  const [showToast, setShowToast] = useState(false);
+  const [folderTree, setFolderTree] = useState<FileType | null>(null);
+  const [fileBrowserOpen, setFileBrowserOpen] = useState(false);
+  const [focusMode, setFocusMode] = useState(false);
   const contentRef=useRef<HTMLDivElement>(null);
-
   const debounceTimer=useRef<number | undefined>(undefined);
   const scrollTimer=useRef<number | undefined>(undefined);
 
-  //key board shorcut
+  const openFolder = useCallback(async () => {
+    const folderPath = await window.api.openFolderDialog();
+    if (!folderPath) return;
+    const tree = await window.api.readFolder(folderPath);
+    setFolderTree(tree);
+    setFileBrowserOpen(true);
+  }, []);
+
+  const loadFileInTab = useCallback(
+    async (path: string) => {
+      const result = await loadFile(path);
+      if (!result) return;
+      dispatch({
+        type: 'OPEN_TAB',
+        payload: {
+          filePath: result.filePath,
+          html: result.html,
+        },
+      });
+    },
+    [loadFile, dispatch]
+  );
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {
-      if ((e.metaKey || e.ctrlKey) && e.key === "o") {
+      const mod=e.metaKey || e.ctrlKey;
+      if (mod && e.shiftKey && e.key.toLowerCase() === 'o') {
         e.preventDefault();
-        openFile();
+        void openFolder();
+        return;
       }
-
-      if (e.key==='[') {
-        setSidebarOpen(prev=>!prev)
+      if (mod && e.shiftKey && e.key.toLowerCase() === 'f') {
+        e.preventDefault();
+        setFocusMode(prev=> !prev);
+        return;
       }
-      if ((e.metaKey || e.ctrlKey) && e.key === 't') {
+      if (mod && e.key.toLowerCase() === 'o') {
+        e.preventDefault();
+        void window.api.openFileDialog().then((chosenPath) => {
+          if (chosenPath) {
+            void loadFileInTab(chosenPath);
+          }
+        });
+        return;
+      }
+      if (mod && e.key.toLowerCase() === 't') {
         e.preventDefault();
         toggleTheme();
+        return;
       }
 
-      if((e.metaKey || e.ctrlKey) && e.key==='f'){
+      if (mod && e.key.toLowerCase() === 'f') {
         e.preventDefault();
         openSearch();
+        return;
       }
 
-      if((e.metaKey||e.ctrlKey) && e.key==='='){
+      if (mod && (e.key === '=' || e.key === '+')) {
         e.preventDefault();
-        increaseFontSize()
+        increaseFontSize();
+        return;
       }
 
-      if((e.metaKey||e.ctrlKey) && (e.key==='-'||e.key==='+')){
+      if (mod && e.key === '-') {
         e.preventDefault();
         decreaseFontSize();
+        return;
       }
 
-      if((e.metaKey||e.ctrlKey) && e.key==='0'){
+      if (mod && e.key==='0') {
         e.preventDefault();
         resetFontSize();
+        return;
+      }
+      if (e.key === '[') {
+        setSidebarOpen((prev) => !prev);
+      }
+      if (e.key === '\\') {
+        setFileBrowserOpen((prev) => !prev);
+      }
+      if (e.key === 'Escape') {
+        closeSearch();
       }
     };
     window.addEventListener('keydown', handleKeyDown);
     return () => window.removeEventListener('keydown', handleKeyDown);
-  }, [openFile,toggleTheme]);
+  }, [openFolder,openFile,toggleTheme,openSearch,closeSearch,increaseFontSize,decreaseFontSize,resetFontSize,
+  ]);
   const handleFileChange = useCallback(() => {
     if (debounceTimer.current) {
       clearTimeout(debounceTimer.current);
@@ -105,11 +158,10 @@ const { theme, toggleTheme,setTheme } = useTheme();
       }
     });
   }, [html, filePath]);
-  
 
   return (
     <>
-    <div className="h-screen flex flex-col bg-bg text-text-base">
+      <div className="h-screen flex flex-col bg-bg text-text-base">
       {isLoading && <Loading />}
       {isSearchOpen && (
         <SearchBar
@@ -122,44 +174,75 @@ const { theme, toggleTheme,setTheme } = useTheme();
           onClose={closeSearch}
         />
       )}
-      <header className='flex justify-between items-center px-4 py-2 border-b border-border-theme shrink-0'>
-        <span className='text-sm font-medium'>Markdown Reader</span>
-        <select value={theme} onChange={(e) => setTheme(e.target.value as BuiltThemeType)} className="px-2 py-1 text-sm bg-surface border border-border-theme rounded text-text-base focus:outline-none">
-          <option value="github-light">Light</option>
-          <option value="github-dark">Dark</option>
-          <option value="notion">Notion</option>
-          <option value="nord">Nord</option>
-          <option value="minimal">Minimal</option>
-          <option value="dracula">Dracula</option>
-        </select>
-      </header>
+      {!focusMode && (
+        <header className='flex justify-between items-center px-4 py-2 border-b border-border-theme shrink-0'>
+          <span className='text-sm font-medium'>Markdown Reader</span>
+          <select value={theme} onChange={(e) => setTheme(e.target.value as BuiltThemeType)} className="px-2 py-1 text-sm bg-surface border border-border-theme rounded text-text-base focus:outline-none">
+            <option value="github-light">Light</option>
+            <option value="github-dark">Dark</option>
+            <option value="notion">Notion</option>
+            <option value="nord">Nord</option>
+            <option value="minimal">Minimal</option>
+            <option value="dracula">Dracula</option>
+          </select>
+        </header>
+      )}
+      {!focusMode && (
+        <TabBar
+          tabs={state.tabs}
+          activeTabId={state.activeTabId}
+          onSwitch={(id) => dispatch({ type: 'SWITCH_TAB', payload: { tabId: id } })}
+          onClose={(id) => dispatch({ type: 'CLOSE_TAB', payload: { tabId: id } })}
+        />
+      )}
 
       {error && <Error message={error} onRetry={openFile} />}
 
       {!filePath && !isLoading && (
-        <Welcome onOpen={openFile} recentFiles={recentFiles} onOpenRecent={loadFile} />
+        <Welcome onOpen={() => {
+            void window.api.openFileDialog().then((chosenPath) => {
+              if (chosenPath) {
+                void loadFileInTab(chosenPath);
+              }
+            });
+          }}
+          recentFiles={recentFiles}
+          onOpenRecent={loadFileInTab}
+        />
       )}
 
-      {html && !isLoading && !error && (
+      {activeTab && !isLoading && !error && (
         <div className="flex flex-1 overflow-hidden">
-          <Sidebar
-            tocItems={toc}
-            activeId={activeId}
-            onSelect={scrollToHeading}
-            isVisible={sidebarOpen}
-          />
-          <main
-            ref={contentRef}
-            className="flex-1 overflow-y-auto"
+          {!focusMode && (
+            <FileBrowser
+              tree={folderTree}
+              activeFilePath={activeTab?.filePath ?? ''}
+              onOpenFile={loadFile}
+              isVisible={fileBrowserOpen}
+            />
+          )}
+          {!focusMode && (
+            <Sidebar
+              tocItems={extractTOC(activeTab.html)}
+              activeId={activeId}
+              onSelect={scrollToHeading}
+              isVisible={sidebarOpen}
+            />
+          )}
+          <main 
+            ref={contentRef} 
+            className="flex-1 overflow-y-auto" 
             onScroll={scroll}
-          >
-            <Reader html={html} getHiglightedHtml={getHiglightedHtml} />
+            >
+            <Reader html={activeTab.html} getHiglightedHtml={getHiglightedHtml} />
           </main>
         </div>
       )}
 
       <Toast message="File updated" show={showToast} onDone={() => setShowToast(false)} />
-      <StatusBar filePath={filePath} theme={theme} fontSize={fontSize}/>
+      {!focusMode && (
+        <StatusBar filePath={activeTab?.filePath ?? ''} theme={theme} fontSize={fontSize}/>
+      )}
     </div>
     </>
-  )}
+    )}

--- a/apps/renderer/src/components/FileBrowser.tsx
+++ b/apps/renderer/src/components/FileBrowser.tsx
@@ -1,0 +1,20 @@
+import { FileBrowserProps } from '../types/component-types';
+import { FileTree } from './FileTree';
+
+export function FileBrowser({
+  tree,
+  activeFilePath,
+  onOpenFile,
+  isVisible = true,
+}: FileBrowserProps) {
+  if (!isVisible || !tree) return null;
+  return (
+    <nav
+      aria-label="File browser"
+      className="w-56 shrink-0 overflow-y-auto border-r border-border-theme bg-surface py-3"
+    >
+      <p className="px-3 pb-2 text-xs font-bold uppercase tracking-wide text-text-muted">Files</p>
+      <FileTree node={tree} depth={0} activeFilePath={activeFilePath} onOpenFile={onOpenFile} />
+    </nav>
+  );
+}

--- a/apps/renderer/src/components/FileTree.tsx
+++ b/apps/renderer/src/components/FileTree.tsx
@@ -1,0 +1,35 @@
+import { FileTreeProps } from "../types/component-types";
+
+export function FileTree({node,depth,activeFilePath,onOpenFile}:FileTreeProps){
+    const paddingLeft=depth*12+8;
+    if(node.isDir){
+         return (
+      <div>
+        <div
+          style={{ paddingLeft }}
+          className="flex items-center gap-1 py-0.5 text-xs font-semibold uppercase tracking-wide text-text-muted"
+        >
+          <span>FOLDER</span>
+          <span>{node.name}</span>
+        </div>
+
+        {node.children?.map((child) => (
+          <FileTree
+            key={child.path}
+            node={child}
+            depth={depth + 1}
+            activeFilePath={activeFilePath}
+            onOpenFile={onOpenFile}
+          />
+        ))}
+      </div>
+    );
+    }
+    return(
+        <button type="button" onClick={()=>onOpenFile(node.path)}>
+            <span>FILE</span>
+            <span >{node.name}</span>
+        </button>
+    )
+    
+}

--- a/apps/renderer/src/components/TabBar.tsx
+++ b/apps/renderer/src/components/TabBar.tsx
@@ -1,0 +1,47 @@
+import type { TabBarProps } from '../types/component-types';
+
+export function TabBar({ tabs, activeTabId, onSwitch, onClose }: TabBarProps) {
+  if (tabs.length === 0) return null;
+
+  return (
+    <div
+      role="tablist"
+      className="flex h-9 shrink-0 items-end overflow-x-auto border-b border-border-theme bg-surface select-none"
+    >
+      {tabs.map((tab) => {
+        const isActive = tab.id === activeTabId;
+
+        return (
+          <div key={tab.id} className="flex max-w-45 shrink-0 items-center">
+            <button
+              role="tab"
+              aria-current={isActive ? 'true' : undefined}
+              aria-label={tab.fileName}
+              onClick={() => onSwitch(tab.id)}
+              className={[
+                'flex h-9 items-center gap-1 truncate border-t-2 px-3 text-xs font-medium transition-colors',
+                isActive
+                  ? 'border-accent bg-bg text-text-base'
+                  : 'border-transparent text-text-muted hover:bg-accent-bg hover:text-text-base',
+              ].join(' ')}
+            >
+              <span className="truncate">{tab.fileName}</span>
+            </button>
+
+            <button
+              type="button"
+              aria-label="close tab"
+              onClick={(event) => {
+                event.stopPropagation();
+                onClose(tab.id);
+              }}
+              className="mr-1 ml-0.5 rounded px-1 text-xs text-text-muted hover:bg-accent-bg hover:text-text-base"
+            >
+              X
+            </button>
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/apps/renderer/src/context/TabProvider.tsx
+++ b/apps/renderer/src/context/TabProvider.tsx
@@ -1,0 +1,13 @@
+import React,{ createContext, useReducer, type Dispatch } from 'react';
+import { TabState, TabAction } from '../types/component-types';
+import { tabReducer } from '../store/tabStore';
+
+export const TabContext = createContext<{
+  state: TabState;
+  dispatch: Dispatch<TabAction>;
+} | null>(null);
+
+export function TabProvider({children}:{children:React.ReactNode}){
+    const [state,dispatch]=useReducer(tabReducer,{tabs:[],activeTabId:null});
+    return <TabContext.Provider value={{state,dispatch}}>{children}</TabContext.Provider>
+}

--- a/apps/renderer/src/hooks/useFile.ts
+++ b/apps/renderer/src/hooks/useFile.ts
@@ -33,6 +33,11 @@ export function useFile() {
       await window.api.addRecentFile(path);
       const updated = await window.api.getRecentFiles();
       setRecentFiles(updated);
+      return {
+        html: safeHtml,
+        toc: toc,
+        filePath: path,
+      };
     } catch (error: unknown) {
       if (error instanceof Error) {
         setError(error.message);

--- a/apps/renderer/src/hooks/useTabStore.ts
+++ b/apps/renderer/src/hooks/useTabStore.ts
@@ -1,0 +1,10 @@
+import { useContext } from 'react';
+import { TabContext } from '../context/TabProvider';
+
+export function useTabStore() {
+  const context = useContext(TabContext);
+  if (!context) {
+    throw new Error('usetab store must be used inside tab provider');
+  }
+  return context;
+}

--- a/apps/renderer/src/main.tsx
+++ b/apps/renderer/src/main.tsx
@@ -6,11 +6,14 @@ import App from './App'
 import "./index.css";
 import { ThemeProvider } from './context/ThemeProvider'
 import 'katex/dist/katex.min.css';
+import { TabProvider } from './context/TabProvider';
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
     <ThemeProvider>
-      <App />
+      <TabProvider>
+        <App />
+      </TabProvider>
     </ThemeProvider>
   </StrictMode>
 )

--- a/apps/renderer/src/store/tabStore.ts
+++ b/apps/renderer/src/store/tabStore.ts
@@ -1,0 +1,50 @@
+import { TabAction, TabState } from '../types/component-types';
+import { createTab } from '../utils/helpers/tab-helper';
+
+export function tabReducer(state: TabState, action: TabAction): TabState {
+  switch (action.type) {
+    case 'OPEN_TAB': {
+      const existingTab = state.tabs.find((tab) => tab.filePath === action.payload.filePath);
+      if (existingTab) {
+        return { ...state, activeTabId: existingTab.id };
+      }
+      const newTab = createTab(action.payload.filePath, action.payload.html);
+      return {
+        tabs: [...state.tabs, newTab],
+        activeTabId: newTab.id,
+      };
+    }
+    case 'CLOSE_TAB': {
+      const tabIndex = state.tabs.findIndex((tab) => tab.id === action.payload.tabId);
+      if (tabIndex === -1) return state;
+      const remainingTabs = state.tabs.filter((tab) => tab.id !== action.payload.tabId);
+      if (remainingTabs.length === 0) {
+        return { tabs: [], activeTabId: null };
+      }
+
+      const nextActiveTab = remainingTabs[Math.max(0, tabIndex - 1)] || remainingTabs[0];
+
+      return {
+        tabs: remainingTabs,
+        activeTabId: nextActiveTab?.id || null,
+      };
+    }
+
+    case 'SWITCH_TAB':
+      return {
+        ...state,
+        activeTabId: action.payload.tabId,
+      };
+
+    case 'UPDATE_TAB_STATE':
+      return {
+        ...state,
+        tabs: state.tabs.map((tab) =>
+          tab.id === action.payload.tabId ? { ...tab, ...action.payload } : tab
+        ),
+      };
+
+    default:
+      return state;
+  }
+}

--- a/apps/renderer/src/types/component-types.ts
+++ b/apps/renderer/src/types/component-types.ts
@@ -1,5 +1,6 @@
 import { APPTHEMES } from '../utils/constants/theme-constants';
 import { RecentFile } from '@package/shared-types/dist/src/recentfile-type';
+import { FileType } from '@package/shared-types';
 export interface ErrorProps {
   message: string;
   onRetry: () => void;
@@ -96,4 +97,53 @@ export interface StatusBarProps {
   filePath: string;
   theme: string;
   fontSize: number;
+}
+
+export interface TabBarProps {
+  tabs: Tab[];
+  activeTabId: string | null;
+  onSwitch: (id: string) => void;
+  onClose: (id: string) => void;
+}
+
+export interface Tab {
+  id: string;
+  filePath: string;
+  fileName: string;
+  html: string;
+  scrollTop: number;
+  fontSize: number;
+}
+
+export interface TabState {
+  tabs: Tab[];
+  activeTabId: string | null;
+}
+
+export type TabAction =
+  | { type: 'OPEN_TAB'; payload: { filePath: string; html?: string } }
+  | { type: 'CLOSE_TAB'; payload: { tabId: string } }
+  | { type: 'SWITCH_TAB'; payload: { tabId: string } }
+  | {
+      type: 'UPDATE_TAB_STATE';
+      payload: {
+        tabId: string;
+        html?: string;
+        scrollTop?: number;
+        fontSize?: number;
+      };
+    };
+
+export interface FileBrowserProps {
+  tree: FileType | null;
+  activeFilePath: string;
+  onOpenFile: (path: string) => void;
+  isVisible?: boolean;
+}
+
+export interface FileTreeProps {
+  node: FileType;
+  depth: number;
+  activeFilePath: string;
+  onOpenFile: (path: string) => void;
 }

--- a/apps/renderer/src/utils/constants/regex-constants.ts
+++ b/apps/renderer/src/utils/constants/regex-constants.ts
@@ -30,3 +30,5 @@ export const CALLOUT_REGEX = {
   CALLOUT_TYPE: /\[!(\w+)\]/i,
   BLOCKQUOTE: /<blockquote>([\s\S]*?)<\/blockquote>/gi,
 };
+
+export const FILE_PATH = /[\\/\\]/;

--- a/apps/renderer/src/utils/helpers/tab-helper.tsx
+++ b/apps/renderer/src/utils/helpers/tab-helper.tsx
@@ -1,0 +1,13 @@
+ import { Tab } from "../../types/component-types";
+import { FILE_PATH } from "../constants/regex-constants";
+
+export function createTab(filePath: string, html = ''): Tab {
+  return {
+    id: crypto.randomUUID(),
+    filePath,
+    fileName: filePath.split(FILE_PATH).pop() ?? 'Untitled',
+    html,
+    scrollTop: 0,
+    fontSize: 16,
+  };
+}

--- a/apps/renderer/tests/components/TabBar.test.tsx
+++ b/apps/renderer/tests/components/TabBar.test.tsx
@@ -1,0 +1,63 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { TabBar } from '../../src/components/TabBar';
+import { Tab } from '../../src/types/component-types';
+
+const tabs: Tab[] = [
+  {
+    id: 'tab-1',
+    filePath: '/README.md',
+    fileName: 'README.md',
+    html: '',
+    scrollTop: 0,
+    fontSize: 16,
+  },
+  {
+    id: 'tab-2',
+    filePath: '/CHANGELOG.md',
+    fileName: 'CHANGELOG.md',
+    html: '',
+    scrollTop: 0,
+    fontSize: 16,
+  },
+];
+
+describe('TabBar', () => {
+  it('renders all opened tabs', () => {
+    render(<TabBar tabs={tabs} activeTabId="tab-1" onSwitch={() => {}} onClose={() => {}} />);
+    expect(screen.getByText('README.md')).toBeInTheDocument();
+    expect(screen.getByText('CHANGELOG.md')).toBeInTheDocument();
+  });
+
+  it('marks the active tab', () => {
+    render(<TabBar tabs={tabs} activeTabId="tab-1" onSwitch={() => {}} onClose={() => {}} />);
+    expect(screen.getByRole('tab', { name: /README/i })).toHaveAttribute('aria-current', 'true');
+  });
+
+  it('switches tab when a tab is clicked', () => {
+    const onSwitch = vi.fn();
+
+    render(<TabBar tabs={tabs} activeTabId="tab-1" onSwitch={onSwitch} onClose={() => {}} />);
+
+    fireEvent.click(screen.getByRole('tab', { name: /CHANGELOG/i }));
+
+    expect(onSwitch).toHaveBeenCalledWith('tab-2');
+  });
+
+  it('closes a tab when close button is clicked', () => {
+    const onClose = vi.fn();
+
+    render(<TabBar tabs={tabs} activeTabId="tab-1" onSwitch={() => {}} onClose={onClose} />);
+
+    fireEvent.click(screen.getAllByRole('button', { name: /close tab/i })[0]);
+
+    expect(onClose).toHaveBeenCalledWith('tab-1');
+  });
+
+  it('renders nothing when there are no tabs', () => {
+    const { container } = render(
+      <TabBar tabs={[]} activeTabId={null} onSwitch={() => {}} onClose={() => {}} />
+    );
+    expect(container.firstChild).toBeNull();
+  });
+});

--- a/apps/renderer/tests/store/tabStore.test.ts
+++ b/apps/renderer/tests/store/tabStore.test.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect } from 'vitest';
+import { tabReducer } from '../../src/store/tabStore';
+import { TabState, TabAction } from '../../src/types/component-types';
+import { createTab } from '../../src/utils/helpers/tab-helper';
+const empty: TabState = {
+  tabs: [],
+  activeTabId: null,
+};
+
+describe('tab reducer test', () => {
+  it('OPEN_TAB should add a new tab and set as active', () => {
+    const action: TabAction = {
+      type: 'OPEN_TAB',
+      payload: {
+        filePath: '/README.md',
+      },
+    };
+    const next = tabReducer(empty, action);
+    expect(next.tabs).toHaveLength(1);
+    expect(next.tabs[0]?.filePath).toBe('/README.md');
+    expect(next.activeTabId).toBe(next.tabs[0]?.id);
+  });
+  it('SWITCH_TAB should set activeTabId to the specified tab', () => {
+    const tab1 = createTab('/tab1.md');
+    const tab2 = createTab('/tab2.md');
+    const switchTab2: TabState = {
+      tabs: [tab1, tab2],
+      activeTabId: tab2.id,
+    };
+    const next = tabReducer(switchTab2, { type: 'SWITCH_TAB', payload: { tabId: tab2.id } });
+    expect(next.activeTabId).toBe(tab2.id);
+  });
+
+  it('closing active tabs should activate the previous tabs', () => {
+    const tab1 = createTab('/tab1.md');
+    const tab2 = createTab('/tab2.md');
+    const closeTab2: TabState = {
+      tabs: [tab1, tab2],
+      activeTabId: tab2.id,
+    };
+    const next = tabReducer(closeTab2, { type: 'CLOSE_TAB', payload: { tabId: tab2.id } });
+    expect(next.activeTabId).toBe(tab1.id);
+  });
+
+  it('UPDATE_TAB_STATE updates scrollTop for one tab without touching others', () => {
+    const t1 = createTab('/a.md');
+    const t2 = createTab('/b.md');
+    const updateTab2: TabState = {
+      tabs: [t1, t2],
+      activeTabId: t1.id,
+    };
+    const next = tabReducer(updateTab2, {
+      type: 'UPDATE_TAB_STATE',
+      payload: {
+        tabId: t1.id,
+        scrollTop: 500,
+      },
+    });
+    expect(next.tabs[0]?.scrollTop).toBe(500);
+    expect(next.tabs[1]?.scrollTop).toBe(0);
+  });
+
+  it('OPEN_TAB for an already open file switches to it, no duplicate', () => {
+    const tab = createTab('/README.md');
+    const openTab1: TabState = {
+      tabs: [tab],
+      activeTabId: tab.id,
+    };
+    const next = tabReducer(openTab1, {
+      type: 'OPEN_TAB',
+      payload: {
+        filePath: '/README.md',
+      },
+    });
+    expect(next.tabs).toHaveLength(1);
+  });
+});

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "start": "electron-vite preview",
     "dev": "electron-vite dev",
     "build": "electron-vite build",
-    "dist": "pnpm build && electron-builder --publish always",
+    "dist": "pnpm build && electron-builder",
     "changeset": "changeset",
     "version-packages": "changeset version",
     "release": "changeset publish",

--- a/packages/shared-types/src/index.ts
+++ b/packages/shared-types/src/index.ts
@@ -2,3 +2,4 @@ export { DEFAULT_SETTINGS } from './markdown-type';
 export type { MarkdownReaderAPI } from './markdown-type';
 export type { ThemeType } from './theme-type';
 export type { RecentFile } from './recentfile-type';
+export type {FileType} from './file-types';

--- a/packages/shared-types/src/markdown-type.ts
+++ b/packages/shared-types/src/markdown-type.ts
@@ -1,3 +1,4 @@
+import { FileType } from './file-types';
 import { RecentFile } from './recentfile-type';
 import { Settings } from './settings-type';
 
@@ -8,7 +9,7 @@ export type MarkdownReaderAPI = {
   unWatchFile(path: string): Promise<void>;
   openFileDialog(): Promise<string | null>;
   openFolderDialog(): Promise<string | null>;
-  readFolder(path: string): Promise<string | null>;
+  readFolder(path: string): Promise<FileType | null>;
   getRecentFiles(): Promise<RecentFile[]>;
   addRecentFile(path: string): Promise<void>;
   clearRecentFiles(): Promise<void>;


### PR DESCRIPTION
## Description

Added support for multi-tab navigation, folder-based file browsing, and focus mode.
- users can now open Markdown file as tabs and switch between them.
- A file browser panel allows opening files from a selected folder.
- Focus mode hides side panels and status bar for distraction free reading.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor (no functional change)
- [ ] Documentation update
- [ ] Style / UI change
- [ ] Build / CI change

## Related Issue

Closes #34 

## Changes Made

- Added tab state management using reducer
- Implemented TabBar UI with active state and close functionality
- Added Filebrowser component with  recursive folder rendering.
- Integrated folder open through IPC and preload bridge.
- Implemented Focus mode to hide all.
- Added key board shortcuts.


## Checklist

- [x] My code follows the project's coding guidelines
- [x] I have tested my changes locally
- [x] I have used [conventional commit](https://www.conventionalcommits.org/) messages
- [ ] I have updated documentation if needed
- [x] My changes do not introduce new warnings or errors
