### PR TITLE
Feature/subsection collapse

### DIFF
--- a/apps/renderer/src/components/Sidebar.tsx
+++ b/apps/renderer/src/components/Sidebar.tsx
@@ -1,34 +1,57 @@
-import { SidebarProps } from "../types/component-types";
-import { Icons } from "../utils/constants/icon-contants";
-import { getItemClasses } from "../utils/helpers/sidebar-helper";
+import { SidebarProps } from '../types/component-types';
+import { Icons } from '../utils/constants/icon-contants';
+import { getItemClasses } from '../utils/helpers/sidebar-helper';
+import { useCollapsibleToc } from '../hooks/useCollapsibleToc';
 
 //sidebar component
 export function Sidebar({tocItems,activeId,onSelect,isVisible=true, onClose }: SidebarProps & { onClose: () => void }) {
-    if(!isVisible||tocItems.length===0){
-        return null;
-    }
-    return (
-        <nav className="w-64 border-r border-border-theme bg-surface overflow-y-auto py-6 shrink-0" aria-label="Table of contents">
-            <div className="flex items-center justify-between px-4 pb-3">
-                <h2 className="text-sm font-semibold tracking-wide text-text-base">
-                  Contents
-                </h2>
-                <button 
-                    onClick={onClose}
-                    className="p-1 text-text-muted hover:text-text-base transition-colors"
-                >
-                    <Icons.X size={18} />
-                </button>
-            </div>
-            <ul>
-                {tocItems.map((item)=>(
-                    <li key={item.id}>
-                        <button onClick={()=>onSelect(item.id)} className={getItemClasses(item,activeId)} aria-current={item.id===activeId?"true":undefined}>
-                            {item.text}
-                        </button>
-                    </li>
-                ))}
-            </ul>
-        </nav>
-    )
+  const { visibleItems, toggleItem, hasChildren, isCollapsed } = useCollapsibleToc(tocItems);
+  if(!isVisible||tocItems.length===0){
+    return null;
+  }
+  return (
+    <nav className="w-64 border-r border-border-theme bg-surface overflow-y-auto py-6 shrink-0" aria-label="Table of contents">
+      <div className="flex items-center justify-between px-4 pb-3">
+        <h2 className="text-sm font-semibold tracking-wide text-text-base">
+            Contents
+        </h2>
+        <button
+          onClick={onClose}
+          className="p-1 text-text-muted hover:text-text-base transition-colors"
+        >
+          <Icons.X size={18} />
+        </button>
+      </div>
+      <ul>
+        {visibleItems.map((item) => {
+          const expandable = hasChildren(item.id);
+          const collapsed = isCollapsed(item.id);
+
+          return (
+            <li key={item.id}>
+              <button onClick={()=>onSelect(item.id)} className={getItemClasses(item,activeId)} aria-current={item.id===activeId?"true":undefined}>
+                <span className="inline-flex items-center gap-1">
+                  {expandable && (
+                    <span
+                      onClick={(event) => {
+                        event.stopPropagation();
+                        toggleItem(item.id);
+                      }}
+                      className="inline-flex text-text-muted hover:text-text-base"
+                    >
+                      {collapsed ? (
+                        <Icons.ChevronRight size={20} />
+                      ) : (
+                        <Icons.ChevronDown size={20} />
+                      )}
+                    </span>
+                  )}
+                  <span>{item.text}</span>
+                </span>
+              </button>
+            </li>
+          )})}
+      </ul>
+    </nav>
+  )
 }

