### PR TITLE
Docs/release docs

### DIFF
--- a/docs/docusaurus.config.ts
+++ b/docs/docusaurus.config.ts
@@ -6,12 +6,16 @@ const config: Config = {
   title: 'Markdown Reader',
   tagline: 'PDF-reader comfort for Markdown files.',
   favicon: 'img/logo.png',
-  url: 'https://your-docusaurus-site.example.com',
-  baseUrl: '/',
+  url: 'https://mindfiredigital.github.io',
+  baseUrl: '/markdown-reader/',
   organizationName: 'mindfiredigital',
   projectName: 'markdown-reader',
   onBrokenLinks: 'throw',
-  onBrokenMarkdownLinks: 'warn',
+  markdown: {
+   hooks: {
+      onBrokenMarkdownLinks: 'warn',
+    },
+  },
   i18n: {
     defaultLocale: 'en',
     locales: ['en'],

--- a/docs/src/global.d.ts
+++ b/docs/src/global.d.ts
@@ -1,0 +1,14 @@
+declare module '*.png' {
+  const value: string;
+  export default value;
+}
+
+declare module '*.jpg' {
+  const value: string;
+  export default value;
+}
+
+declare module '*.svg' {
+  const value: string;
+  export default value;
+}

--- a/docs/src/utils/constants/download-constants.ts
+++ b/docs/src/utils/constants/download-constants.ts
@@ -1,20 +1,23 @@
+import windowsIcon from '@site/static/img/downloads/windows.png';
+import macosIcon from '@site/static/img/downloads/macos.png';
+import linuxIcon from '@site/static/img/downloads/linux.png';
 export const downloads = [
   {
     name: 'Windows',
     format: '.exe installer',
     href: 'https://github.com/mindfiredigital/markdown-reader/releases/latest/download/Markdown-Reader-Setup-1.0.0.exe',
-    icon: '/img/downloads/windows.png',
+    icon: windowsIcon,
   },
   {
     name: 'macOS',
     format: '.dmg package',
     href: 'https://github.com/mindfiredigital/markdown-reader/releases/latest/download/Markdown-Reader-1.0.0-arm64.dmg',
-    icon: '/img/downloads/macos.png',
+    icon: macosIcon,
   },
   {
     name: 'Linux',
     format: '.AppImage / .deb',
     href: 'https://github.com/mindfiredigital/markdown-reader/releases/latest/download/markdown-reader_1.0.0_amd64.deb',
-    icon: '/img/downloads/linux.png',
+    icon: linuxIcon ,
   },
 ];


### PR DESCRIPTION
## Description

This PR addresses two critical production issues in the documentation site: broken asset paths for download icons on the production build and an upcoming configuration deprecation warning for Docusaurus v4. It also introduces proper TypeScript typings for static asset modules while ensuring all code aligns with project ESLint rules.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [x] Refactor (no functional change)
- [ ] Documentation update
- [ ] Style / UI change
- [ ] Build / CI change

## Changes Made

- Configuration Update: Migrated onBrokenMarkdownLinks to markdown.hooks.onBrokenMarkdownLinks within docusaurus.config.ts to prevent Docusaurus v4 deprecation errors.
- Converted  image string paths in the downloads constant array to standard module assets to allow Webpack to resolve paths correctly under the /markdown-reader/ production base URL subdirectory.
-  Added asset declarations to global.d.ts so TypeScript recognizes .png, .jpg, and .svg asset modules.

## Checklist

- [x] My code follows the project's coding guidelines
- [x] I have tested my changes locally
- [x] I have used [conventional commit](https://www.conventionalcommits.org/) messages
- [ ] I have updated documentation if needed
- [x] My changes do not introduce new warnings or errors


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated documentation site configuration for GitHub Pages deployment with correct URL and base path settings.
  * Enhanced TypeScript support for importing image and SVG assets.
  * Refactored download asset references to use proper imports.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mindfiredigital/markdown-reader/pull/55)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->