### PR TITLE
fix(ipc): ipc path traversal risk

### DIFF
--- a/apps/main-processor/src/ipc.ts
+++ b/apps/main-processor/src/ipc.ts
@@ -1,17 +1,18 @@
 import { ipcMain, dialog } from 'electron';
 import { readFile, unWatchFile, watchFile } from './file';
 import { getFolder } from './folder';
-import {
-  validateMarkdownFile,
-  validatePath,
-  validateSender,
-} from './utils/constants/ipc-validation';
+import { validatePath, validateSender, allowedFolderRoots } from './utils/constants/ipc-validation';
 import { IPC_CONSTANTS } from '@package/shared-constants';
 import { getRecentFiles } from './recent/getRecentFile';
 import { addRecentFile } from './recent/addRecentFile';
 import { exportHTML } from './export/exportHtml';
 import { exportPDF } from './export/exportPdf';
 import { exportDOCX } from './export/exportDocx';
+import {
+  resolveMarkdownFilePath,
+  resolveDirectoryPath,
+  resolveWatchedMarkdownPath,
+} from './utils/helper/ipc-path-resolver';
 
 //registers all IPC handlers for main process
 export function registerIPCHandlers(): void {
@@ -20,14 +21,8 @@ export function registerIPCHandlers(): void {
     if (!validateSender(event)) {
       throw new Error('Untrusted sender');
     }
-    if (!validatePath(filePath)) {
-      throw new Error('Invalid file path');
-    }
-
-    if (!validateMarkdownFile(filePath)) {
-      throw new Error('Only markdown files allowed');
-    }
-    return await readFile(filePath);
+    const safeFilePath = await resolveMarkdownFilePath(filePath);
+    return await readFile(safeFilePath);
   });
 
   // opens the file path
@@ -48,10 +43,7 @@ export function registerIPCHandlers(): void {
     }
     const selected = result.filePaths[0];
     if (!selected) return null;
-    if (!validateMarkdownFile(selected)) {
-      throw new Error('Only markdown files allowed');
-    }
-    return selected;
+    return await resolveMarkdownFilePath(selected);
   });
 
   // watches a file
@@ -59,11 +51,9 @@ export function registerIPCHandlers(): void {
     if (!validateSender(event)) {
       throw new Error('Untrusted sender');
     }
-    if (!validatePath(filePath)) {
-      throw new Error('Invalid File Path');
-    }
-    await watchFile(filePath, () => {
-      event.sender.send('file-changed', filePath);
+    const safeFilePath = await resolveWatchedMarkdownPath(filePath);
+    await watchFile(safeFilePath, () => {
+      event.sender.send(IPC_CONSTANTS.FILE_CHANGED, safeFilePath);
     });
   });
 
@@ -72,10 +62,8 @@ export function registerIPCHandlers(): void {
     if (!validateSender(event)) {
       throw new Error('Untrusted sender');
     }
-    if (!validatePath(filePath)) {
-      throw new Error('Invalid file path');
-    }
-    await unWatchFile(filePath);
+    const safeFilePath = await resolveMarkdownFilePath(filePath);
+    await unWatchFile(safeFilePath);
   });
 
   //get recent files