--- a/apps/renderer/src/components/Sidebar.tsx
+++ b/apps/renderer/src/components/Sidebar.tsx
@@ -16,7 +16,9 @@ export function Sidebar({tocItems,activeId,onSelect,isVisible=true, onClose }: S
             Contents
         </h2>
         <button
+          type="button"
           onClick={onClose}
+          aria-label="Close table of contents"
           className="p-1 text-text-muted hover:text-text-base transition-colors"
         >
           <Icons.X size={18} />
@@ -29,7 +31,7 @@ export function Sidebar({tocItems,activeId,onSelect,isVisible=true, onClose }: S
 
           return (
             <li key={item.id}>
-              <button onClick={()=>onSelect(item.id)} className={getItemClasses(item,activeId)} aria-current={item.id===activeId?"true":undefined}>
+              <button type="button" onClick={()=>onSelect(item.id)} className={getItemClasses(item,activeId)} aria-current={item.id===activeId?"location":undefined}>
                 <span className="inline-flex items-center gap-1">
                   {expandable && (
                     <span

--- a/apps/renderer/src/components/Sidebar.tsx
+++ b/apps/renderer/src/components/Sidebar.tsx
@@ -31,26 +31,29 @@ export function Sidebar({tocItems,activeId,onSelect,isVisible=true, onClose }: S
 
           return (
             <li key={item.id}>
-              <button type="button" onClick={()=>onSelect(item.id)} className={getItemClasses(item,activeId)} aria-current={item.id===activeId?"location":undefined}>
-                <span className="inline-flex items-center gap-1">
+              <div className="flex items-center w-full">
                   {expandable && (
-                    <span
+                    <button
+                    type="button"
+                    aria-expanded={!collapsed}
+                    aria-label={`${collapsed ? 'Expand' : 'Collapse'} ${item.text}`}
                       onClick={(event) => {
                         event.stopPropagation();
                         toggleItem(item.id);
                       }}
-                      className="inline-flex text-text-muted hover:text-text-base"
+                      className="inline-flex p-1 text-text-muted hover:text-text-base transition-colors shrink-0"
                     >
                       {collapsed ? (
                         <Icons.ChevronRight size={20} />
                       ) : (
                         <Icons.ChevronDown size={20} />
                       )}
-                    </span>
+                    </button>
                   )}
+                <button type="button" onClick={()=>onSelect(item.id)} className={`${getItemClasses(item, activeId)} text-left w-full`} aria-current={item.id===activeId?"location":undefined}>
                   <span>{item.text}</span>
-                </span>
               </button>
+              </div>
             </li>
           )})}
       </ul>

--- a/apps/renderer/src/hooks/useCollapsibleToc.ts
+++ b/apps/renderer/src/hooks/useCollapsibleToc.ts
@@ -1,0 +1,60 @@
+import { useCallback, useMemo, useState } from 'react';
+import { TOCType } from '../types/component-types';
+
+export function useCollapsibleToc(tocItems: TOCType[]) {
+  const [collapsedItems, setCollapsedItems] = useState<Record<string, boolean>>({});
+
+  const toggleItem = useCallback((id: string) => {
+    setCollapsedItems((prev) => ({
+      ...prev,
+      [id]: !prev[id],
+    }));
+  }, []);
+
+  const visibleItems = useMemo(() => {
+    return tocItems.filter((item, index) => {
+      let currentLevel = item.level;
+
+      for (let i = index - 1; i >= 0; i--) {
+        const previous = tocItems[i];
+        if (!previous) {
+          continue;
+        }
+
+        if (previous.level < currentLevel) {
+          if (collapsedItems[previous.id]) {
+            return false;
+          }
+          currentLevel = previous.level;
+        }
+      }
+
+      return true;
+    });
+  }, [tocItems, collapsedItems]);
+
+  const hasChildren = useCallback(
+    (id: string) => {
+      const index = tocItems.findIndex((item) => item.id === id);
+      if (index === -1) return false;
+
+      const currentItem = tocItems[index];
+      const nextItem = tocItems[index + 1];
+      if (!currentItem || !nextItem) {
+        return false;
+      }
+
+      return nextItem.level > currentItem.level;
+    },
+    [tocItems]
+  );
+
+  const isCollapsed = useCallback((id: string) => Boolean(collapsedItems[id]), [collapsedItems]);
+
+  return {
+    visibleItems,
+    toggleItem,
+    hasChildren,
+    isCollapsed,
+  };
+}

--- a/apps/renderer/src/hooks/useCollapsibleToc.ts
+++ b/apps/renderer/src/hooks/useCollapsibleToc.ts
@@ -11,42 +11,44 @@ export function useCollapsibleToc(tocItems: TOCType[]) {
     }));
   }, []);
 
