### PR TITLE
Feature/drag drop

### DIFF
--- a/apps/preload/src/index.ts
+++ b/apps/preload/src/index.ts
@@ -1,4 +1,4 @@
-import { contextBridge, ipcRenderer } from 'electron';
+import { contextBridge, ipcRenderer, webUtils } from 'electron';
 import { MarkdownReaderAPI } from '@package/shared-types';
 import { IPC_CONSTANTS } from '@package/shared-constants';
 import { BRIDGE_NAME } from '@package/shared-constants';
@@ -33,6 +33,7 @@ const apiContract: MarkdownReaderAPI = {
   removeOpenFilePathListener: (): void => {
     ipcRenderer.removeAllListeners(IPC_CONSTANTS.OPEN_FILE_PATH);
   },
+  getPathForFile: (file: File) => webUtils.getPathForFile(file),
 };
 
 // bridge between renderer and main

--- a/apps/renderer/src/App.tsx
+++ b/apps/renderer/src/App.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState, useRef, useCallback } from 'react';
+import React,{ useEffect, useState, useRef, useCallback } from 'react';
 import { useFile } from './hooks/useFile';
 import { Welcome } from './components/Welcome';
 import { Reader } from './components/Reader';
@@ -22,6 +22,7 @@ import { extractTOC } from './renderer/toc';
 import { Icons } from './utils/constants/icon-contants';
 import { useShortcuts } from './hooks/useShortcuts';
 import { useMenuEvents } from './hooks/useMenuEvents';
