### PR TITLE
Fix/search pagination states

### DIFF
--- a/apps/renderer/src/components/SearchBar.tsx
+++ b/apps/renderer/src/components/SearchBar.tsx
@@ -13,7 +13,7 @@ export function SearchBar({
   onClose,
 }: SearchBarProps) {
   const inputRef = useRef<HTMLInputElement>(null);
-  const [localQuery,setLoacalQuery]=useState(query);
+  const [localQuery,setLocalQuery]=useState(query);
 
   useEffect(() => {
     inputRef.current?.focus();
@@ -45,7 +45,7 @@ export function SearchBar({
         type="text"
         value={localQuery}
         className="w-56 px-3 py-1.5 text-sm rounded border border-border-theme bg-bg text-text-base placeholder:text-text-muted outline-none focus:ring-2 focus:ring-accent transition-shadow"
-        onChange={(e) => setLoacalQuery(e.target.value)}
+        onChange={(e) => setLocalQuery(e.target.value)}
         onKeyDown={handleKeyDown}
         placeholder="Search in the document"
         aria-label="Search in document"

--- a/apps/renderer/src/components/SearchBar.tsx
+++ b/apps/renderer/src/components/SearchBar.tsx
@@ -24,19 +24,29 @@ export function SearchBar({
       onQueryChange(localQuery);
     },300);
     return ()=>clearTimeout(handler)
-  },[localQuery,onQueryChange])
+  },[localQuery,onQueryChange]);
+
+  const prevDisable=matchCount===0 || currentMatch<=1;
+  const nextDisable=matchCount===0 || currentMatch>=matchCount;
 
   const handleKeyDown = (e: React.KeyboardEvent) => {
     if (e.key === 'Enter' && e.shiftKey) {
       e.preventDefault();
+      if (!prevDisable){
         onPrev();
+      }
     } else if (e.key === 'Enter') {
       e.preventDefault();
+      if (!nextDisable){
         onNext();
+      }
     } else if (e.key === 'Escape') {
       onClose();
     }
   };
+
+
+  const newButtonClass=(isDisable:boolean)=>`${btnClass} ${isDisable? 'cursor-not-allowed opacity-50' : 'cursor-pointer'}`;
 
   return (
     <div role="search" aria-label="Document Search" className="fixed top-0 right-0 z-50 flex items-center gap-2 p-2 bg-surface border border-border-theme rounded-bl-lg shadow-lg">
@@ -66,9 +76,9 @@ export function SearchBar({
       )}
 
       <div className="flex gap-1" role="group" aria-label="Search navigation">
-        <button onClick={onPrev} aria-label="Previous match" className={btnClass}><Icons.ArrowUp size={18} /></button>
-        <button onClick={onNext} aria-label="Next match" className={btnClass}><Icons.ArrowDown size={18} /></button>
-        <button onClick={onClose} aria-label="Close search" className={btnClass}><Icons.X size={18} /></button>
+        <button onClick={onPrev} disabled={prevDisable} aria-label="Previous match" className={newButtonClass(prevDisable)}><Icons.ArrowUp size={18} /></button>
+        <button onClick={onNext} disabled={nextDisable} aria-label="Next match" className={newButtonClass(nextDisable)}><Icons.ArrowDown size={18} /></button>
+        <button onClick={onClose} aria-label="Close search" className={newButtonClass(false)}><Icons.X size={18} /></button>
       </div>
     </div>
   );

--- a/apps/renderer/src/components/SearchBar.tsx
+++ b/apps/renderer/src/components/SearchBar.tsx
@@ -29,17 +29,17 @@ export function SearchBar({
   const handleKeyDown = (e: React.KeyboardEvent) => {
     if (e.key === 'Enter' && e.shiftKey) {
       e.preventDefault();
-      onPrev();
+        onPrev();
     } else if (e.key === 'Enter') {
       e.preventDefault();
-      onNext();
+        onNext();
     } else if (e.key === 'Escape') {
       onClose();
     }
   };
 
   return (
-    <div className="fixed top-0 right-0 z-50 flex items-center gap-2 p-2 bg-surface border border-border-theme rounded-bl-lg shadow-lg">
+    <div role="search" aria-label="Document Search" className="fixed top-0 right-0 z-50 flex items-center gap-2 p-2 bg-surface border border-border-theme rounded-bl-lg shadow-lg">
       <input
         ref={inputRef}
         type="text"
@@ -52,10 +52,12 @@ export function SearchBar({
       />
 
      {query && (
-        <div className="flex items-center gap-2">
+        <div role="status" aria-live="polite" className="flex items-center gap-2">
           {matchCount > 0 ? (
             <span className="min-w-15 font-mono text-sm text-text-muted">
-              {currentMatch} / {matchCount}
+              <span className="sr-only">Match</span> {currentMatch} 
+              <span aria-hidden="true"> / </span> 
+              <span className="sr-only">of</span> {matchCount}
             </span>
           ) : (
             <span className="min-w-15 text-sm text-error">No results</span>
@@ -63,7 +65,7 @@ export function SearchBar({
         </div>
       )}
 
-      <div className="flex gap-1">
+      <div className="flex gap-1" role="group" aria-label="Search navigation">
         <button onClick={onPrev} aria-label="Previous match" className={btnClass}><Icons.ArrowUp size={18} /></button>
         <button onClick={onNext} aria-label="Next match" className={btnClass}><Icons.ArrowDown size={18} /></button>
         <button onClick={onClose} aria-label="Close search" className={btnClass}><Icons.X size={18} /></button>


### PR DESCRIPTION
## Description

It fixes a typo in the document search bar state configuration and implements UI boundary states for the pagination controls. It  handles navigation controls correctly  and functionally lock when reaching boundary matches or when no results exist. 
It also adds necessary ARIA roles, live regions, and descriptive screen-reader for  accessibility.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor (no functional change)
- [ ] Documentation update
- [x] Style / UI change
- [ ] Build / CI change

## Related Issue

Closes #49 

## Changes Made

- fixed typo 
- calculated prev disable and next disable and added contional rule to disable
- updated handlekeydown to block enter 
- Added aria label for accessebility


## Checklist

- [x] My code follows the project's coding guidelines
- [x] I have tested my changes locally
- [x] I have used [conventional commit](https://www.conventionalcommits.org/) messages
- [ ] I have updated documentation if needed
- [x] My changes do not introduce new warnings or errors