+  const childMap = useMemo(() => {
+    const map: Record<string, boolean> = {};
+    for (let i = 0; i < tocItems.length; i++) {
+      const currentItem = tocItems[i];
+      const nextItem = tocItems[i + 1];
+      if (!currentItem) continue;
+      map[currentItem.id] = nextItem ? nextItem.level > currentItem.level : false;
+    }
+    return map;
+  }, [tocItems]);
+
   const visibleItems = useMemo(() => {
-    return tocItems.filter((item, index) => {
-      let currentLevel = item.level;
+    const visible: TOCType[] = [];
+    let activeHiddenLevel: number | null = null;
 
-      for (let i = index - 1; i >= 0; i--) {
-        const previous = tocItems[i];
-        if (!previous) {
+    for (let i = 0; i < tocItems.length; i++) {
+      const item = tocItems[i];
+      if (!item) continue;
+      if (activeHiddenLevel !== null) {
+        if (item.level > activeHiddenLevel) {
           continue;
-        }
-
-        if (previous.level < currentLevel) {
-          if (collapsedItems[previous.id]) {
-            return false;
-          }
-          currentLevel = previous.level;
+        } else {
+          activeHiddenLevel = null;
         }
       }
-
-      return true;
-    });
+      visible.push(item);
+      if (collapsedItems[item.id]) {
+        activeHiddenLevel = item.level;
+      }
+    }
+    return visible;
   }, [tocItems, collapsedItems]);
 
   const hasChildren = useCallback(
     (id: string) => {
-      const index = tocItems.findIndex((item) => item.id === id);
-      if (index === -1) return false;
-
-      const currentItem = tocItems[index];
-      const nextItem = tocItems[index + 1];
-      if (!currentItem || !nextItem) {
-        return false;
-      }
-
-      return nextItem.level > currentItem.level;
+      return Boolean(childMap[id]);
     },
-    [tocItems]
+    [childMap]
   );
 
   const isCollapsed = useCallback((id: string) => Boolean(collapsedItems[id]), [collapsedItems]);

--- a/apps/renderer/src/utils/constants/icon-contants.tsx
+++ b/apps/renderer/src/utils/constants/icon-contants.tsx
@@ -120,6 +120,18 @@ const ChevronRight = ({ size = 20, ...props }: IconProps) => (
   </svg>
 );
 
+const ChevronDown = ({ size = 20, ...props }: IconProps) => (
+  <svg
+    width={size}
+    height={size}
+    viewBox="0 0 24 24"
+    {...defaultProps}
+    {...props}
+  >
+    <polyline points="6 9 12 15 18 9" />
+  </svg>
+);
+
 export const Icons = {
-X,Hamburger,ZoomIn,ZoomOut,Sun,Moon,Folder,ChevronRight
+X,Hamburger,ZoomIn,ZoomOut,Sun,Moon,Folder,ChevronRight,ChevronDown
 };

--- a/apps/renderer/tests/hooks/useCollapsibleToc.test.ts
+++ b/apps/renderer/tests/hooks/useCollapsibleToc.test.ts
@@ -1,0 +1,49 @@
+import { renderHook, act } from '@testing-library/react';
+import { describe, test, expect } from 'vitest';
+import { useCollapsibleToc } from '../../src/hooks/useCollapsibleToc';
+import { TOCType } from '../../src/types/component-types';
+
+describe('Table of Contents Hook Tests', () => {
+  const sampleDocumentItems: TOCType[] = [
+    { id: 'chapter-1', text: 'Chapter 1', level: 1 },
+    { id: 'section-1.1', text: 'Section 1.1', level: 2 },
+    { id: 'subsection-1.1.1', text: 'Sub-section 1.1.1', level: 3 },
+    { id: 'chapter-2', text: 'Chapter 2', level: 1 },
+  ];
+
+  test('should accurately identify which items have chilren under them', () => {
+    const { result } = renderHook(() => useCollapsibleToc(sampleDocumentItems));
+    expect(result.current.hasChildren('chapter-1')).toBe(true);
+    expect(result.current.hasChildren('section-1.1')).toBe(true);
+    expect(result.current.hasChildren('subsection-1.1.1')).toBe(false);
+  });
+
+  test('should hide nested sub items when their parent is collapsed', () => {
+    const { result } = renderHook(() => useCollapsibleToc(sampleDocumentItems));
+    expect(result.current.visibleItems.length).toBe(4);
+    act(() => {
+      result.current.toggleItem('section-1.1');
+    });
+    expect(result.current.visibleItems.length).toBe(3);
+    const containsSubSection = result.current.visibleItems.some(
+      (item) => item.id === 'subsection-1.1.1'
+    );
+    expect(containsSubSection).toBe(false);
+  });
+
+  test('should handle completely empty lists without crashing the app', () => {
+    const { result } = renderHook(() => useCollapsibleToc([]));
+    expect(result.current.visibleItems.length).toBe(0);
+  });
+
+  test('should handle corrupted or missing list items safely', () => {
+    const brokenList = [
+      { id: 'item-1', text: 'Item 1', level: 1 },
+      undefined,
+      { id: 'item-2', text: 'Item 2', level: 2 },
+    ];
+
+    const { result } = renderHook(() => useCollapsibleToc(brokenList as TOCType[]));
+    expect(result.current.visibleItems.length).toBe(2);
+  });
+});


### PR DESCRIPTION
## Description

Added collapsible feature to the table of contents so that heading with nested child can now expand and collapse.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor (no functional change)
- [ ] Documentation update
- [ ] Style / UI change
- [ ] Build / CI change

## Related Issue

Closes #46 

## Changes Made

- Added useCollapsible custom hook for managing the collapse state.
- Added arrow down icon for it

## Screenshots (if applicable)

<img width="232" height="445" alt="Screenshot 2026-05-14 141954" src="https://github.com/user-attachments/assets/8ffc54ec-670e-49c8-8c5e-6a07197098d0" />


<img width="230" height="142" alt="image" src="https://github.com/user-attachments/assets/273aa1cd-aae2-47db-92b5-061893101139" />

## Checklist

- [x] My code follows the project's coding guidelines
- [x] I have tested my changes locally
- [x] I have used [conventional commit](https://www.conventionalcommits.org/) messages
- [ ] I have updated documentation if needed
- [x] My changes do not introduce new warnings or errors