@@ -91,10 +79,8 @@ export function registerIPCHandlers(): void {
     if (!validateSender(event)) {
       throw new Error('Untrusted sender');
     }
-    if (!validatePath(filePath)) {
-      throw new Error('Invalid file path');
-    }
-    await addRecentFile(filePath);
+    const safeFilePath = await resolveMarkdownFilePath(filePath);
+    await addRecentFile(safeFilePath);
   });
 
   ipcMain.handle(IPC_CONSTANTS.OPEN_FOLDER_DIALOG, async (event) => {
@@ -111,7 +97,10 @@ export function registerIPCHandlers(): void {
       return null;
     }
 
-    return result.filePaths[0] ?? null;
+    if (!result.filePaths[0]) return null;
+    const safeFolderPath = await resolveDirectoryPath(result.filePaths[0]);
+    allowedFolderRoots.add(safeFolderPath);
+    return safeFolderPath;
   });
 
   ipcMain.handle(IPC_CONSTANTS.READ_FOLDER, async (event, folderPath: string) => {
@@ -119,10 +108,9 @@ export function registerIPCHandlers(): void {
       throw new Error('Untrusted sender');
     }
 
-    if (!validatePath(folderPath)) {
-      throw new Error('Invalid folder path');
-    }
-    return await getFolder(folderPath);
+    const safeFolderPath = await resolveDirectoryPath(folderPath);
+    allowedFolderRoots.add(safeFolderPath);
+    return await getFolder(safeFolderPath);
   });
 
   ipcMain.handle(

--- a/apps/main-processor/src/utils/constants/ipc-validation.ts
+++ b/apps/main-processor/src/utils/constants/ipc-validation.ts
@@ -3,6 +3,8 @@ import { IpcMainInvokeEvent } from 'electron';
 
 // production and dev urls
 const allowedOrigin = ['file://', 'http://localhost'];
+export const ALLOWED_MARKDOWN_EXTENSIONS = new Set(['.md', '.markdown']);
+export const allowedFolderRoots = new Set<string>();
 
 //validate the sender
 export function validateSender(event: IpcMainInvokeEvent): boolean {
@@ -11,12 +13,54 @@ export function validateSender(event: IpcMainInvokeEvent): boolean {
 }
 
 //validate path type
-export function validatePath(path: string) {
-  return typeof path == 'string' && path.trim().length > 0;
+export function validatePath(filePath: string) {
+  if (typeof filePath !== 'string' || filePath.trim().length === 0) {
+    return false;
+  }
+
+  try {
+    const resolvedPath = path.resolve(filePath);
+    if (!path.isAbsolute(resolvedPath)) {
+      return false;
+    }
+    // Prevent access to sensitive OS system folders
+    const lower = resolvedPath.toLowerCase();
+    if (process.platform === 'win32') {
+      const forbiddenPrefixes = [
+        'c:\\windows\\',
+        'c:\\winnt\\',
+        'c:\\boot\\',
+        'c:\\system volume information\\',
+        'c:\\$recycle.bin\\',
+      ];
+      if (forbiddenPrefixes.some((p) => lower === p.slice(0, -1) || lower.startsWith(p))) {
+        return false;
+      }
+    } else {
+      const forbiddenPrefixes = [
+        '/etc/',
+        '/var/',
+        '/sys/',
+        '/proc/',
+        '/boot/',
+        '/bin/',
+        '/sbin/',
+        '/dev/',
+      ];
+      if (forbiddenPrefixes.some((p) => lower === p.slice(0, -1) || lower.startsWith(p))) {
+        return false;
+      }
+    }
+
+    return true;
+  } catch {
+    return false;
+  }
 }
 
-//validate file extension
-export function validateMarkdownFile(filePath: string): boolean {
-  const ext = path.extname(filePath).toLowerCase();
-  return ext === '.md' || ext === '.markdown';
+export function isPathInside(childPath: string, parentPath: string): boolean {
+  const relative = path.relative(parentPath, childPath);
+  return (
+    relative === '' || (!!relative && !relative.startsWith('..') && !path.isAbsolute(relative))
+  );
 }

--- a/apps/main-processor/src/utils/helper/ipc-path-resolver.ts
+++ b/apps/main-processor/src/utils/helper/ipc-path-resolver.ts
@@ -1,0 +1,69 @@
+import path from 'path';
+import { realpath, stat } from 'node:fs/promises';
+import {
+  validatePath,
+  isPathInside,
+  ALLOWED_MARKDOWN_EXTENSIONS,
+  allowedFolderRoots,
+} from '../constants/ipc-validation';
+
+/* Validates, resolves symlink and ensures a path is a valid Markdown file inside an optional root directory */
+export async function resolveMarkdownFilePath(
+  filePath: string,
+  allowedRoot?: string
+): Promise<string> {
+  if (!validatePath(filePath)) {
+    throw new Error('Invalid file path');
+  }
+  const realFilePath = await realpath(path.resolve(filePath));
+  if (!validatePath(realFilePath)) {
+    throw new Error('Invalid file path');
+  }
+  const fileStats = await stat(realFilePath);
+  if (!fileStats.isFile()) {
+    throw new Error('Path is not a file');
+  }
+  const ext = path.extname(realFilePath).toLowerCase();
+  if (!ALLOWED_MARKDOWN_EXTENSIONS.has(ext)) {
+    throw new Error(`Disallowed file extension: ${ext}`);
+  }
+  if (allowedRoot) {
+    const realAllowedRoot = await realpath(path.resolve(allowedRoot));
+    if (!isPathInside(realFilePath, realAllowedRoot)) {
+      throw new Error('Path escapes allowed directory');
+    }
+  }
+  return realFilePath;
+}
+
+/*Validates, resolves symlinks and ensures a path points to an existing directory.*/
+export async function resolveDirectoryPath(folderPath: string): Promise<string> {
+  if (!validatePath(folderPath)) {
+    throw new Error('Invalid folder path');
+  }
+  const realFolderPath = await realpath(path.resolve(folderPath));
+  if (!validatePath(realFolderPath)) {
+    throw new Error('Invalid folder path');
+  }
+  const folderStats = await stat(realFolderPath);
+  if (!folderStats.isDirectory()) {
+    throw new Error('Path is not a directory');
+  }
+  return realFolderPath;
+}
+
+/*Resolves a Markdown file path against a dynamic set of allowed root folders throwing an error if it matches none*/
+export async function resolveWatchedMarkdownPath(filePath: string): Promise<string> {
+  let lastError: unknown;
+  for (const allowedRoot of allowedFolderRoots) {
+    try {
+      return await resolveMarkdownFilePath(filePath, allowedRoot);
+    } catch (error) {
+      lastError = error;
+    }
+  }
+  if (allowedFolderRoots.size > 0) {
+    throw lastError instanceof Error ? lastError : new Error('Path escapes allowed directory');
+  }
+  return await resolveMarkdownFilePath(filePath);
+}

--- a/apps/main-processor/tests/ipc.test.ts
+++ b/apps/main-processor/tests/ipc.test.ts
@@ -8,6 +8,15 @@ vi.mock('node:fs/promises', () => ({
   stat: vi.fn(),
 }));
 
+// Mocking the ipc validation module
+vi.mock('../src/utils/constants/ipc-validation', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../src/utils/constants/ipc-validation')>();
+  return {
+    ...actual,
+    validatePath: vi.fn(actual.validatePath),
+  };
+});
+
 // mocking the url
 function mockEvent(url: string) {
   return {
@@ -46,6 +55,7 @@ describe('ipc - validation test', () => {
   it('throws an error if file escapes the allowed root directory', async () => {
     const maliciousPath = '/etc/passwd.md';
     const allowedRoot = '/app/user/docs';
+    vi.mocked(validatePath).mockReturnValue(true);
     vi.mocked(realpath).mockResolvedValueOnce(maliciousPath).mockResolvedValueOnce(allowedRoot);
     vi.mocked(stat).mockResolvedValue({ isFile: () => true } as any);
     await expect(resolveMarkdownFilePath('../../etc/passwd.md', allowedRoot)).rejects.toThrow(

--- a/apps/main-processor/tests/ipc.test.ts
+++ b/apps/main-processor/tests/ipc.test.ts
@@ -1,9 +1,12 @@
-import { describe, it, expect } from 'vitest';
-import {
-  validateMarkdownFile,
-  validatePath,
-  validateSender,
-} from '../src/utils/constants/ipc-validation';
+import { describe, it, expect, vi } from 'vitest';
+import { realpath, stat } from 'node:fs/promises';
+import { validatePath, validateSender } from '../src/utils/constants/ipc-validation';
+import { resolveMarkdownFilePath } from '../src/utils/helper/ipc-path-resolver';
+
+vi.mock('node:fs/promises', () => ({
+  realpath: vi.fn(),
+  stat: vi.fn(),
+}));
 
 // mocking the url
 function mockEvent(url: string) {
@@ -30,8 +33,23 @@ describe('ipc - validation test', () => {
     expect(validatePath('C:\\Users\\file.md')).toBe(true);
   });
 
-  //test 4:- to check file extension
-  it('return true for .md files', () => {
-    expect(validateMarkdownFile('/docs/readme.md')).toBe(true);
+  //test 4:- to check successful markdown resolution
+  it('resolves and returns the path for valid markdown files', async () => {
+    const fakeInput = '/docs/readme.md';
+    vi.mocked(realpath).mockResolvedValue(fakeInput);
+    vi.mocked(stat).mockResolvedValue({ isFile: () => true } as any);
+    const result = await resolveMarkdownFilePath(fakeInput);
+    expect(result).toBe(fakeInput);
+  });
+
+  //test 5:- to check directory traversal security
+  it('throws an error if file escapes the allowed root directory', async () => {
+    const maliciousPath = '/etc/passwd.md';
+    const allowedRoot = '/app/user/docs';
+    vi.mocked(realpath).mockResolvedValueOnce(maliciousPath).mockResolvedValueOnce(allowedRoot);
+    vi.mocked(stat).mockResolvedValue({ isFile: () => true } as any);
+    await expect(resolveMarkdownFilePath('../../etc/passwd.md', allowedRoot)).rejects.toThrow(
+      'Path escapes allowed directory'
+    );
   });
 });


### PR DESCRIPTION
## Description

This PR fixes the issue (#71 ) ,IPC path traversal risks in markdown file read and watch flows.
Renderer provided file paths are now resolved through a shared path resolver before being used by the main process. The resolver validates that the target exists, resolves symlinks, ensure .md or .markdown extensions, and optionally ensures the file remains inside an opened folder root.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor (no functional change)
- [ ] Documentation update
- [ ] Style / UI change
- [ ] Build / CI change

## Related Issue

Closes #71 

## Changes Made

- Added markdown path resolver using realpath() and stat().
- Added allowed markdown extension validation for .md and .markdown.
- Added folder-root validation with isPathInside().
- Updated read file to read only validated markdown file paths.
- Updated watch file to watch only validated markdown file paths.

## Checklist

- [x] My code follows the project's coding guidelines
- [x] I have tested my changes locally
- [x] I have used [conventional commit](https://www.conventionalcommits.org/) messages
- [ ] I have updated documentation if needed
- [x] My changes do not introduce new warnings or errors