+import { extractDroppedMdpath } from './renderer/drag-drop';
 
 export default function App() {
   const {  error, isLoading, openFile, toc,recentFiles,loadFile } =useFile();
@@ -39,6 +40,8 @@ export default function App() {
   const contentRef=useRef<HTMLDivElement>(null);
   const debounceTimer=useRef<number | undefined>(undefined);
   const scrollTimer=useRef<number | undefined>(undefined);
+  const [isDraggingFile,setIsDraggingFile]=useState(false);
+
 
   const openFolder = useCallback(async () => {
     const folderPath = await window.api.openFolderDialog();
@@ -118,6 +121,19 @@ const closeActiveTab = useCallback(() => {
       window.api.removeOpenFilePathListener();
     };
   }, [loadFileInTab]);
+
+  useEffect(()=>{
+    const preventDefaultDrag=(e:DragEvent)=>{
+      e.preventDefault();
+    };
+    window.addEventListener('dragover',preventDefaultDrag);
+    window.addEventListener('drop',preventDefaultDrag);
+
+    return ()=>{
+      window.removeEventListener('dragover',preventDefaultDrag);
+      window.removeEventListener('drop',preventDefaultDrag);
+    }
+  },[]);
 
   useMenuEvents({
   onOpenFile: openFileDialog,
@@ -203,9 +219,46 @@ useShortcuts({
   });
 }, [activeTab?.id, activeTab?.html]);
 
+  const handleDragEnter=useCallback((e:React.DragEvent<HTMLDivElement>)=>{
+        e.preventDefault();
+        e.stopPropagation();
+        setIsDraggingFile(true);
+    },[]);
+
+  const handleDragOver=useCallback((e:React.DragEvent<HTMLDivElement>)=>{
+        e.preventDefault();
+        e.stopPropagation();
+        e.dataTransfer.dropEffect='copy';
+        setIsDraggingFile(true);
+    },[]);
+
+  const handleDragLeave=useCallback((e:React.DragEvent<HTMLDivElement>)=>{
+        e.preventDefault();
+        e.stopPropagation();
+        if(e.currentTarget.contains(e.relatedTarget as Node)){
+            return;
+        }
+        setIsDraggingFile(false);
+    },[]);
+
+  const handleDrop=useCallback((e:React.DragEvent<HTMLDivElement>)=>{
+        e.preventDefault();
+        e.stopPropagation();
+        setIsDraggingFile(false);
+        const droppedPath=extractDroppedMdpath(e.dataTransfer);
+        if(droppedPath){
+            void loadFileInTab(droppedPath);
+        }
+    },[loadFileInTab])
+
   return (
     <>
-      <div className="h-screen flex flex-col bg-bg text-text-base">
+      <div className="h-screen flex flex-col bg-bg text-text-base"  onDragEnter={handleDragEnter} onDragOver={handleDragOver} onDragLeave={handleDragLeave} onDrop={handleDrop}>
+        {isDraggingFile &&(
+          <div className='pointer-events-none fixed inset-0 z-50 flex items-center justify-center border-2 border-dashed border-accent bg-bg/80ntext-text-base'>
+            <div className='rounded-xl border border-border-theme bg-surface px-6 py-4 text-sm font-medium shadow-lg'>Drop Markdown file to open</div>
+          </div>
+        )}
         {isLoading && <Loading />}
         {isSearchOpen && (
           <SearchBar

--- a/apps/renderer/src/renderer/drag-drop.ts
+++ b/apps/renderer/src/renderer/drag-drop.ts
@@ -1,11 +1,21 @@
 import { ElectronFile } from '../types/component-types';
-
+import { MARKDOWN_FILE_PATTERN } from '@package/shared-constants';
 export function extractDroppedMdpath(dt: DataTransfer): string | null {
   if (!dt.files || dt.files.length === 0) return null;
   const files = Array.from(dt.files) as ElectronFile[];
   for (const f of files) {
-    if (f && f.path && /\.m(?:d|arkdown)$/i.test(f.name)) {
+    if (!f || !MARKDOWN_FILE_PATTERN.test(f.name)) {
+      continue;
+    }
+    if (f.path) {
       return f.path;
+    }
+    const api = window.api as typeof window.api & {
+      getPathForFile?: (file: File) => string;
+    };
+    const filePath = api.getPathForFile?.(f);
+    if (filePath) {
+      return filePath;
     }
   }
   return null;

--- a/apps/renderer/src/renderer/drag-drop.ts
+++ b/apps/renderer/src/renderer/drag-drop.ts
@@ -1,0 +1,12 @@
+import { ElectronFile } from '../types/component-types';
+
+export function extractDroppedMdpath(dt: DataTransfer): string | null {
+  if (!dt.files || dt.files.length === 0) return null;
+  const files = Array.from(dt.files) as ElectronFile[];
+  for (const f of files) {
+    if (f && f.path && /\.m(?:d|arkdown)$/i.test(f.name)) {
+      return f.path;
+    }
+  }
+  return null;
+}

--- a/apps/renderer/src/types/component-types.ts
+++ b/apps/renderer/src/types/component-types.ts
@@ -182,3 +182,7 @@ export interface UseShortcutsProps {
   onToggleSidebar: () => void;
   onToggleFileBrowser: () => void;
 }
+
+export interface ElectronFile extends File {
+  path: string;
+}

--- a/apps/renderer/tests/renderer/drag-drop.test.ts
+++ b/apps/renderer/tests/renderer/drag-drop.test.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect } from 'vitest';
+import { extractDroppedMdpath } from '../../src/renderer/drag-drop';
+
+const makeTransfer = (files: { name: string; path: string }[]) =>
+  ({
+    files: {
+      length: files.length,
+      item: (i: number) => files[i] ?? null,
+    },
+  }) as unknown as DataTransfer;
+
+describe('extract dropped md file path', () => {
+  it('it should return path of a dropped .md file', () => {
+    expect(extractDroppedMdpath(makeTransfer([{ name: 'README.md', path: '/p/README.md' }]))).toBe(
+      '/p/README.md'
+    );
+  });
+  it('should return null for a non markdown file path', () => {
+    expect(extractDroppedMdpath(makeTransfer([{ name: 'img.png', path: '/img.png' }]))).toBeNull();
+  });
+  it('it should return null for empty drop', () => {
+    expect(extractDroppedMdpath(makeTransfer([]))).toBeNull();
+  });
+  it('it should return first .md file when multiple files dropped', () => {
+    const dt = makeTransfer([
+      { name: 'img.png', path: '/i/png' },
+      { name: 'README.md', path: '/r.md' },
+    ]);
+    expect(extractDroppedMdpath(dt)).toBe('/r.md');
+  });
+});

--- a/apps/renderer/tests/renderer/drag-drop.test.ts
+++ b/apps/renderer/tests/renderer/drag-drop.test.ts
@@ -1,13 +1,23 @@
 import { describe, it, expect } from 'vitest';
 import { extractDroppedMdpath } from '../../src/renderer/drag-drop';
 
-const makeTransfer = (files: { name: string; path: string }[]) =>
-  ({
-    files: {
-      length: files.length,
-      item: (i: number) => files[i] ?? null,
-    },
-  }) as unknown as DataTransfer;
+const makeTransfer = (files: { name: string; path: string }[]) => {
+  const filesMock = {
+    length: files.length,
+    item: (i: number) => files[i] ?? null,
+    ...files.reduce(
+      (acc, file, index) => {
+        acc[index] = file;
+        return acc;
+      },
+      {} as Record<number, any>
+    ),
+  };
+
+  return {
+    files: filesMock,
+  } as unknown as DataTransfer;
+};
 
 describe('extract dropped md file path', () => {
   it('it should return path of a dropped .md file', () => {

--- a/packages/shared-constants/src/index.ts
+++ b/packages/shared-constants/src/index.ts
@@ -1,3 +1,4 @@
+export { MARKDOWN_FILE_PATTERN } from './path-constants.js';
 export { SHORTCUTS } from './keyboard-constants.js';
 export { MENU_LABELS, MENU_EVENTS, MENU_EVENT_LIST } from './menu-constants.js';
 export { THEMES } from './theme-constants.js';

--- a/packages/shared-constants/src/path-constants.ts
+++ b/packages/shared-constants/src/path-constants.ts
@@ -1,0 +1,1 @@
+export const MARKDOWN_FILE_PATTERN = /\.(md|markdown)$/i;

--- a/packages/shared-types/src/markdown-type.ts
+++ b/packages/shared-types/src/markdown-type.ts
@@ -22,6 +22,7 @@ export type MarkdownReaderAPI = {
   removeMenuListeners: () => void;
   onOpenFilePath(callback: (path: string) => void): void;
   removeOpenFilePathListener(): void;
+  getPathForFile(file: File): string;
 };
 
 // initial setting


### PR DESCRIPTION
## Description

This PR solve the issue(#62 ), now a user can drag a .md file and drop it any where in the application , and can read it , it will also prevent from dropping a non md file

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor (no functional change)
- [ ] Documentation update
- [ ] Style / UI change
- [ ] Build / CI change

## Related Issue

Closes #62 

## Changes Made

- Implemented extractDroppedMdPath funtion to extract markdown file paths from DataTransfer.
- Integrated onDragOver, onDrop, onDragEnter handlers into the application container.

## Checklist

- [x] My code follows the project's coding guidelines
- [x] I have tested my changes locally
- [x] I have used [conventional commit](https://www.conventionalcommits.org/) messages
- [ ] I have updated documentation if needed
- [x] My changes do not introduce new warnings or errors
