### PR TITLE
Docs/release docs

### DIFF
--- a/docs/src/components/Homepage/hero.tsx
+++ b/docs/src/components/Homepage/hero.tsx
@@ -5,7 +5,6 @@ import clsx from 'clsx';
 import styles from './styles.module.css';
 import {
   ArrowRight,
-  Download,
   GitBranchIcon,
 } from 'lucide-react';
 import { downloads } from '@site/src/utils/constants/download-constants';
@@ -81,14 +80,13 @@ export function HeroSection() {
                     <span className="text-xs text-muted-foreground font-mono mb-4">
                       {item.format}
                     </span>
-                    <a
-                      href={item.href}
-                      download
-                      className="inline-flex items-center gap-1.5 text-xs font-semibold text-primary hover:underline no-underline transition-colors group"
-                    >
-                      <Download className="h-3.5 w-3.5 transition-transform group-hover:translate-y-0.5" />
-                      Download
-                    </a>
+                    <div className="flex items-center gap-2">
+                       {item.links.map((link) => (
+                       <a key={link.label} href={link.href} download className="inline-flex items-center justify-center px-3 py-1.5 rounded-md text-xs font-medium border border-input bg-background hover:bg-accent hover:text-accent-foreground transition-all active:scale-[0.98]">
+                          {link.label}
+                       </a>
+                        ))}
+                    </div>
                   </div>
                 ))}
               </div>

--- a/docs/src/utils/constants/download-constants.ts
+++ b/docs/src/utils/constants/download-constants.ts
@@ -5,19 +5,38 @@ export const downloads = [
   {
     name: 'Windows',
     format: '.exe installer',
-    href: 'https://github.com/mindfiredigital/markdown-reader/releases/latest/download/Markdown-Reader-Setup.exe',
+    links: [
+      {
+        label: 'Download',
+        href: 'https://github.com/mindfiredigital/markdown-reader/releases/latest/download/Markdown-Reader-Setup.exe',
+      },
+    ],
     icon: windowsIcon,
   },
   {
     name: 'macOS',
     format: '.dmg package',
-    href: 'https://github.com/mindfiredigital/markdown-reader/releases/latest/download/Markdown-Reader.dmg',
+    links: [
+      {
+        label: 'Download',
+        href: 'https://github.com/mindfiredigital/markdown-reader/releases/latest/download/Markdown-Reader.dmg',
+      },
+    ],
     icon: macosIcon,
   },
   {
     name: 'Linux',
     format: '.AppImage / .deb',
-    href: 'https://github.com/mindfiredigital/markdown-reader/releases/latest/download/Markdown-Reader.deb',
+    links: [
+      {
+        label: 'DEB',
+        href: 'https://github.com/mindfiredigital/markdown-reader/releases/latest/download/Markdown-Reader.deb',
+      },
+      {
+        label: 'AppImage',
+        href: 'https://github.com/mindfiredigital/markdown-reader/releases/latest/download/Markdown-Reader.AppImage',
+      },
+    ],
     icon: linuxIcon,
   },
 ];

--- a/docs/src/utils/constants/download-constants.ts
+++ b/docs/src/utils/constants/download-constants.ts
@@ -5,19 +5,19 @@ export const downloads = [
   {
     name: 'Windows',
     format: '.exe installer',
-    href: 'https://github.com/mindfiredigital/markdown-reader/releases/latest/download/Markdown-Reader-Setup-1.0.0.exe',
+    href: 'https://github.com/mindfiredigital/markdown-reader/releases/latest/download/Markdown-Reader-Setup.exe',
     icon: windowsIcon,
   },
   {
     name: 'macOS',
     format: '.dmg package',
-    href: 'https://github.com/mindfiredigital/markdown-reader/releases/latest/download/Markdown-Reader-1.0.0-arm64.dmg',
+    href: 'https://github.com/mindfiredigital/markdown-reader/releases/latest/download/Markdown-Reader.dmg',
     icon: macosIcon,
   },
   {
     name: 'Linux',
     format: '.AppImage / .deb',
-    href: 'https://github.com/mindfiredigital/markdown-reader/releases/latest/download/markdown-reader_1.0.0_amd64.deb',
-    icon: linuxIcon ,
+    href: 'https://github.com/mindfiredigital/markdown-reader/releases/latest/download/Markdown-Reader.deb',
+    icon: linuxIcon,
   },
 ];

--- a/electron-builder.ts
+++ b/electron-builder.ts
@@ -46,10 +46,12 @@ const config: Configuration = {
     icon: 'assets/icon.icns',
     target: ['dmg'],
     type: 'distribution',
+    artifactName: 'Markdown-Reader.${ext}',
   },
   win: {
     icon: 'assets/icon.ico',
     target: [{ target: 'nsis', arch: ['x64'] }],
+    artifactName: 'Markdown-Reader-Setup.${ext}',
   },
   nsis: {
     oneClick: false,
@@ -64,6 +66,7 @@ const config: Configuration = {
     category: 'Utility',
     mimeTypes: ['text/markdown'],
     maintainer: 'Mindfire Digital <ashminita12@gmail.com>',
+    artifactName: 'Markdown-Reader.${ext}',
   },
 };
 

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -5,7 +5,7 @@ import tsPlugin from "@typescript-eslint/eslint-plugin";
 
 export default [
   {
-    ignores: ["**/dist/**", "**/out/**", "node_modules","**/.docusaurus/**"]
+    ignores: ["**/dist/**", "**/out/**", "node_modules","**/.docusaurus/**","**/build/**"]
   },
   js.configs.recommended,
   {


### PR DESCRIPTION
## Description

This PR solves the issue of application download through the documentation website, and also the Linux system has two differentend ext, but the application had only one download button , so added two different 

## Type of Change

- [x] Bug fix
- [ ] New feature
- [x] Refactor (no functional change)
- [ ] Documentation update
- [ ] Style / UI change
- [ ] Build / CI change

## Related Issue

Closes #58 

## Changes Made

- Added artifact name in electron builder to fix the application download name.
- Also updated the download link in download constants.
- Added two labels for .deb and .AppImage .

## Screenshots (if applicable)

<img width="827" height="233" alt="image" src="https://github.com/user-attachments/assets/32bf0ed0-2731-4c15-8636-7fd7f4b856bb" />


## Checklist

- [x] My code follows the project's coding guidelines
- [x] I have tested my changes locally
- [x] I have used [conventional commit](https://www.conventionalcommits.org/) messages
- [ ] I have updated documentation if needed
- [x] My changes do not introduce new warnings or errors
