### PR TITLE
Perf/shiki singleton

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,8 +79,8 @@ markdown-reader is a dedicated native desktop Markdown reader:
 - Links
 - Footnotes
 - Inline HTML
-- KaTeX math
 - Mermaid diagrams
+- KaTeX math
 
 ---
 

--- a/apps/renderer/src/renderer/shiki.ts
+++ b/apps/renderer/src/renderer/shiki.ts
@@ -3,7 +3,7 @@ import { createJavaScriptRegexEngine } from 'shiki/engine/javascript';
 import type { HighlighterCore } from 'shiki';
 import { SHIKI_LANG, SHIKI_THEME } from '../utils/constants/shiki-constants';
 
-let highlighter: HighlighterCore | null = null;
+let highlighter: Promise<HighlighterCore> | null = null;
 const themes = Object.values(SHIKI_THEME).map((fn) => fn());
 const langs = Object.values(SHIKI_LANG).map((fn) => fn());
 
@@ -13,14 +13,12 @@ export function resetHilighter() {
 
 // make shiki highlighter
 export async function shikiHighlighter(): Promise<HighlighterCore> {
-  if (highlighter) {
-    return highlighter;
+  if (!highlighter) {
+    highlighter = createHighlighterCore({
+      themes,
+      langs,
+      engine: createJavaScriptRegexEngine(),
+    });
   }
-  highlighter = await createHighlighterCore({
-    themes,
-    langs,
-    engine: createJavaScriptRegexEngine(),
-  });
-
   return highlighter;
 }

--- a/apps/renderer/src/utils/helpers/heading-helper.ts
+++ b/apps/renderer/src/utils/helpers/heading-helper.ts
@@ -12,8 +12,10 @@ export function getHeadingId(text: string): string {
 
 // assigns id to the headings
 export function heading({ text, depth }: HeadingProps) {
+  const plainText = stripHtml(text);
   const id = getHeadingId(text);
-  return `<h${depth} id="${id}">${text}</h${depth}>\n`;
+  const safeText = escapeHtml(plainText);
+  return `<h${depth} id="${id}">${safeText}</h${depth}>\n`;
 }
 
 //removes inline html


### PR DESCRIPTION
## Description

This PR solves the issue(#73 ) , by refactoring shiki highlighter initialization and escaping HTML characters in heading content before rendering.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor (no functional change)
- [ ] Documentation update
- [ ] Style / UI change
- [ ] Build / CI change

## Related Issue

Closes #73 

## Changes Made

- Updated shiki setup to reuse the same initialization process by preventing simultaneous async creation during markdown parsing.
- Added HTML escaping for heading content

## Checklist

- [x] My code follows the project's coding guidelines
- [x] I have tested my changes locally
- [x] I have used [conventional commit](https://www.conventionalcommits.org/) messages
- [ ] I have updated documentation if needed
- [x] My changes do not introduce new warnings or errors


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for exporting markdown as HTML, PDF, and DOCX formats via File menu
  * Implemented automatic update checking with download and installation notifications
  * Added visual drag-and-drop overlay feedback when dropping files
  * Introduced new reader toolbar with zoom controls and theme toggle

* **Improvements**
  * Enhanced security with CSS and HTML sanitization for exports
  * Improved UI/UX with consolidated toolbar and update banner components

* **Tests**
  * Added comprehensive test coverage for export functionality and HTML sanitization

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mindfiredigital/markdown-reader/pull/74?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->