### PR TITLE
Fix/system hardening

### DIFF
--- a/.github/workflows/development.yml
+++ b/.github/workflows/development.yml
@@ -41,3 +41,33 @@ jobs:
 
       - name: Build Electron app
         run: pnpm dist
+
+  security:
+    name: Security Audit
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: pnpm audit
+        run: pnpm audit --audit-level=high
+
+      - name: Run Trivy vulnerability scanner
+        uses: aquasecurity/trivy-action@master
+        with:
+          scan-type: fs
+          scan-ref: .
+          severity: CRITICAL,HIGH
+          format: table

--- a/.github/workflows/development.yml
+++ b/.github/workflows/development.yml
@@ -63,7 +63,7 @@ jobs:
         run: pnpm audit --audit-level=high
 
       - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@v0.28.0
+        uses: aquasecurity/trivy-action@v0.36.0
         with:
           scan-type: fs
           scan-ref: .

--- a/.github/workflows/development.yml
+++ b/.github/workflows/development.yml
@@ -21,8 +21,6 @@ jobs:
  
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
-        with:
-          version: 10
  
       - name: Install dependencies
         run: pnpm install --frozen-lockfile

--- a/.github/workflows/development.yml
+++ b/.github/workflows/development.yml
@@ -20,7 +20,7 @@ jobs:
           node-version: 22
  
       - name: Setup pnpm
-        uses: pnpm/action-setup@v3
+        uses: pnpm/action-setup@v4
         with:
           version: 10
  

--- a/.github/workflows/development.yml
+++ b/.github/workflows/development.yml
@@ -65,9 +65,10 @@ jobs:
         run: pnpm audit --audit-level=high
 
       - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@master
+        uses: aquasecurity/trivy-action@v0.28.0
         with:
           scan-type: fs
           scan-ref: .
           severity: CRITICAL,HIGH
           format: table
+          exit-code: 1

--- a/.github/workflows/development.yml
+++ b/.github/workflows/development.yml
@@ -49,14 +49,14 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
           node-version: 22
           cache: pnpm
-
-      - name: Setup pnpm
-        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile

--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -65,7 +65,7 @@ jobs:
         run: pnpm audit --audit-level=high
 
       - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@v0.28.0
+        uses: aquasecurity/trivy-action@v0.36.0
         with:
           scan-type: fs
           scan-ref: .

--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -51,8 +51,6 @@ jobs:
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
-        with:
-          version: 10
 
       - name: Setup Node
         uses: actions/setup-node@v4

--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -41,3 +41,33 @@ jobs:
 
       - name: Build Electron app
         run: pnpm dist
+
+  security:
+    name: Security Audit
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: pnpm audit
+        run: pnpm audit --audit-level=high
+
+      - name: Run Trivy vulnerability scanner
+        uses: aquasecurity/trivy-action@master
+        with:
+          scan-type: fs
+          scan-ref: .
+          severity: CRITICAL,HIGH
+          format: table

--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -20,7 +20,7 @@ jobs:
           node-version: 22
  
       - name: Setup pnpm
-        uses: pnpm/action-setup@v3
+        uses: pnpm/action-setup@v4
         with:
           version: 10
  
@@ -51,6 +51,8 @@ jobs:
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
+        with:
+          version: 10
 
       - name: Setup Node
         uses: actions/setup-node@v4
@@ -65,9 +67,10 @@ jobs:
         run: pnpm audit --audit-level=high
 
       - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@master
+        uses: aquasecurity/trivy-action@v0.28.0
         with:
           scan-type: fs
           scan-ref: .
           severity: CRITICAL,HIGH
           format: table
+          exit-code: 1

--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -49,14 +49,14 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
           node-version: 22
           cache: pnpm
-
-      - name: Setup pnpm
-        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile

--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,40 @@
-node_modules
-dist
-build
-.env
-out 
-coverage
-release
+# Dependencies
+node_modules/
+
+# Build outputs
+out/
+dist/
+build/
+release/
+*.tgz
 .vite/
+
+# Electron builder
+.cache/
+
+# Environment
+.env
+.env.local
+.env.*.local
+
+# Logs
+*.log
+npm-debug.log*
+pnpm-debug.log*
+
+# OS artifacts
+.DS_Store
+Thumbs.db
+
+# IDE
+.vscode/
+.idea/
+*.swp
+*.swo
+
+# Test coverage
+coverage/
+
+# Docusaurus
+docs/.docusaurus/
+docs/build/

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,0 +1,1 @@
+pnpm test

--- a/.prettierignore
+++ b/.prettierignore
@@ -2,3 +2,8 @@ node_modules
 dist
 .next
 build
+out/
+release/
+coverage/
+docs/.docusaurus/
+docs/build/

--- a/apps/main-processor/setup.ts
+++ b/apps/main-processor/setup.ts
@@ -1,0 +1,8 @@
+import { vi } from 'vitest';
+
+vi.mock('electron', () => ({
+  app: {
+    isPackaged: false,
+    getPath: vi.fn(),
+  },
+}));

--- a/apps/main-processor/src/export/inlineImage.ts
+++ b/apps/main-processor/src/export/inlineImage.ts
@@ -9,7 +9,7 @@ export async function inlineImages(html: string): Promise<string> {
 
   for (const match of matches) {
     const fullMatch = match[0];
-    const src = match[1];
+    const src = match[2];
 
     if (!src) continue;
 

--- a/apps/main-processor/src/file.ts
+++ b/apps/main-processor/src/file.ts
@@ -1,5 +1,6 @@
 import { readFile as fsReadFile } from 'node:fs/promises';
 import chokidar, { type FSWatcher } from 'chokidar';
+import { WatchFileOptions } from './types/watch-file-types';
 
 //file read logic
 export async function readFile(filePath: string): Promise<string> {
@@ -13,10 +14,15 @@ export async function readFile(filePath: string): Promise<string> {
 
 const currentWatchers = new Map<string, FSWatcher>();
 //file watching logic
-export async function watchFile(filePath: string, onChange: () => void): Promise<void> {
+export async function watchFile(
+  filePath: string,
+  options: WatchFileOptions | (() => void)
+): Promise<void> {
+  const { onChange, onDeleted, onError } =
+    typeof options === 'function' ? { onChange: options } : options;
+
   if (currentWatchers.has(filePath)) {
-    await currentWatchers.get(filePath)!.close();
-    currentWatchers.delete(filePath);
+    await unWatchFile(filePath);
   }
 
   const watcher = chokidar.watch(filePath, {
@@ -31,6 +37,13 @@ export async function watchFile(filePath: string, onChange: () => void): Promise
     watcher.on('ready', resolve);
   });
   watcher.on('change', onChange);
+  watcher.on('unlink', () => {
+    void unWatchFile(filePath).then(() => onDeleted?.());
+  });
+  watcher.on('error', (error) => {
+    const watcherError = error instanceof Error ? error : new Error(String(error));
+    void unWatchFile(filePath).then(() => onError?.(watcherError));
+  });
   currentWatchers.set(filePath, watcher);
 }
 

--- a/apps/main-processor/src/file.ts
+++ b/apps/main-processor/src/file.ts
@@ -13,6 +13,7 @@ export async function readFile(filePath: string): Promise<string> {
 }
 
 const currentWatchers = new Map<string, FSWatcher>();
+const debounceTimers = new Map<string, NodeJS.Timeout>();
 //file watching logic
 export async function watchFile(
   filePath: string,
@@ -36,7 +37,22 @@ export async function watchFile(
   await new Promise<void>((resolve) => {
     watcher.on('ready', resolve);
   });
-  watcher.on('change', onChange);
+  watcher.on('change', () => {
+    const existingTimer = debounceTimers.get(filePath);
+    if (existingTimer) {
+      clearTimeout(existingTimer);
+    }
+
+    const timer = setTimeout(() => {
+      if (!currentWatchers.has(filePath)) {
+        debounceTimers.delete(filePath);
+        return;
+      }
+      debounceTimers.delete(filePath);
+      onChange();
+    }, 100);
+    debounceTimers.set(filePath, timer);
+  });
   watcher.on('unlink', () => {
     void unWatchFile(filePath).then(() => onDeleted?.());
   });
@@ -49,7 +65,19 @@ export async function watchFile(
 
 //unwatch file
 export async function unWatchFile(filePath: string): Promise<void> {
+  const timer = debounceTimers.get(filePath);
+  if (timer) {
+    clearTimeout(timer);
+    debounceTimers.delete(filePath);
+  }
   if (!currentWatchers.has(filePath)) return;
   await currentWatchers.get(filePath)!.close();
   currentWatchers.delete(filePath);
+}
+
+export function getWatcherDiagnostics(): { watchers: number; debounceTimers: number } {
+  return {
+    watchers: currentWatchers.size,
+    debounceTimers: debounceTimers.size,
+  };
 }

--- a/apps/main-processor/src/folder.ts
+++ b/apps/main-processor/src/folder.ts
@@ -10,7 +10,12 @@ export async function getFolder(
   currentDepth = 0,
   seenPaths = new Set<string>()
 ): Promise<FileType> {
-  const realFolderPath = await realpath(folderPath);
+  let realFolderPath: string;
+  try {
+    realFolderPath = await realpath(folderPath);
+  } catch {
+    realFolderPath = folderPath;
+  }
   if (currentDepth >= maxDepth || seenPaths.has(realFolderPath)) {
     return {
       name: basename(folderPath),

--- a/apps/main-processor/src/folder.ts
+++ b/apps/main-processor/src/folder.ts
@@ -1,19 +1,37 @@
-import { readdir } from 'node:fs/promises';
+import { readdir, realpath } from 'node:fs/promises';
 import { basename, join } from 'node:path';
 import { FileType } from '@package/shared-types';
 import { isMarkdownFile } from './utils/helper/path-helper';
+import { MAX_FOLDER_DEPTH } from './utils/constants/path-constants';
 
-export async function getFolder(folderPath: string): Promise<FileType> {
-  const entries = await readdir(folderPath, { withFileTypes: true });
+export async function getFolder(
+  folderPath: string,
+  maxDepth = MAX_FOLDER_DEPTH,
+  currentDepth = 0,
+  seenPaths = new Set<string>()
+): Promise<FileType> {
+  const realFolderPath = await realpath(folderPath);
+  if (currentDepth >= maxDepth || seenPaths.has(realFolderPath)) {
+    return {
+      name: basename(folderPath),
+      path: folderPath,
+      isDir: true,
+      children: [],
+    };
+  }
+  seenPaths.add(realFolderPath);
+  const entries = (await readdir(folderPath, { withFileTypes: true })).sort((a, b) =>
+    a.name.localeCompare(b.name)
+  );
   const children: FileType[] = [];
 
   for (const entry of entries) {
     if (entry.name.startsWith('.')) continue;
-
+    if (entry.isSymbolicLink()) continue;
     const fullPath = join(folderPath, entry.name);
 
     if (entry.isDirectory()) {
-      children.push(await getFolder(fullPath));
+      children.push(await getFolder(fullPath, maxDepth, currentDepth + 1, seenPaths));
       continue;
     }
 

--- a/apps/main-processor/src/index.ts
+++ b/apps/main-processor/src/index.ts
@@ -6,16 +6,18 @@ import { PATHS } from './utils/constants/path-constants';
 import { registerMenu } from './register-menu';
 import { parseFilePathFromArgv } from './cli';
 import { setupAutoUpdater } from './updater';
+import { resolveMarkdownFilePath } from './utils/helper/ipc-path-resolver';
 
 let mainWindow: BrowserWindow | null = null;
 let pendingFilePath: string | null = null;
 
-function sendFilePathToRenderer(filePath: string): void {
+async function sendFilePathToRenderer(filePath: string): Promise<void> {
+  const safeFilePath = await resolveMarkdownFilePath(filePath);
   if (!mainWindow) {
-    pendingFilePath = filePath;
+    pendingFilePath = safeFilePath;
     return;
   }
-  mainWindow.webContents.send('open-file-path', filePath);
+  mainWindow.webContents.send('open-file-path', safeFilePath);
 }
 
 // register all IPC before window is created
@@ -71,7 +73,9 @@ function createWindow(): void {
 
 app.on('open-file', (event, filePath) => {
   event.preventDefault();
-  sendFilePathToRenderer(filePath);
+  void sendFilePathToRenderer(filePath).catch((error) => {
+    console.error('Failed to open file from Os:-', error);
+  });
 });
 const hasSingleInstanceLock = app.requestSingleInstanceLock();
 if (!hasSingleInstanceLock) {

--- a/apps/main-processor/src/ipc.ts
+++ b/apps/main-processor/src/ipc.ts
@@ -1,4 +1,4 @@
-import { ipcMain, dialog } from 'electron';
+import { app, ipcMain, dialog } from 'electron';
 import { readFile, unWatchFile, watchFile } from './file';
 import { getFolder } from './folder';
 import { validatePath, validateSender, allowedFolderRoots } from './utils/constants/ipc-validation';
@@ -13,6 +13,9 @@ import {
   resolveDirectoryPath,
   resolveWatchedMarkdownPath,
 } from './utils/helper/ipc-path-resolver';
+import { AppSettings } from '@package/shared-types';
+import { getSettings } from './settings/get-settings';
+import { saveSettings } from './settings/save-settings';
 
 //registers all IPC handlers for main process
 export function registerIPCHandlers(): void {
@@ -111,6 +114,27 @@ export function registerIPCHandlers(): void {
     const safeFolderPath = await resolveDirectoryPath(folderPath);
     allowedFolderRoots.add(safeFolderPath);
     return await getFolder(safeFolderPath);
+  });
+
+  ipcMain.handle(IPC_CONSTANTS.GET_SETTINGS, async (event) => {
+    if (!validateSender(event)) {
+      throw new Error('Untrusted sender');
+    }
+    return await getSettings();
+  });
+
+  ipcMain.handle(IPC_CONSTANTS.SAVE_SETTINGS, async (event, settings: Partial<AppSettings>) => {
+    if (!validateSender(event)) {
+      throw new Error('Untrusted sender');
+    }
+    return await saveSettings(settings);
+  });
+
+  ipcMain.handle(IPC_CONSTANTS.GET_APP_VERSION, async (event) => {
+    if (!validateSender(event)) {
+      throw new Error('Untrusted sender');
+    }
+    return app.getVersion();
   });
 
   ipcMain.handle(

--- a/apps/main-processor/src/menu.ts
+++ b/apps/main-processor/src/menu.ts
@@ -1,5 +1,5 @@
 import type { MenuItemConstructorOptions } from 'electron';
-import { MENU_EVENTS, MENU_LABELS, SHORTCUTS } from '@package/shared-constants';
+import { MENU_EVENTS, MENU_LABELS, SHORTCUTS, THEMES } from '@package/shared-constants';
 import { createMenuSender } from './utils/helper/menu-helper';
 
 export function buildMenuTemplate(): MenuItemConstructorOptions[] {
@@ -70,6 +70,14 @@ export function buildMenuTemplate(): MenuItemConstructorOptions[] {
           accelerator: SHORTCUTS.CYCLE_THEME,
           click: send(MENU_EVENTS.CYCLE_THEME),
         },
+        {
+          label: MENU_LABELS.THEME,
+          submenu: THEMES.map((theme) => ({
+            label: theme,
+            type: 'radio' as const,
+            click: send(MENU_EVENTS.SET_THEME, theme),
+          })),
+        },
         { type: 'separator' },
         {
           label: MENU_LABELS.ZOOM_IN,
@@ -87,7 +95,7 @@ export function buildMenuTemplate(): MenuItemConstructorOptions[] {
           click: send(MENU_EVENTS.ZOOM_RESET),
         },
         { type: 'separator' },
-        { role: 'toggleDevTools' },
+        ...(process.env.NODE_ENV === 'development' ? [{ role: 'toggleDevTools' as const }] : []),
       ],
     },
     {

--- a/apps/main-processor/src/menu.ts
+++ b/apps/main-processor/src/menu.ts
@@ -60,6 +60,10 @@ export function buildMenuTemplate(): MenuItemConstructorOptions[] {
           accelerator: SHORTCUTS.FOCUS_MODE,
           click: send(MENU_EVENTS.FOCUS_MODE),
         },
+        {
+          label: MENU_LABELS.SETTINGS,
+          click: send(MENU_EVENTS.OPEN_SETTINGS),
+        },
         { type: 'separator' },
         {
           label: MENU_LABELS.CYCLE_THEME,

--- a/apps/main-processor/src/settings/get-settings.ts
+++ b/apps/main-processor/src/settings/get-settings.ts
@@ -1,0 +1,19 @@
+import { readFile } from 'node:fs/promises';
+import { DEFAULT_SETTINGS } from '@package/shared-types';
+import { AppSettings } from '@package/shared-types';
+import { validateSettings, getSettingsPath } from '../utils/helper/setting-helper';
+
+/*Loads settings from local file system */
+export async function getSettings(): Promise<AppSettings> {
+  const settingsPath = getSettingsPath();
+  try {
+    const data = await readFile(settingsPath, 'utf-8');
+    const parsed = JSON.parse(data);
+    if (parsed && typeof parsed === 'object') {
+      return { ...DEFAULT_SETTINGS, ...validateSettings(parsed) };
+    }
+    return DEFAULT_SETTINGS;
+  } catch {
+    return DEFAULT_SETTINGS;
+  }
+}

--- a/apps/main-processor/src/settings/save-settings.ts
+++ b/apps/main-processor/src/settings/save-settings.ts
@@ -1,0 +1,20 @@
+import path from 'path';
+import { writeFile, mkdir } from 'node:fs/promises';
+import { AppSettings } from '@package/shared-types';
+import { validateSettings, getSettingsPath } from '../utils/helper/setting-helper';
+import { getSettings } from './get-settings';
+
+/*Save settings changes to local file*/
+export async function saveSettings(settings: Partial<AppSettings>): Promise<AppSettings> {
+  const validatedSettings = validateSettings(settings);
+  const nextSettings: AppSettings = { ...(await getSettings()), ...validatedSettings };
+  const settingsPath = getSettingsPath();
+  try {
+    const dir = path.dirname(settingsPath);
+    await mkdir(dir, { recursive: true });
+    await writeFile(settingsPath, JSON.stringify(nextSettings, null, 2), 'utf-8');
+    return nextSettings;
+  } catch (error) {
+    throw new Error('Failed to save settings file', { cause: error });
+  }
+}

--- a/apps/main-processor/src/settings/save-settings.ts
+++ b/apps/main-processor/src/settings/save-settings.ts
@@ -1,20 +1,23 @@
-import path from 'path';
-import { writeFile, mkdir } from 'node:fs/promises';
 import { AppSettings } from '@package/shared-types';
-import { validateSettings, getSettingsPath } from '../utils/helper/setting-helper';
+import {
+  validateSettings,
+  getSettingsPath,
+  writeSettingsAtomically,
+} from '../utils/helper/setting-helper';
 import { getSettings } from './get-settings';
+import { runExclusive } from '../utils/helper/setting-helper';
 
 /*Save settings changes to local file*/
 export async function saveSettings(settings: Partial<AppSettings>): Promise<AppSettings> {
-  const validatedSettings = validateSettings(settings);
-  const nextSettings: AppSettings = { ...(await getSettings()), ...validatedSettings };
-  const settingsPath = getSettingsPath();
-  try {
-    const dir = path.dirname(settingsPath);
-    await mkdir(dir, { recursive: true });
-    await writeFile(settingsPath, JSON.stringify(nextSettings, null, 2), 'utf-8');
-    return nextSettings;
-  } catch (error) {
-    throw new Error('Failed to save settings file', { cause: error });
-  }
+  return runExclusive(async () => {
+    const validatedSettings = validateSettings(settings);
+    const nextSettings: AppSettings = { ...(await getSettings()), ...validatedSettings };
+    const settingsPath = getSettingsPath();
+    try {
+      await writeSettingsAtomically(settingsPath, nextSettings);
+      return nextSettings;
+    } catch (error) {
+      throw new Error('Failed to save settings file', { cause: error });
+    }
+  });
 }

--- a/apps/main-processor/src/types/watch-file-types.ts
+++ b/apps/main-processor/src/types/watch-file-types.ts
@@ -1,0 +1,5 @@
+export type WatchFileOptions = {
+  onChange: () => void;
+  onDeleted?: () => void;
+  onError?: (error: Error) => void;
+};

--- a/apps/main-processor/src/utils/constants/path-constants.ts
+++ b/apps/main-processor/src/utils/constants/path-constants.ts
@@ -11,4 +11,6 @@ export const PATHS = {
 
 export const MAX_RECENT = 20;
 
+export const MAX_FOLDER_DEPTH = 10;
+
 export const MARKDOWN_FILE_PATTERN = /\.(md|markdown)$/i;

--- a/apps/main-processor/src/utils/constants/setting-constants.ts
+++ b/apps/main-processor/src/utils/constants/setting-constants.ts
@@ -1,0 +1,14 @@
+import { AppSettings } from '@package/shared-types';
+
+export const SETTINGS_KEYS = new Set<keyof AppSettings>([
+  'theme',
+  'fontSize',
+  'readingWidth',
+  'lineNumbers',
+  'customCss',
+  'zoom',
+  'recentFilesLimit',
+  'showHiddenFiles',
+]);
+
+export const READING_WIDTHS = new Set<AppSettings['readingWidth']>(['narrow', 'default', 'wide']);

--- a/apps/main-processor/src/utils/helper/menu-helper.ts
+++ b/apps/main-processor/src/utils/helper/menu-helper.ts
@@ -1,9 +1,9 @@
 import { BrowserWindow, BaseWindow, MenuItem, KeyboardEvent } from 'electron';
 
-export function createMenuSender(eventName: string) {
+export function createMenuSender(eventName: string, payload?: unknown) {
   return (_menuItem: MenuItem, window: BaseWindow | undefined, _event: KeyboardEvent): void => {
     if (window instanceof BrowserWindow) {
-      window.webContents.send(eventName);
+      window.webContents.send(eventName, payload);
     }
   };
 }

--- a/apps/main-processor/src/utils/helper/setting-helper.ts
+++ b/apps/main-processor/src/utils/helper/setting-helper.ts
@@ -1,0 +1,70 @@
+import { app } from 'electron';
+import path from 'path';
+import { AppSettings } from '@package/shared-types';
+import { THEMES } from '@package/shared-constants';
+import { SETTINGS_KEYS, READING_WIDTHS } from '../constants/setting-constants';
+
+/* Gives file system path for settings.json */
+export function getSettingsPath(): string {
+  try {
+    return path.join(app.getPath('userData'), 'settings.json');
+  } catch {
+    return path.join(process.cwd(), 'settings.json');
+  }
+}
+
+/* To validate the settings preference before saving */
+export function validateSettings(partial: Partial<AppSettings>): Partial<AppSettings> {
+  if (!partial || typeof partial !== 'object' || Array.isArray(partial)) {
+    throw new Error('Invalid settings object');
+  }
+
+  const validated: Partial<AppSettings> = {};
+  for (const [key, value] of Object.entries(partial)) {
+    if (!SETTINGS_KEYS.has(key as keyof AppSettings)) {
+      throw new Error(`Unknown settings key: ${key}`);
+    }
+
+    if (key === 'theme') {
+      if (typeof value !== 'string' || !THEMES.includes(value as AppSettings['theme'])) {
+        throw new Error('Invalid theme');
+      }
+      validated.theme = value as AppSettings['theme'];
+    }
+    if (key === 'fontSize') {
+      if (typeof value !== 'number' || value < 12 || value > 24)
+        throw new Error('Invalid fontSize');
+      validated.fontSize = value;
+    }
+    if (key === 'readingWidth') {
+      if (!READING_WIDTHS.has(value as AppSettings['readingWidth'])) {
+        throw new Error('Invalid readingWidth');
+      }
+      validated.readingWidth = value as AppSettings['readingWidth'];
+    }
+    if (key === 'lineNumbers') {
+      if (typeof value !== 'boolean') throw new Error('Invalid lineNumbers');
+      validated.lineNumbers = value;
+    }
+    if (key === 'customCss') {
+      if (typeof value !== 'string') throw new Error('Invalid customCss');
+      validated.customCss = value;
+    }
+    if (key === 'zoom') {
+      if (typeof value !== 'number' || value < 50 || value > 200) throw new Error('Invalid zoom');
+      validated.zoom = value;
+    }
+    if (key === 'recentFilesLimit') {
+      if (typeof value !== 'number' || value < 1 || value > 50) {
+        throw new Error('Invalid recentFilesLimit');
+      }
+      validated.recentFilesLimit = value;
+    }
+    if (key === 'showHiddenFiles') {
+      if (typeof value !== 'boolean') throw new Error('Invalid showHiddenFiles');
+      validated.showHiddenFiles = value;
+    }
+  }
+
+  return validated;
+}

--- a/apps/main-processor/src/utils/helper/setting-helper.ts
+++ b/apps/main-processor/src/utils/helper/setting-helper.ts
@@ -1,5 +1,6 @@
 import { app } from 'electron';
 import path from 'path';
+import { mkdir, open, rename, unlink, writeFile } from 'node:fs/promises';
 import { AppSettings } from '@package/shared-types';
 import { THEMES } from '@package/shared-constants';
 import { SETTINGS_KEYS, READING_WIDTHS } from '../constants/setting-constants';
@@ -63,4 +64,48 @@ export function validateSettings(partial: Partial<AppSettings>): Partial<AppSett
   }
 
   return validated;
+}
+
+/* writes settings to disk without risking file corruption*/
+export async function writeSettingsAtomically(
+  settingsPath: string,
+  nextSettings: AppSettings
+): Promise<void> {
+  const dir = path.dirname(settingsPath);
+  const tempPath = `${settingsPath}.tmp`;
+
+  try {
+    await mkdir(dir, { recursive: true });
+    await writeFile(tempPath, JSON.stringify(nextSettings, null, 2), 'utf-8');
+
+    const tempFile = await open(tempPath, 'r');
+    try {
+      await tempFile.sync();
+    } finally {
+      await tempFile.close();
+    }
+    await rename(tempPath, settingsPath);
+  } catch (error) {
+    await unlink(tempPath).catch(() => {});
+    throw error;
+  }
+}
+
+/* Runs an asynchronous operation sequentially to prevent concurrent execution*/
+let mutex: Promise<void> = Promise.resolve();
+
+export async function runExclusive<T>(operation: () => Promise<T>): Promise<T> {
+  const previous = mutex;
+  let release!: () => void;
+  mutex = new Promise<void>((resolve) => {
+    release = resolve;
+  });
+
+  await previous.catch(() => {});
+
+  try {
+    return await operation();
+  } finally {
+    release();
+  }
 }

--- a/apps/main-processor/src/utils/helper/setting-helper.ts
+++ b/apps/main-processor/src/utils/helper/setting-helper.ts
@@ -6,11 +6,7 @@ import { SETTINGS_KEYS, READING_WIDTHS } from '../constants/setting-constants';
 
 /* Gives file system path for settings.json */
 export function getSettingsPath(): string {
-  try {
-    return path.join(app.getPath('userData'), 'settings.json');
-  } catch {
-    return path.join(process.cwd(), 'settings.json');
-  }
+  return path.join(app.getPath('userData'), 'settings.json');
 }
 
 /* To validate the settings preference before saving */

--- a/apps/main-processor/tests/export.test.ts
+++ b/apps/main-processor/tests/export.test.ts
@@ -1,7 +1,11 @@
 import { describe, it, expect } from 'vitest';
+import { mkdtemp, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
 import { buildDocument } from '../src/export/buildDocument';
 import { sanitizeCss } from '../src/export/sanitizeCss';
 import { getImage } from '../src/export/getImage';
+import { inlineImages } from '../src/export/inlineImage';
 
 describe('build html document', () => {
   it('wraps content in a valid HTML5 document shell', () => {
@@ -48,5 +52,15 @@ describe('get image of mime type', () => {
     expect(getImage('image.jpeg')).toBe('image/jpeg');
     expect(getImage('image.svg')).toBe('image/svg+xml');
     expect(getImage('image.webp')).toBe('image/webp');
+  });
+});
+
+describe('inline images for HTML export', () => {
+  it('keeps local images as base 64 data URIs', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'markdown-reader-export-'));
+    const imagePath = join(dir, 'image.png');
+    await writeFile(imagePath, Buffer.from([137, 80, 78, 71]));
+    const html = await inlineImages(`<img src="${imagePath}"/>`);
+    expect(html).toContain('src="data:image/png;base64,');
   });
 });

--- a/apps/main-processor/tests/export.test.ts
+++ b/apps/main-processor/tests/export.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { mkdtemp, writeFile } from 'node:fs/promises';
+import { mkdtemp, writeFile, rm } from 'node:fs/promises';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { buildDocument } from '../src/export/buildDocument';
@@ -58,9 +58,13 @@ describe('get image of mime type', () => {
 describe('inline images for HTML export', () => {
   it('keeps local images as base 64 data URIs', async () => {
     const dir = await mkdtemp(join(tmpdir(), 'markdown-reader-export-'));
-    const imagePath = join(dir, 'image.png');
-    await writeFile(imagePath, Buffer.from([137, 80, 78, 71]));
-    const html = await inlineImages(`<img src="${imagePath}"/>`);
-    expect(html).toContain('src="data:image/png;base64,');
+    try {
+      const imagePath = join(dir, 'image.png');
+      await writeFile(imagePath, Buffer.from([137, 80, 78, 71]));
+      const html = await inlineImages(`<img src="${imagePath}"/>`);
+      expect(html).toContain('src="data:image/png;base64,');
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
   });
 });

--- a/apps/main-processor/tests/file.test.ts
+++ b/apps/main-processor/tests/file.test.ts
@@ -72,4 +72,14 @@ describe('File watcher', () => {
     await unWatchFile(TEST_FILE);
     expect(getWatcherDiagnostics().debounceTimers).toBe(0);
   });
+
+  it('does not call callback for a file unwatched during debounce', async () => {
+    const cb = vi.fn();
+    await watchFile(TEST_FILE, cb);
+    writeFileSync(TEST_FILE, 'change before immediate unwatch');
+    await new Promise((r) => setTimeout(r, 25));
+    await unWatchFile(TEST_FILE);
+    await new Promise((r) => setTimeout(r, 200));
+    expect(cb).not.toHaveBeenCalled();
+  });
 });

--- a/apps/main-processor/tests/file.test.ts
+++ b/apps/main-processor/tests/file.test.ts
@@ -2,6 +2,7 @@ import { vi, describe, expect, it, beforeAll, afterAll } from 'vitest';
 import { writeFileSync, unlinkSync, mkdirSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
+import { getWatcherDiagnostics } from '../src/file';
 
 import { readFile, watchFile, unWatchFile } from '../src/file';
 
@@ -47,6 +48,7 @@ describe('File watcher', () => {
     writeFileSync(TEST_FILE, 'change after unwatch');
     await new Promise((r) => setTimeout(r, 200));
     expect(cb).not.toHaveBeenCalled();
+    expect(getWatcherDiagnostics().debounceTimers).toBe(0);
   });
 
   it('should protect from double call', async () => {
@@ -60,5 +62,14 @@ describe('File watcher', () => {
 
   it('should not crash if I unwatch a file which is not watched', async () => {
     await expect(unWatchFile('fake-file.txt')).resolves.toBeUndefined();
+  });
+
+  it('should clean debounce timer references after unwatching', async () => {
+    const cb = vi.fn();
+    await watchFile(TEST_FILE, cb);
+    writeFileSync(TEST_FILE, 'change with pending debounce');
+    await new Promise((r) => setTimeout(r, 25));
+    await unWatchFile(TEST_FILE);
+    expect(getWatcherDiagnostics().debounceTimers).toBe(0);
   });
 });

--- a/apps/main-processor/tests/folder.test.ts
+++ b/apps/main-processor/tests/folder.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from 'vitest';
+import { mkdtemp, mkdir, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { getFolder } from '../src/folder';
+
+describe('folder reader testing', async () => {
+  it('should enforce the recursion depth', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'markdown-reader-folder-'));
+    let current = root;
+    for (let index = 0; index < 12; index += 1) {
+      current = join(current, `level-${index}`);
+      await mkdir(current);
+      await writeFile(join(current, `file-${index}.md`), '# test', 'utf-8');
+    }
+
+    const tree = await getFolder(root, 2);
+    const first = tree.children?.find((child) => child.isDir);
+    const second = first?.children?.find((child) => child.isDir);
+    expect(second?.children).toEqual([]);
+  });
+});

--- a/apps/main-processor/tests/recent.test.ts
+++ b/apps/main-processor/tests/recent.test.ts
@@ -1,9 +1,4 @@
-import { vi, describe, it, expect } from 'vitest';
-vi.mock('electron', () => ({
-  app: {
-    isPackaged: false,
-  },
-}));
+import { describe, it, expect } from 'vitest';
 import { RecentFile } from '@package/shared-types';
 import { addToRecentList } from '../src/recent/addToRecentList';
 import { getUniqueRecentFile } from '../src/recent/getUniqueRecentFile';

--- a/apps/main-processor/tests/settings.test.ts
+++ b/apps/main-processor/tests/settings.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from 'vitest';
+import { validateSettings } from '../src/utils/helper/setting-helper';
+
+describe('settings validation', () => {
+  it('accepts valid settings', () => {
+    expect(validateSettings({ fontSize: 18 })).toEqual({ fontSize: 18 });
+  });
+
+  it('rejects unknown keys', () => {
+    expect(() => validateSettings({ unexpected: true } as never)).toThrow('Unknown settings key');
+  });
+
+  it('rejects invalid values', () => {
+    expect(() => validateSettings({ fontSize: 100 })).toThrow('Invalid font size');
+  });
+});

--- a/apps/main-processor/tests/settings.test.ts
+++ b/apps/main-processor/tests/settings.test.ts
@@ -11,6 +11,6 @@ describe('settings validation', () => {
   });
 
   it('rejects invalid values', () => {
-    expect(() => validateSettings({ fontSize: 100 })).toThrow('Invalid font size');
+    expect(() => validateSettings({ fontSize: 100 })).toThrow('Invalid fontSize');
   });
 });

--- a/apps/main-processor/tests/settings.test.ts
+++ b/apps/main-processor/tests/settings.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import { validateSettings } from '../src/utils/helper/setting-helper';
-
+import { READING_WIDTHS } from '../src/utils/constants/setting-constants';
+import { THEMES } from '@package/shared-constants';
 describe('settings validation', () => {
   it('accepts valid settings', () => {
     expect(validateSettings({ fontSize: 18 })).toEqual({ fontSize: 18 });
@@ -12,5 +13,48 @@ describe('settings validation', () => {
 
   it('rejects invalid values', () => {
     expect(() => validateSettings({ fontSize: 100 })).toThrow('Invalid fontSize');
+  });
+
+  it('validates theme values', () => {
+    expect(validateSettings({ theme: THEMES[0] })).toEqual({ theme: THEMES[0] });
+    expect(() => validateSettings({ theme: 'unknown-theme' as never })).toThrow('Invalid theme');
+  });
+
+  it('validates readingWidth values', () => {
+    expect(READING_WIDTHS.has('default')).toBe(true);
+    expect(validateSettings({ readingWidth: 'default' })).toEqual({ readingWidth: 'default' });
+    expect(() => validateSettings({ readingWidth: 'full' as never })).toThrow(
+      'Invalid readingWidth'
+    );
+  });
+
+  it('validates boolean settings', () => {
+    expect(validateSettings({ lineNumbers: true })).toEqual({ lineNumbers: true });
+    expect(validateSettings({ showHiddenFiles: false })).toEqual({ showHiddenFiles: false });
+    expect(() => validateSettings({ lineNumbers: 'yes' as never })).toThrow('Invalid lineNumbers');
+    expect(() => validateSettings({ showHiddenFiles: 'no' as never })).toThrow(
+      'Invalid showHiddenFiles'
+    );
+  });
+
+  it('validates customCss values', () => {
+    expect(validateSettings({ customCss: '.markdown-body { color: red; }' })).toEqual({
+      customCss: '.markdown-body { color: red; }',
+    });
+    expect(() => validateSettings({ customCss: 42 as never })).toThrow('Invalid customCss');
+  });
+
+  it('validates zoom range', () => {
+    expect(validateSettings({ zoom: 50 })).toEqual({ zoom: 50 });
+    expect(validateSettings({ zoom: 200 })).toEqual({ zoom: 200 });
+    expect(() => validateSettings({ zoom: 49 })).toThrow('Invalid zoom');
+    expect(() => validateSettings({ zoom: 201 })).toThrow('Invalid zoom');
+  });
+
+  it('validates recentFilesLimit range', () => {
+    expect(validateSettings({ recentFilesLimit: 1 })).toEqual({ recentFilesLimit: 1 });
+    expect(validateSettings({ recentFilesLimit: 50 })).toEqual({ recentFilesLimit: 50 });
+    expect(() => validateSettings({ recentFilesLimit: 0 })).toThrow('Invalid recentFilesLimit');
+    expect(() => validateSettings({ recentFilesLimit: 51 })).toThrow('Invalid recentFilesLimit');
   });
 });

--- a/apps/main-processor/vitest.config.ts
+++ b/apps/main-processor/vitest.config.ts
@@ -6,6 +6,7 @@ export default defineConfig({
     environment: 'node',
     globals: true,
     exclude: ['dist/**', 'node_modules/**'],
+    setupFiles: ['./setup.ts'],
   },
   resolve: {
     alias: {

--- a/apps/preload/src/index.ts
+++ b/apps/preload/src/index.ts
@@ -1,4 +1,4 @@
-import { contextBridge, ipcRenderer, webUtils } from 'electron';
+import { contextBridge, ipcRenderer, IpcRendererEvent, webUtils } from 'electron';
 import { MarkdownReaderAPI } from '@package/shared-types';
 import { IPC_CONSTANTS } from '@package/shared-constants';
 import { BRIDGE_NAME } from '@package/shared-constants';
@@ -20,7 +20,11 @@ const apiContract: MarkdownReaderAPI = {
   onFileChanged: (callback: (path: string) => void) =>
     ipcRenderer.on(IPC_CONSTANTS.FILE_CHANGED, (_event, path: string) => callback(path)),
   removeFileChangedListener: () => ipcRenderer.removeAllListeners(IPC_CONSTANTS.FILE_CHANGED),
-  onMenuEvent: (event: string, callback: () => void) => ipcRenderer.on(event, () => callback()),
+  onMenuEvent: (event: string, callback: (payload?: unknown) => void) => {
+    const handler = (_event: IpcRendererEvent, payload?: unknown) => callback(payload);
+    ipcRenderer.on(event, handler);
+    return () => ipcRenderer.removeListener(event, handler);
+  },
   removeMenuListeners: () =>
     MENU_EVENT_LIST.forEach((event) => {
       ipcRenderer.removeAllListeners(event);

--- a/apps/preload/src/index.ts
+++ b/apps/preload/src/index.ts
@@ -3,6 +3,7 @@ import { MarkdownReaderAPI } from '@package/shared-types';
 import { IPC_CONSTANTS } from '@package/shared-constants';
 import { BRIDGE_NAME } from '@package/shared-constants';
 import { MENU_EVENT_LIST } from '@package/shared-constants';
+import { isMenuEvent } from './utils/menu-event-helper';
 
 const apiContract: MarkdownReaderAPI = {
   readFile: (path) => ipcRenderer.invoke(IPC_CONSTANTS.READ_FILE, path),
@@ -21,6 +22,9 @@ const apiContract: MarkdownReaderAPI = {
     ipcRenderer.on(IPC_CONSTANTS.FILE_CHANGED, (_event, path: string) => callback(path)),
   removeFileChangedListener: () => ipcRenderer.removeAllListeners(IPC_CONSTANTS.FILE_CHANGED),
   onMenuEvent: (event: string, callback: (payload?: unknown) => void) => {
+    if (!isMenuEvent(event)) {
+      throw new Error(`Unsupported menu event: ${event}`);
+    }
     const handler = (_event: IpcRendererEvent, payload?: unknown) => callback(payload);
     ipcRenderer.on(event, handler);
     return () => ipcRenderer.removeListener(event, handler);

--- a/apps/preload/src/utils/menu-event-helper.ts
+++ b/apps/preload/src/utils/menu-event-helper.ts
@@ -1,0 +1,7 @@
+import { MENU_EVENT_LIST } from '@package/shared-constants';
+
+export type MenuEventName = (typeof MENU_EVENT_LIST)[number];
+
+export function isMenuEvent(event: string): event is MenuEventName {
+  return MENU_EVENT_LIST.includes(event as MenuEventName);
+}

--- a/apps/renderer/index.html
+++ b/apps/renderer/index.html
@@ -3,6 +3,8 @@
   <head>
     <meta charset="UTF-8" />
     <title>Markdown Reader</title>
+    <link rel="icon" type="image/svg+xml" href="/icons/app-icon.svg" />
+    <meta name="description" content="A beautiful, offline-first Markdown reader" />
     <!-- https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP -->
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta

--- a/apps/renderer/public/icons/app-icon.svg
+++ b/apps/renderer/public/icons/app-icon.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" role="img" aria-label="Markdown Reader">
+  <rect width="64" height="64" rx="12" fill="#0969da"/>
+  <path fill="#fff" d="M13 18h38a4 4 0 0 1 4 4v20a4 4 0 0 1-4 4H13a4 4 0 0 1-4-4V22a4 4 0 0 1 4-4Zm7 21V27l6 7 6-7v12h-5v-5l-1 2h-1l-1-2v5h-4Zm20 0 8-8h-5v-4h-6v4h-5l8 8Z"/>
+</svg>

--- a/apps/renderer/src/App.tsx
+++ b/apps/renderer/src/App.tsx
@@ -54,7 +54,7 @@ export default function App() {
   useEffect(()=>{
     if(!window.api?.getAppVersion) return;
     void window.api.getAppVersion().then(setAppVersion).catch(()=>{});
-  })
+  },[])
   
   useEffect(()=>{
     if(folderTree){

--- a/apps/renderer/src/App.tsx
+++ b/apps/renderer/src/App.tsx
@@ -34,8 +34,9 @@ export default function App() {
   const {  error, isLoading, openFile, toc,recentFiles,loadFile } =useFile();
   const { state, dispatch } = useTabStore();
   const activeTab = state.tabs.find((tab) => tab.id === state.activeTabId) ?? null;
+  const activeToc=activeTab?.toc?? toc;
   const { theme, toggleTheme} = useTheme();
-  const {activeId,scrollToHeading}=useToc(toc);
+  const {activeId,scrollToHeading}=useToc(activeToc);
   const {increaseFontSize,decreaseFontSize,resetFontSize,fontSize}=useSettings();
   const {query,matchCount,currentMatch,isSearchOpen,openSearch,closeSearch,setQuery,goToNextMatch,goToPrevMatch,getHiglightedHtml} = useSearch(activeTab?.html ?? '');
   const [showToast, setShowToast] = useState(false);
@@ -146,7 +147,7 @@ useShortcuts({
             )}
             {!focusMode && (
               <Sidebar
-                tocItems={extractTOC(activeTab.html)}
+                tocItems={activeToc}
                 activeId={activeId}
                 onSelect={scrollToHeading}
                 isVisible={sidebarOpen}

--- a/apps/renderer/src/App.tsx
+++ b/apps/renderer/src/App.tsx
@@ -15,7 +15,6 @@ import { StatusBar } from './components/StatusBar';
 import { FileBrowser } from './components/FileBrowser';
 import { TabBar } from './components/TabBar';
 import { useTabStore } from './hooks/useTabStore';
-import { extractTOC } from './renderer/toc';
 import { Icons } from './utils/constants/icon-contants';
 import { useShortcuts } from './hooks/useShortcuts';
 import { useMenuEvents } from './hooks/useMenuEvents';
@@ -29,6 +28,7 @@ import { useFileActions } from './hooks/useFileActions';
 import { useOpenFilePath } from './hooks/useOpenFilePath';
 import { useFilePersistence } from './hooks/useFilePersistence';
 import { ReaderToolbar } from './components/ReaderToolbar';
+import { SettingsPanel } from './components/SettingsPanel';
 
 export default function App() {
   const {  error, isLoading, openFile, toc,recentFiles,loadFile } =useFile();
@@ -37,7 +37,7 @@ export default function App() {
   const activeToc=activeTab?.toc?? toc;
   const { theme, toggleTheme} = useTheme();
   const {activeId,scrollToHeading}=useToc(activeToc);
-  const {increaseFontSize,decreaseFontSize,resetFontSize,fontSize}=useSettings();
+  const {settings,increaseFontSize,decreaseFontSize,resetFontSize,fontSize,updateSettings}=useSettings();
   const {query,matchCount,currentMatch,isSearchOpen,openSearch,closeSearch,setQuery,goToNextMatch,goToPrevMatch,getHiglightedHtml} = useSearch(activeTab?.html ?? '');
   const [showToast, setShowToast] = useState(false);
   const contentRef=useRef<HTMLDivElement>(null);
@@ -48,6 +48,13 @@ export default function App() {
   const {isDraggingFile,handleDragEnter,handleDragOver,handleDragLeave,handleDrop}=useDragDrop(loadFileInTab);
   useOpenFilePath(loadFileInTab);
   const {scroll}=useFilePersistence({activeTab,loadFile,dispatch,contentRef,setShowToast});
+  const [settingsOpen, setSettingsOpen] = useState(false);
+  const [appVersion, setAppVersion] = useState('');
+
+  useEffect(()=>{
+    if(!window.api?.getAppVersion) return;
+    void window.api.getAppVersion().then(setAppVersion).catch(()=>{});
+  })
   
   useEffect(()=>{
     if(folderTree){
@@ -71,7 +78,8 @@ export default function App() {
   onCloseTab: closeActiveTab,
   onExportHtml:exportHtml,
   onExportPdf:exportPdf,
-  onExportDocx:exportDocx
+  onExportDocx:exportDocx,
+  onOpenSettings:()=>setSettingsOpen(true)
 });
 
 useShortcuts({
@@ -86,6 +94,7 @@ useShortcuts({
   onZoomReset: resetFontSize,
   onToggleSidebar: toggleSidebar,
   onToggleFileBrowser: toggleFileBrowser,
+  onOpenSettings:()=>setSettingsOpen(true)
 });
   
 
@@ -171,6 +180,7 @@ useShortcuts({
         {!focusMode && (
           <StatusBar filePath={activeTab?.filePath ?? ''} theme={theme} fontSize={fontSize} />
         )}
+        <SettingsPanel settings={settings} isOpen={settingsOpen} onClose={()=>setSettingsOpen(false)} onChange={(partial)=>void updateSettings(partial)} appVersion={appVersion}/>
       </div>
     </>
   )}

--- a/apps/renderer/src/App.tsx
+++ b/apps/renderer/src/App.tsx
@@ -35,7 +35,7 @@ export default function App() {
   const { state, dispatch } = useTabStore();
   const activeTab = state.tabs.find((tab) => tab.id === state.activeTabId) ?? null;
   const activeToc=activeTab?.toc?? toc;
-  const { theme, toggleTheme} = useTheme();
+  const { theme, toggleTheme,setTheme} = useTheme();
   const {activeId,scrollToHeading}=useToc(activeToc);
   const {settings,increaseFontSize,decreaseFontSize,resetFontSize,fontSize,updateSettings}=useSettings();
   const {query,matchCount,currentMatch,isSearchOpen,openSearch,closeSearch,setQuery,goToNextMatch,goToPrevMatch,getHiglightedHtml} = useSearch(activeTab?.html ?? '');
@@ -79,7 +79,8 @@ export default function App() {
   onExportHtml:exportHtml,
   onExportPdf:exportPdf,
   onExportDocx:exportDocx,
-  onOpenSettings:()=>setSettingsOpen(true)
+  onOpenSettings:()=>setSettingsOpen(true),
+  onSetTheme:setTheme
 });
 
 useShortcuts({

--- a/apps/renderer/src/components/SettingsPanel.tsx
+++ b/apps/renderer/src/components/SettingsPanel.tsx
@@ -1,0 +1,80 @@
+import { SettingsPanelProps } from '../types/component-types';
+import { Icons } from '../utils/constants/icon-contants';
+import { WIDTH_MAP } from '../types/component-types';
+
+/*Displays the settings features in UI*/
+export function SettingsPanel({
+  settings,
+  isOpen,
+  onClose,
+  onChange,
+  appVersion,
+}: SettingsPanelProps) {
+  if (!isOpen) return null;
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 p-4">
+      <section
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="settings-title"
+        className="w-full max-w-xl rounded-lg border border-border-theme bg-bg shadow-xl"
+      >
+        <header className="flex items-center justify-between border-b border-border-theme px-4 py-3">
+          <h2 id="settings-title" className="text-base font-semibold text-text-base">
+            Settings
+          </h2>
+          <button type="button" aria-label="Close settings" onClick={onClose} className="p-1">
+            <Icons.X size={18} />
+          </button>
+        </header>
+
+        <div className="space-y-5 p-4">
+          <fieldset>
+            <legend className="mb-2 text-sm font-medium text-text-base">Reading width</legend>
+            <div className="grid grid-cols-3 gap-2">
+              {(['narrow', 'default', 'wide'] as const).map((width) => (
+                <label
+                  key={width}
+                  className="flex cursor-pointer items-center gap-2 rounded border border-border-theme px-3 py-2 text-sm"
+                >
+                  <input
+                    type="radio"
+                    name="readingWidth"
+                    value={width}
+                    checked={settings.readingWidth === width}
+                    onChange={() => onChange({ readingWidth: width })}
+                  />
+                  <span className="capitalize">{width}</span>
+                  <span className="text-xs text-text-muted">{WIDTH_MAP[width]}</span>
+                </label>
+              ))}
+            </div>
+          </fieldset>
+
+          <label className="flex items-center gap-2 text-sm text-text-base">
+            <input
+              type="checkbox"
+              checked={settings.lineNumbers}
+              onChange={(event) => onChange({ lineNumbers: event.target.checked })}
+            />
+            Show code line numbers
+          </label>
+
+          <label className="block">
+            <span className="mb-2 block text-sm font-medium text-text-base">Custom CSS</span>
+            <textarea
+              value={settings.customCss}
+              onChange={(event) => onChange({ customCss: event.target.value })}
+              rows={8}
+              aria-label="Custom CSS"
+              className="w-full resize-y rounded border border-border-theme bg-surface p-3 font-mono text-sm text-text-base outline-none focus:ring-2 focus:ring-accent"
+              placeholder="Add custom reader CSS here "
+            />
+          </label>
+
+          {appVersion && <p className="text-xs text-text-muted">Version {appVersion}</p>}
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/apps/renderer/src/components/SettingsPanel.tsx
+++ b/apps/renderer/src/components/SettingsPanel.tsx
@@ -1,3 +1,4 @@
+import { useEffect,useRef } from 'react';
 import { SettingsPanelProps } from '../types/component-types';
 import { Icons } from '../utils/constants/icon-contants';
 import { WIDTH_MAP } from '../types/component-types';
@@ -10,10 +11,24 @@ export function SettingsPanel({
   onChange,
   appVersion,
 }: SettingsPanelProps) {
+  const dialogRef = useRef<HTMLElement>(null);
+
+  useEffect(() => {
+    if (!isOpen) return;
+    dialogRef.current?.focus();
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onClose();
+    };
+    document.addEventListener('keydown', onKeyDown);
+    return () => document.removeEventListener('keydown', onKeyDown);
+  }, [isOpen, onClose]);
   if (!isOpen) return null;
   return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 p-4">
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 p-4" onClick={onClose}>
       <section
+        ref={dialogRef}
+        tabIndex={-1}
+        onClick={(e)=>e.stopPropagation()}
         role="dialog"
         aria-modal="true"
         aria-labelledby="settings-title"

--- a/apps/renderer/src/components/Sidebar.tsx
+++ b/apps/renderer/src/components/Sidebar.tsx
@@ -1,3 +1,4 @@
+import { useEffect,useRef } from 'react';
 import { SidebarProps } from '../types/component-types';
 import { Icons } from '../utils/constants/icon-contants';
 import { getItemClasses } from '../utils/helpers/sidebar-helper';
@@ -6,12 +7,16 @@ import { useCollapsibleToc } from '../hooks/useCollapsibleToc';
 //sidebar component
 export function Sidebar({tocItems,activeId,onSelect,isVisible=true, onClose }: SidebarProps & { onClose: () => void }) {
   const { visibleItems, toggleItem, hasChildren, isCollapsed } = useCollapsibleToc(tocItems);
+  const activeItemRef = useRef<HTMLButtonElement | null>(null);
+  useEffect(() => {
+    activeItemRef.current?.scrollIntoView({ block: 'nearest' });
+  }, [activeId]);
   if(!isVisible||tocItems.length===0){
     return null;
   }
   return (
-    <nav className="w-64 border-r border-border-theme bg-surface overflow-y-auto py-6 shrink-0" aria-label="Table of contents">
-      <div className="flex items-center justify-between px-4 pb-3">
+    <nav className="w-64 border-r border-border-theme bg-surface overflow-y-auto py-5 shrink-0" aria-label="Table of contents">
+      <div className="flex items-center justify-between px-4 pb-3 border-b border-border-theme">
         <h2 className="text-sm font-semibold tracking-wide text-text-base">
             Contents
         </h2>
@@ -24,35 +29,39 @@ export function Sidebar({tocItems,activeId,onSelect,isVisible=true, onClose }: S
           <Icons.X size={18} />
         </button>
       </div>
-      <ul>
+      <ul className='py-2'>
         {visibleItems.map((item) => {
           const expandable = hasChildren(item.id);
           const collapsed = isCollapsed(item.id);
 
           return (
             <li key={item.id}>
-              <div className="flex items-center w-full">
-                  {expandable && (
-                    <button
+              <div className="flex w-full items-stretch">
+                <div className="flex w-7 shrink-0 justify-center">
+                  {expandable ? (
+                  <button
                     type="button"
                     aria-expanded={!collapsed}
                     aria-label={`${collapsed ? 'Expand' : 'Collapse'} ${item.text}`}
-                      onClick={(event) => {
-                        event.stopPropagation();
-                        toggleItem(item.id);
-                      }}
-                      className="inline-flex p-1 text-text-muted hover:text-text-base transition-colors shrink-0"
-                    >
-                      {collapsed ? (
-                        <Icons.ChevronRight size={20} />
-                      ) : (
-                        <Icons.ChevronDown size={20} />
-                      )}
-                    </button>
+                    onClick={(event) => {
+                      event.stopPropagation();
+                      toggleItem(item.id);
+                    }}
+                    className="inline-flex h-8 w-7 items-center justify-center text-text-muted hover:text-text-base transition-colors"
+                  >
+                    {collapsed ? (
+                      <Icons.ChevronRight size={16} />
+                    ) : (
+                      <Icons.ChevronDown size={16} />
+                    )}
+                  </button>
+                  ) : (
+                    <span aria-hidden="true" className="block h-8 w-7" />
                   )}
-                <button type="button" onClick={()=>onSelect(item.id)} className={`${getItemClasses(item, activeId)} text-left w-full`} aria-current={item.id===activeId?"location":undefined}>
+                </div>
+                <button ref={item.id===activeId ? activeItemRef : undefined} type="button" onClick={()=>onSelect(item.id)} className={`${getItemClasses(item, activeId)} min-w-0 flex-1`} aria-current={item.id===activeId?"location":undefined}>
                   <span>{item.text}</span>
-              </button>
+                </button>
               </div>
             </li>
           )})}

--- a/apps/renderer/src/config/marked.ts
+++ b/apps/renderer/src/config/marked.ts
@@ -28,7 +28,7 @@ export function getMarkdown(): Marked {
           return escapeHtml(code);
         }
         const highlighter = await shikiHighlighter();
-        const theme = THEMES.GITHUB_DARK;
+        const theme = THEMES[1];
         try {
           return highlighter.codeToHtml(code, {
             lang: language,

--- a/apps/renderer/src/context/ThemeProvider.tsx
+++ b/apps/renderer/src/context/ThemeProvider.tsx
@@ -1,6 +1,7 @@
 import React,{createContext,useState,useEffect,useCallback} from "react";
 import { ThemeContextType,Theme } from "../types/component-types";
 import { APPTHEMES } from "../utils/constants/theme-constants";
+import { getSystemTheme } from "../utils/helpers/theme-helper";
 
 export const ThemeContext=createContext<ThemeContextType|undefined>(undefined);
 
@@ -14,19 +15,30 @@ export function ThemeProvider({ children }: { children: React.ReactNode }) {
     }
   },[])
 
+  useEffect(()=>{
+    const media=window.matchMedia('(prefers-color-scheme:dark)');
+    const onChange=()=>{
+      if(!localStorage.getItem('app-theme')){
+        setThemeState(getSystemTheme());
+      }
+    };
+    media.addEventListener('change',onChange);
+    return ()=>media.removeEventListener('change',onChange);
+  },[]);
+
   useEffect(() => {
     document.documentElement.dataset.theme = theme;
-    localStorage.setItem('app-theme', theme);
   }, [theme]);
 
   const setTheme = useCallback((t: Theme) => {
+    localStorage.setItem('app-theme',t);
     setThemeState(t);
   }, []);
 
   const toggleTheme = () => {
     const currentIdx=APPTHEMES.indexOf(theme);
     const nextTheme=APPTHEMES[(currentIdx + 1) % APPTHEMES.length] as Theme;
-    setThemeState(nextTheme);
+    setTheme(nextTheme);
   };
 
   return (

--- a/apps/renderer/src/hooks/useCollapsibleToc.ts
+++ b/apps/renderer/src/hooks/useCollapsibleToc.ts
@@ -37,7 +37,8 @@ export function useCollapsibleToc(tocItems: TOCType[]) {
         }
       }
       visible.push(item);
-      if (collapsedItems[item.id]) {
+      const collapsed = collapsedItems[item.id] ?? (item.level >= 2 && childMap[item.id]);
+      if (collapsed) {
         activeHiddenLevel = item.level;
       }
     }
@@ -51,8 +52,13 @@ export function useCollapsibleToc(tocItems: TOCType[]) {
     [childMap]
   );
 
-  const isCollapsed = useCallback((id: string) => Boolean(collapsedItems[id]), [collapsedItems]);
-
+  const isCollapsed = useCallback(
+    (id: string) => {
+      const item = tocItems.find((tocItem) => tocItem.id === id);
+      return Boolean(collapsedItems[id] ?? (item && item.level >= 2 && childMap[id]));
+    },
+    [childMap, collapsedItems, tocItems]
+  );
   return {
     visibleItems,
     toggleItem,

--- a/apps/renderer/src/hooks/useCollapsibleToc.ts
+++ b/apps/renderer/src/hooks/useCollapsibleToc.ts
@@ -4,13 +4,6 @@ import { TOCType } from '../types/component-types';
 export function useCollapsibleToc(tocItems: TOCType[]) {
   const [collapsedItems, setCollapsedItems] = useState<Record<string, boolean>>({});
 
-  const toggleItem = useCallback((id: string) => {
-    setCollapsedItems((prev) => ({
-      ...prev,
-      [id]: !prev[id],
-    }));
-  }, []);
-
   const childMap = useMemo(() => {
     const map: Record<string, boolean> = {};
     for (let i = 0; i < tocItems.length; i++) {
@@ -21,6 +14,20 @@ export function useCollapsibleToc(tocItems: TOCType[]) {
     }
     return map;
   }, [tocItems]);
+
+  const toggleItem = useCallback(
+    (id: string) => {
+      setCollapsedItems((prev) => {
+        const item = tocItems.find((t) => t?.id === id);
+        const isCurrentlyCollapsed = prev[id] ?? Boolean(item && item.level >= 2 && childMap[id]);
+        return {
+          ...prev,
+          [id]: !isCurrentlyCollapsed,
+        };
+      });
+    },
+    [tocItems, childMap]
+  );
 
   const visibleItems = useMemo(() => {
     const visible: TOCType[] = [];

--- a/apps/renderer/src/hooks/useFile.ts
+++ b/apps/renderer/src/hooks/useFile.ts
@@ -29,7 +29,7 @@ export function useFile() {
       const renderHtml = await renderMarkdown(rawMarkdown);
       const safeHtml = DOMpurify.sanitize(renderHtml);
       setHtml(safeHtml);
-      const nextToc = extractTOC(safeHtml);
+      const nextToc = extractTOC(rawMarkdown);
       setToc(nextToc);
       await window.api.addRecentFile(path);
       const updated = await window.api.getRecentFiles();

--- a/apps/renderer/src/hooks/useFileActions.ts
+++ b/apps/renderer/src/hooks/useFileActions.ts
@@ -21,6 +21,7 @@ export function useFileActions({ loadFile, dispatch }: FileActionProps) {
         payload: {
           filePath: result.filePath,
           html: result.html,
+          ...(result.toc ? { toc: result.toc } : {}),
         },
       });
     },

--- a/apps/renderer/src/hooks/useFilePersistence.ts
+++ b/apps/renderer/src/hooks/useFilePersistence.ts
@@ -27,6 +27,7 @@ export function useFilePersistence({
         payload: {
           tabId: activeTab.id,
           html: result.html,
+          ...(result.toc ? { toc: result.toc } : {}),
         },
       });
       requestAnimationFrame(() => {

--- a/apps/renderer/src/hooks/useMenuEvents.ts
+++ b/apps/renderer/src/hooks/useMenuEvents.ts
@@ -1,7 +1,7 @@
 import { useEffect } from 'react';
 import { MENU_EVENTS } from '@package/shared-constants';
 import { UseMenuEventsProps } from '../types/hook-types';
-
+import { Theme } from '../types/component-types';
 export function useMenuEvents({
   onOpenFile,
   onOpenFolder,
@@ -20,6 +20,7 @@ export function useMenuEvents({
   onExportPdf,
   onExportDocx,
   onOpenSettings,
+  onSetTheme,
 }: UseMenuEventsProps) {
   useEffect(() => {
     if (!window.api?.onMenuEvent) return;
@@ -41,6 +42,11 @@ export function useMenuEvents({
     window.api.onMenuEvent(MENU_EVENTS.EXPORT_PDF, onExportPdf);
     window.api.onMenuEvent(MENU_EVENTS.EXPORT_DOCX, onExportDocx);
     window.api.onMenuEvent(MENU_EVENTS.OPEN_SETTINGS, onOpenSettings);
+    window.api.onMenuEvent(MENU_EVENTS.SET_THEME, (theme) => {
+      if (typeof theme === 'string') {
+        onSetTheme(theme as Theme);
+      }
+    });
 
     return () => {
       window.api.removeMenuListeners?.();
@@ -63,5 +69,6 @@ export function useMenuEvents({
     onExportPdf,
     onExportDocx,
     onOpenSettings,
+    onSetTheme,
   ]);
 }

--- a/apps/renderer/src/hooks/useMenuEvents.ts
+++ b/apps/renderer/src/hooks/useMenuEvents.ts
@@ -19,6 +19,7 @@ export function useMenuEvents({
   onExportHtml,
   onExportPdf,
   onExportDocx,
+  onOpenSettings,
 }: UseMenuEventsProps) {
   useEffect(() => {
     if (!window.api?.onMenuEvent) return;
@@ -39,6 +40,7 @@ export function useMenuEvents({
     window.api.onMenuEvent(MENU_EVENTS.EXPORT_HTML, onExportHtml);
     window.api.onMenuEvent(MENU_EVENTS.EXPORT_PDF, onExportPdf);
     window.api.onMenuEvent(MENU_EVENTS.EXPORT_DOCX, onExportDocx);
+    window.api.onMenuEvent(MENU_EVENTS.OPEN_SETTINGS, onOpenSettings);
 
     return () => {
       window.api.removeMenuListeners?.();
@@ -58,5 +60,8 @@ export function useMenuEvents({
     onPreviousTab,
     onCloseTab,
     onExportHtml,
+    onExportPdf,
+    onExportDocx,
+    onOpenSettings,
   ]);
 }

--- a/apps/renderer/src/hooks/useSettings.ts
+++ b/apps/renderer/src/hooks/useSettings.ts
@@ -1,12 +1,28 @@
 import { useCallback, useEffect, useState } from 'react';
-import { FONT_SISE, ReadingWidth, WIDTH_MAP } from '../types/component-types';
+import { FONT_SIZE, WIDTH_MAP } from '../types/component-types';
+import { AppSettings, DEFAULT_SETTINGS, ReadingWidth } from '@package/shared-types';
 
 export function useSettings() {
-  const [fontSize, setFontSize] = useState(FONT_SISE.DEFAULT);
+  const [fontSize, setFontSize] = useState(FONT_SIZE.DEFAULT);
   const [readingWidth, setReadingWidth] = useState<ReadingWidth>('default');
+  const [settings, setSettings] = useState<AppSettings>(DEFAULT_SETTINGS);
+
+  useEffect(() => {
+    if (!window.api) return;
+
+    void window.api
+      .getSettings()
+      .then((savedSettings) => {
+        setSettings(savedSettings);
+        setFontSize(savedSettings.fontSize);
+        setReadingWidth(savedSettings.readingWidth);
+      })
+      .catch(() => {});
+  }, []);
 
   useEffect(() => {
     document.documentElement.style.setProperty('--font-size-content', `${fontSize}px`);
+    setSettings((current) => ({ ...current, fontSize }));
   }, [fontSize]);
 
   useEffect(() => {
@@ -14,25 +30,57 @@ export function useSettings() {
       '--reading-width',
       WIDTH_MAP[readingWidth] ?? '768px'
     );
+    setSettings((current) => ({ ...current, readingWidth }));
   }, [readingWidth]);
 
+  useEffect(() => {
+    const styleId = 'markdown-reader-custon-css';
+    let style = document.getElementById(styleId) as HTMLStyleElement | null;
+    if (!style) {
+      style = document.createElement('style');
+      style.id = styleId;
+      document.head.appendChild(style);
+    }
+    style.textContent = settings.customCss;
+  }, [settings.customCss]);
+
   const increaseFontSize = useCallback(() => {
-    setFontSize((prev) => Math.min(FONT_SISE.MAX, prev + FONT_SISE.INCREMENT));
+    setFontSize((prev) => Math.min(FONT_SIZE.MAX, prev + FONT_SIZE.INCREMENT));
   }, []);
 
   const decreaseFontSize = useCallback(() => {
-    setFontSize((prev) => Math.max(FONT_SISE.MIN, prev - FONT_SISE.INCREMENT));
+    setFontSize((prev) => Math.max(FONT_SIZE.MIN, prev - FONT_SIZE.INCREMENT));
   }, []);
 
   const resetFontSize = useCallback(() => {
-    setFontSize(FONT_SISE.DEFAULT);
+    setFontSize(FONT_SIZE.DEFAULT);
   }, []);
+
+  const updateSettings = useCallback(
+    async (partial: Partial<AppSettings>) => {
+      if (!window.api) {
+        const next = { ...settings, ...partial };
+        setSettings(next);
+        setFontSize(next.fontSize);
+        setReadingWidth(next.readingWidth);
+        return;
+      }
+
+      const next = await window.api.saveSettings(partial);
+      setSettings(next);
+      setFontSize(next.fontSize);
+      setReadingWidth(next.readingWidth);
+    },
+    [settings]
+  );
   return {
+    settings,
     fontSize,
     readingWidth,
     increaseFontSize,
     decreaseFontSize,
     resetFontSize,
     setReadingWidth,
+    updateSettings,
   };
 }

--- a/apps/renderer/src/renderer/toc.ts
+++ b/apps/renderer/src/renderer/toc.ts
@@ -1,27 +1,26 @@
+import { lexer } from 'marked';
 import { TOCType } from '../types/component-types';
-import { getHeadingId, stripHtml } from '../utils/helpers/heading-helper';
-import { HTML_PATTERNS } from '../utils/constants/regex-constants';
+import { getHeadingId, isHeadingToken, headingText } from '../utils/helpers/heading-helper';
 
 // extracts table of content from HTML string
 export function extractTOC(html: string): TOCType[] {
   const items: TOCType[] = [];
   const idCount = new Map<string, number>();
-  let match: RegExpExecArray | null;
-  while ((match = HTML_PATTERNS.HEADINGS.exec(html)) !== null) {
-    const level = parseInt(match[1] ?? '1', 10) as 1 | 2 | 3;
-    const attrs = match[2] ?? '';
-    const rawtext = match[3] ?? '';
+  const tokens = lexer(html);
 
-    const strip = stripHtml(rawtext).trim();
-    if (!strip) continue;
-    const matchId = HTML_PATTERNS.ID_ATTRIBUTE.exec(attrs);
-    const firstid = matchId?.[1] ?? getHeadingId(strip);
+  for (const token of tokens) {
+    if (!isHeadingToken(token)) continue;
+
+    const level = Math.min(token.depth, 3) as 1 | 2 | 3;
+    const text = headingText(token);
+    if (!text) continue;
+    const firstid = getHeadingId(text);
 
     const count = idCount.get(firstid) ?? 0;
     idCount.set(firstid, count + 1);
     const id = count === 0 ? firstid : `${firstid}-${count}`;
 
-    items.push({ id, text: strip, level });
+    items.push({ id, text, level });
   }
   return items;
 }

--- a/apps/renderer/src/store/tabStore.ts
+++ b/apps/renderer/src/store/tabStore.ts
@@ -8,7 +8,7 @@ export function tabReducer(state: TabState, action: TabAction): TabState {
       if (existingTab) {
         return { ...state, activeTabId: existingTab.id };
       }
-      const newTab = createTab(action.payload.filePath, action.payload.html);
+      const newTab = createTab(action.payload.filePath, action.payload.html, action.payload.toc);
       return {
         tabs: [...state.tabs, newTab],
         activeTabId: newTab.id,

--- a/apps/renderer/src/types/component-types.ts
+++ b/apps/renderer/src/types/component-types.ts
@@ -1,7 +1,17 @@
 import React from 'react';
 import { APPTHEMES } from '../utils/constants/theme-constants';
 import { RecentFile } from '@package/shared-types/dist/src/recentfile-type';
-import { FileType } from '@package/shared-types';
+import { AppSettings, FileType } from '@package/shared-types';
+import { ReadingWidth } from '@package/shared-types';
+import {
+  DEFAULT_FONT_SIZE,
+  DEFAULT_WIDTH,
+  FONT_SIZE_INCREMENT,
+  MAX_FONT_SIZE,
+  MIN_FONT_SIZE,
+  NARROW_WIDTH,
+  WIDE_WIDTH,
+} from '@package/shared-constants';
 export interface ErrorProps {
   message: string;
   onRetry: () => void;
@@ -66,20 +76,17 @@ export interface SearchBarProps {
   onClose: () => void;
 }
 
-export type ReadingWidth = 'narrow' | 'default' | 'wide' | 'full';
-
-export const FONT_SISE = {
-  DEFAULT: 16,
-  MIN: 12,
-  MAX: 24,
-  INCREMENT: 2,
+export const FONT_SIZE = {
+  DEFAULT: DEFAULT_FONT_SIZE,
+  MIN: MIN_FONT_SIZE,
+  MAX: MAX_FONT_SIZE,
+  INCREMENT: FONT_SIZE_INCREMENT,
 };
 
 export const WIDTH_MAP: Record<ReadingWidth, string> = {
-  narrow: '640px',
-  default: '768px',
-  wide: '1024px',
-  full: '100%',
+  narrow: `${NARROW_WIDTH}px`,
+  default: `${DEFAULT_WIDTH}px`,
+  wide: `${WIDE_WIDTH}px`,
 };
 export interface StatusBarProps {
   filePath: string;
@@ -157,4 +164,12 @@ export interface ReaderToolbarProps {
   onZoomOut: () => void;
   onZoomReset: () => void;
   onToggleTheme: () => void;
+}
+
+export interface SettingsPanelProps {
+  settings: AppSettings;
+  isOpen: boolean;
+  onClose: () => void;
+  onChange: (settings: Partial<AppSettings>) => void;
+  appVersion?: string;
 }

--- a/apps/renderer/src/types/component-types.ts
+++ b/apps/renderer/src/types/component-types.ts
@@ -99,6 +99,7 @@ export interface Tab {
   filePath: string;
   fileName: string;
   html: string;
+  toc?: TOCType[];
   scrollTop: number;
   fontSize: number;
 }
@@ -109,7 +110,7 @@ export interface TabState {
 }
 
 export type TabAction =
-  | { type: 'OPEN_TAB'; payload: { filePath: string; html?: string } }
+  | { type: 'OPEN_TAB'; payload: { filePath: string; html?: string; toc?: TOCType[] } }
   | { type: 'CLOSE_TAB'; payload: { tabId: string } }
   | { type: 'SWITCH_TAB'; payload: { tabId: string } }
   | {
@@ -117,6 +118,7 @@ export type TabAction =
       payload: {
         tabId: string;
         html?: string;
+        toc?: TOCType[];
         scrollTop?: number;
         fontSize?: number;
       };

--- a/apps/renderer/src/types/component-types.ts
+++ b/apps/renderer/src/types/component-types.ts
@@ -1,6 +1,6 @@
 import React from 'react';
 import { APPTHEMES } from '../utils/constants/theme-constants';
-import { RecentFile } from '@package/shared-types/dist/src/recentfile-type';
+import { RecentFile } from '@package/shared-types';
 import { AppSettings, FileType } from '@package/shared-types';
 import { ReadingWidth } from '@package/shared-types';
 import {

--- a/apps/renderer/src/types/hook-types.ts
+++ b/apps/renderer/src/types/hook-types.ts
@@ -1,4 +1,5 @@
 import React from 'react';
+import { Theme } from './component-types';
 import { TOCType } from './component-types';
 import { Tab, TabAction } from './component-types';
 
@@ -42,6 +43,7 @@ export interface UseMenuEventsProps {
   onExportPdf: () => void;
   onExportDocx: () => void;
   onOpenSettings: () => void;
+  onSetTheme: (theme: Theme) => void;
 }
 
 export interface UseShortcutsProps {

--- a/apps/renderer/src/types/hook-types.ts
+++ b/apps/renderer/src/types/hook-types.ts
@@ -41,6 +41,7 @@ export interface UseMenuEventsProps {
   onExportHtml: () => void;
   onExportPdf: () => void;
   onExportDocx: () => void;
+  onOpenSettings: () => void;
 }
 
 export interface UseShortcutsProps {
@@ -55,6 +56,7 @@ export interface UseShortcutsProps {
   onZoomReset: () => void;
   onToggleSidebar: () => void;
   onToggleFileBrowser: () => void;
+  onOpenSettings: () => void;
 }
 
 export interface UseSearchProps {

--- a/apps/renderer/src/utils/helpers/heading-helper.ts
+++ b/apps/renderer/src/utils/helpers/heading-helper.ts
@@ -1,5 +1,7 @@
 import { HeadingProps } from '../../types/component-types';
 import { SLUG_PATTERNS, HTML_PATTERNS } from '../constants/regex-constants';
+import { parseInline, type Tokens } from 'marked';
+
 // converts heading text into a ID
 export function getHeadingId(text: string): string {
   let id = text.toLowerCase();
@@ -22,6 +24,15 @@ export function heading({ text, depth }: HeadingProps) {
 export function stripHtml(html: string): string {
   const strip = html.replace(HTML_PATTERNS.ANY_TAG, '');
   return strip;
+}
+
+export function headingText(token: Tokens.Heading): string {
+  const inlineHtml = parseInline(token.text) as string;
+  return stripHtml(inlineHtml).trim();
+}
+
+export function isHeadingToken(token: unknown): token is Tokens.Heading {
+  return !!token && typeof token === 'object' && (token as { type?: string }).type === 'heading';
 }
 
 export function escapeHtml(value: string): string {

--- a/apps/renderer/src/utils/helpers/heading-helper.ts
+++ b/apps/renderer/src/utils/helpers/heading-helper.ts
@@ -15,7 +15,7 @@ export function getHeadingId(text: string): string {
 // assigns id to the headings
 export function heading({ text, depth }: HeadingProps) {
   const plainText = stripHtml(text);
-  const id = getHeadingId(text);
+  const id = getHeadingId(plainText);
   const safeText = escapeHtml(plainText);
   return `<h${depth} id="${id}">${safeText}</h${depth}>\n`;
 }

--- a/apps/renderer/src/utils/helpers/sidebar-helper.ts
+++ b/apps/renderer/src/utils/helpers/sidebar-helper.ts
@@ -2,20 +2,19 @@ import { TOCType } from '../../types/component-types';
 
 // sets item level wise
 export function getItemClasses(item: TOCType, activeId: string): string {
-  let baseStyle = 'block w-full text-left px-4 py-1 text-sm transition';
+  let baseStyle =
+    'toc-item flex h-8 items-center truncate pr-3 text-left text-sm transition-colors';
   if (item.level === 1) {
-    baseStyle += ' pl-4 font-semibold';
+    baseStyle += ' pl-1 font-semibold';
   }
   if (item.level === 2) {
-    baseStyle += ' pl-8';
+    baseStyle += ' pl-4';
   }
   if (item.level === 3) {
-    baseStyle += ' pl-12 text-xs';
+    baseStyle += ' pl-7 text-xs';
   }
   if (item.id === activeId) {
-    baseStyle += ' toc-item';
-  } else {
-    baseStyle += ' toc-item';
+    baseStyle += ' font-medium';
   }
   return baseStyle;
 }

--- a/apps/renderer/src/utils/helpers/tab-helper.tsx
+++ b/apps/renderer/src/utils/helpers/tab-helper.tsx
@@ -1,12 +1,13 @@
  import { Tab } from "../../types/component-types";
 import { FILE_PATH } from "../constants/regex-constants";
 
-export function createTab(filePath: string, html = ''): Tab {
+export function createTab(filePath: string, html = '',toc: Tab['toc']=[]): Tab {
   return {
     id: crypto.randomUUID(),
     filePath,
     fileName: filePath.split(FILE_PATH).pop() ?? 'Untitled',
     html,
+    toc,
     scrollTop: 0,
     fontSize: 16,
   };

--- a/apps/renderer/src/utils/helpers/theme-helper.ts
+++ b/apps/renderer/src/utils/helpers/theme-helper.ts
@@ -1,0 +1,6 @@
+import { Theme } from '../../types/component-types';
+
+/*checks user's system color scheme preference. */
+export function getSystemTheme(): Theme {
+  return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'github-dark' : 'github-light';
+}

--- a/apps/renderer/tests/hooks/useCollapsibleToc.test.ts
+++ b/apps/renderer/tests/hooks/useCollapsibleToc.test.ts
@@ -20,15 +20,19 @@ describe('Table of Contents Hook Tests', () => {
 
   test('should hide nested sub items when their parent is collapsed', () => {
     const { result } = renderHook(() => useCollapsibleToc(sampleDocumentItems));
+    expect(result.current.visibleItems.length).toBe(3);
+    act(() => {
+      result.current.toggleItem('section-1.1');
+    });
     expect(result.current.visibleItems.length).toBe(4);
+    const containsSubSection = result.current.visibleItems.some(
+      (item) => item.id === 'subsection-1.1.1'
+    );
+    expect(containsSubSection).toBe(true);
     act(() => {
       result.current.toggleItem('section-1.1');
     });
     expect(result.current.visibleItems.length).toBe(3);
-    const containsSubSection = result.current.visibleItems.some(
-      (item) => item.id === 'subsection-1.1.1'
-    );
-    expect(containsSubSection).toBe(false);
   });
 
   test('should handle completely empty lists without crashing the app', () => {

--- a/apps/renderer/tests/renderer/toc.test.ts
+++ b/apps/renderer/tests/renderer/toc.test.ts
@@ -4,47 +4,63 @@ import { extractTOC } from '../../src/renderer/toc';
 describe('extract table of contents', () => {
   //test 1: checks empty array return from no heading
   it('returns empty array for HTML with no headings', () => {
-    const html = '<p>My name is Ashminita</p>';
-    const toc = extractTOC(html);
+    const markdown = 'My name is Ashminita';
+    const toc = extractTOC(markdown);
     expect(toc).toEqual([]);
   });
 
   // test 2:- checks single heading extraction
   it('extracts a single H1 headings', () => {
-    const html = '<h1 id="intro">Introduction</h1><p>text</p>';
-    const toc = extractTOC(html);
+    const markdown = '# Introduction\n\ntext';
+    const toc = extractTOC(markdown);
     expect(toc).toHaveLength(1);
-    expect(toc[0]).toEqual({ id: 'intro', text: 'Introduction', level: 1 });
+    expect(toc[0]).toEqual({ id: 'introduction', text: 'Introduction', level: 1 });
   });
 
   //test 3:-headings without id generate a slug from the text
   it('generates a id when heading has no id attribute', () => {
-    const html = '<h2>Getting Started</h2>';
+    const html = '## Getting Started';
     const toc = extractTOC(html);
     expect(toc[0]?.id).toBe('getting-started');
   });
 
   //test 4:- checks duplicate id
   it('generates unique ids for duplicate headings', () => {
-    const html = `<h2>Duplicate</h2>
-  <h2>Duplicate</h2>`;
-    const toc = extractTOC(html);
+    const markdown = `## Duplicate
+  ## Duplicate`;
+    const toc = extractTOC(markdown);
     expect(toc[0].id).toBe('duplicate');
     expect(toc[1].id).toBe('duplicate-1');
   });
 
   //test 5:-checks inline formating
   it('handles headings with inline HTML formating', () => {
-    const html = `<h2><em>Hello</em> World</h2>`;
-    const toc = extractTOC(html);
+    const markdown = `## <em>Hello</em> World`;
+    const toc = extractTOC(markdown);
     expect(toc[0].text).toBe('Hello World');
     expect(toc[0].id).toBe('hello-world');
   });
 
   //test 6:- checks code spans
   it('handle headings with code spans', () => {
-    const html = `<h2>Install <code>npm</code></h2>`;
-    const toc = extractTOC(html);
+    const markdown = '## Install `npm`';
+    const toc = extractTOC(markdown);
     expect(toc[0].text).toBe('Install npm');
+  });
+
+  it('does not extract headings from fenced code blocks', () => {
+    const markdown = `# Real Heading
+
+\`\`\`python
+# Not a heading
+## Also not a heading
+\`\`\``;
+    const toc = extractTOC(markdown);
+    expect(toc).toEqual([{ id: 'real-heading', text: 'Real Heading', level: 1 }]);
+  });
+
+  it('handles headings with links', () => {
+    const toc = extractTOC('## Read [the docs](https://example.com)');
+    expect(toc[0]).toEqual({ id: 'read-the-docs', text: 'Read the docs', level: 2 });
   });
 });

--- a/assets/unsigned-install-notice.txt
+++ b/assets/unsigned-install-notice.txt
@@ -1,0 +1,23 @@
+Markdown Reader unsigned build notice
+
+This early build is not code signed because the project does not currently have
+a macOS Developer ID certificate or Windows code-signing certificate.
+
+What this means:
+- macOS may show a Gatekeeper warning.
+- Windows may show a SmartScreen warning.
+- Some Linux desktop environments may show an untrusted-package warning.
+
+The app is intended to be safe when downloaded from the official project
+release page. For your safety, do not install copies from unknown sources.
+If checksums are published with the release, verify the downloaded installer
+before running it.
+
+How to continue:
+- macOS: open System Settings > Privacy & Security and choose Open Anyway for
+  Markdown Reader, or right-click the app and choose Open.
+- Windows: choose More info > Run anyway in the SmartScreen dialog.
+- Linux: install the .deb with your package manager, or mark the AppImage as
+  executable before launching it.
+
+Code signing will be added in a future release.

--- a/electron-builder.ts
+++ b/electron-builder.ts
@@ -22,6 +22,10 @@ const config: Configuration = {
       from: 'assets',
       to: 'assets',
     },
+    {
+      from: 'assets/unsigned-install-notice.txt',
+      to: 'UNSIGNED_INSTALL_NOTICE.txt',
+    },
   ],
   asar: true,
   fileAssociations: [
@@ -59,6 +63,7 @@ const config: Configuration = {
     createDesktopShortcut: true,
     createStartMenuShortcut: true,
     shortcutName: 'Markdown Reader',
+    license: 'assets/unsigned-install-notice.txt',
   },
   linux: {
     icon: 'assets/icons',

--- a/electron.vite.config.ts
+++ b/electron.vite.config.ts
@@ -11,9 +11,6 @@ export default defineConfig({
       lib: {
         entry: resolve(__dirname, 'apps/main-processor/src/index.ts'),
       },
-      rollupOptions: {
-        external: ['html-to-docx', 'core-util-is'],
-      },
     },
   },
   preload: {

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   "packageManager": "pnpm@10.33.0",
   "devDependencies": {
     "@changesets/cli": "^2.31.0",
-    "@commitlint/cli": "^20.5.0",
+    "@commitlint/cli": "^20.5.3",
     "@commitlint/config-conventional": "^20.5.0",
     "@eslint/js": "^10.0.1",
     "@tailwindcss/typography": "^0.5.19",
@@ -65,5 +65,12 @@
   "dependencies": {
     "react": "^19.2.5",
     "react-dom": "^19.2.5"
+  },
+  "pnpm": {
+    "overrides": {
+      "serialize-javascript": ">=7.0.3",
+      "fast-uri": ">=3.1.2",
+      "tmp": ">=0.2.6"
+    }
   }
 }

--- a/packages/shared-constants/src/index.ts
+++ b/packages/shared-constants/src/index.ts
@@ -1,6 +1,15 @@
 export { MARKDOWN_FILE_PATTERN } from './path-constants.js';
 export { SHORTCUTS } from './keyboard-constants.js';
 export { MENU_LABELS, MENU_EVENTS, MENU_EVENT_LIST } from './menu-constants.js';
-export { THEMES } from './theme-constants.js';
 export { BRIDGE_NAME } from './bridge-constants.js';
 export { IPC_CONSTANTS } from './ipc-constants.js';
+export {
+  DEFAULT_FONT_SIZE,
+  DEFAULT_WIDTH,
+  FONT_SIZE_INCREMENT,
+  MAX_FONT_SIZE,
+  MIN_FONT_SIZE,
+  NARROW_WIDTH,
+  THEMES,
+  WIDE_WIDTH,
+} from './theme-constants.js';

--- a/packages/shared-constants/src/menu-constants.ts
+++ b/packages/shared-constants/src/menu-constants.ts
@@ -20,6 +20,7 @@ export const MENU_LABELS = {
   PREVIOUS_TAB: 'Previous Tab',
   SEARCH_DOCUMENT: 'Search In Document',
   SEARCH_FOLDER: 'Search in Folder',
+  SETTINGS: 'Settings',
 } as const;
 
 export const MENU_EVENTS = {
@@ -40,6 +41,7 @@ export const MENU_EVENTS = {
   EXPORT_HTML: 'menu:export-html',
   EXPORT_PDF: 'menu:export-pdf',
   EXPORT_DOCX: 'menu:export-docx',
+  OPEN_SETTINGS: 'menu:open:settings',
 } as const;
 
 export const MENU_EVENT_LIST = Object.values(MENU_EVENTS);

--- a/packages/shared-constants/src/menu-constants.ts
+++ b/packages/shared-constants/src/menu-constants.ts
@@ -21,6 +21,7 @@ export const MENU_LABELS = {
   SEARCH_DOCUMENT: 'Search In Document',
   SEARCH_FOLDER: 'Search in Folder',
   SETTINGS: 'Settings',
+  THEME: 'Theme',
 } as const;
 
 export const MENU_EVENTS = {
@@ -42,6 +43,7 @@ export const MENU_EVENTS = {
   EXPORT_PDF: 'menu:export-pdf',
   EXPORT_DOCX: 'menu:export-docx',
   OPEN_SETTINGS: 'menu:open:settings',
+  SET_THEME: 'menu:set-theme',
 } as const;
 
 export const MENU_EVENT_LIST = Object.values(MENU_EVENTS);

--- a/packages/shared-constants/src/theme-constants.ts
+++ b/packages/shared-constants/src/theme-constants.ts
@@ -8,3 +8,12 @@ export const THEMES = [
 ] as const;
 
 export type Theme = (typeof THEMES)[number];
+
+export const MIN_FONT_SIZE = 12;
+export const MAX_FONT_SIZE = 24;
+export const DEFAULT_FONT_SIZE = 16;
+export const FONT_SIZE_INCREMENT = 2;
+
+export const NARROW_WIDTH = 640;
+export const DEFAULT_WIDTH = 768;
+export const WIDE_WIDTH = 1024;

--- a/packages/shared-constants/src/theme-constants.ts
+++ b/packages/shared-constants/src/theme-constants.ts
@@ -1,4 +1,10 @@
-export const THEMES = {
-  GITHUB_LIGHT: 'github-light',
-  GITHUB_DARK: 'github-dark',
-} as const;
+export const THEMES = [
+  'github-light',
+  'github-dark',
+  'notion',
+  'nord',
+  'minimal',
+  'dracula',
+] as const;
+
+export type Theme = (typeof THEMES)[number];

--- a/packages/shared-types/package.json
+++ b/packages/shared-types/package.json
@@ -8,6 +8,7 @@
     "build": "pnpm exec tsc",
     "lint": "eslint ."
   },
+  "type": "module",
   "keywords": [],
   "author": "Mindfire-digital",
   "license": "ISC",

--- a/packages/shared-types/src/index.ts
+++ b/packages/shared-types/src/index.ts
@@ -1,5 +1,7 @@
-export { DEFAULT_SETTINGS } from './markdown-type';
-export type { MarkdownReaderAPI } from './markdown-type';
-export type { ThemeType } from './theme-type';
-export type { RecentFile } from './recentfile-type';
-export type { FileType } from './file-types';
+export { DEFAULT_SETTINGS } from './settings-type.js';
+export type { MarkdownReaderAPI } from './markdown-type.js';
+export type { ThemeType } from './theme-type.js';
+export type { RecentFile } from './recentfile-type.js';
+export type { FileType } from './file-types.js';
+export type { Settings } from './settings-type.js';
+export type { AppSettings } from './settings-type.js';

--- a/packages/shared-types/src/index.ts
+++ b/packages/shared-types/src/index.ts
@@ -5,3 +5,4 @@ export type { RecentFile } from './recentfile-type.js';
 export type { FileType } from './file-types.js';
 export type { Settings } from './settings-type.js';
 export type { AppSettings } from './settings-type.js';
+export type { ReadingWidth } from './settings-type.js';

--- a/packages/shared-types/src/index.ts
+++ b/packages/shared-types/src/index.ts
@@ -1,8 +1,7 @@
-export { DEFAULT_SETTINGS } from './settings-type.js';
+export { DEFAULT_SETTINGS } from './settings-default.js';
 export type { MarkdownReaderAPI } from './markdown-type.js';
 export type { ThemeType } from './theme-type.js';
 export type { RecentFile } from './recentfile-type.js';
 export type { FileType } from './file-types.js';
-export type { Settings } from './settings-type.js';
 export type { AppSettings } from './settings-type.js';
 export type { ReadingWidth } from './settings-type.js';

--- a/packages/shared-types/src/markdown-type.ts
+++ b/packages/shared-types/src/markdown-type.ts
@@ -18,7 +18,7 @@ export type MarkdownReaderAPI = {
   getAppVersion(): Promise<string>;
   onFileChanged: (callback: (path: string) => void) => void;
   removeFileChangedListener: () => void;
-  onMenuEvent: (event: string, callback: () => void) => void;
+  onMenuEvent: (event: string, callback: (payload?: unknown) => void) => () => void;
   removeMenuListeners: () => void;
   onOpenFilePath(callback: (path: string) => void): void;
   removeOpenFilePathListener(): void;

--- a/packages/shared-types/src/markdown-type.ts
+++ b/packages/shared-types/src/markdown-type.ts
@@ -1,6 +1,6 @@
-import { FileType } from './file-types';
-import { RecentFile } from './recentfile-type';
-import { Settings } from './settings-type';
+import { FileType } from './file-types.js';
+import { RecentFile } from './recentfile-type.js';
+import { Settings } from './settings-type.js';
 
 // markdown reader api
 export type MarkdownReaderAPI = {
@@ -29,12 +29,4 @@ export type MarkdownReaderAPI = {
   getPathForFile(file: File): string;
   onUpdateAvailable: (callback: (version: string) => void) => void;
   downloadUpdate: () => void;
-};
-
-// initial setting
-export const DEFAULT_SETTINGS: Settings = {
-  theme: 'github-light',
-  fontSize: 16,
-  readingWidth: 'default',
-  showLineNumbers: false,
 };

--- a/packages/shared-types/src/markdown-type.ts
+++ b/packages/shared-types/src/markdown-type.ts
@@ -1,6 +1,6 @@
 import { FileType } from './file-types.js';
 import { RecentFile } from './recentfile-type.js';
-import { Settings } from './settings-type.js';
+import { AppSettings } from './settings-type.js';
 
 // markdown reader api
 export type MarkdownReaderAPI = {
@@ -13,8 +13,8 @@ export type MarkdownReaderAPI = {
   getRecentFiles(): Promise<RecentFile[]>;
   addRecentFile(path: string): Promise<void>;
   clearRecentFiles(): Promise<void>;
-  getSettings(): Promise<Settings>;
-  saveSettings(settings: Settings[]): Promise<void>;
+  getSettings(): Promise<AppSettings>;
+  saveSettings(settings: Partial<AppSettings>): Promise<AppSettings>;
   getAppVersion(): Promise<string>;
   onFileChanged: (callback: (path: string) => void) => void;
   removeFileChangedListener: () => void;

--- a/packages/shared-types/src/settings-default.ts
+++ b/packages/shared-types/src/settings-default.ts
@@ -1,0 +1,12 @@
+import { AppSettings } from './settings-type.js';
+// initial setting
+export const DEFAULT_SETTINGS: AppSettings = {
+  theme: 'github-light',
+  fontSize: 16,
+  readingWidth: 'default',
+  lineNumbers: false,
+  customCss: '',
+  zoom: 100,
+  recentFilesLimit: 10,
+  showHiddenFiles: false,
+};

--- a/packages/shared-types/src/settings-type.ts
+++ b/packages/shared-types/src/settings-type.ts
@@ -1,7 +1,27 @@
 // type of user preferences settings
-export interface Settings {
-  theme: string;
+export type ReadingWidth = 'narrow' | 'default' | 'wide';
+export type Theme = 'github-light' | 'github-dark' | 'notion' | 'nord' | 'minimal' | 'dracula';
+export interface AppSettings {
+  theme: Theme;
   fontSize: number;
-  readingWidth: string;
-  showLineNumbers: boolean;
+  readingWidth: ReadingWidth;
+  lineNumbers: boolean;
+  customCss: string;
+  zoom: number;
+  recentFilesLimit: number;
+  showHiddenFiles: boolean;
 }
+
+export type Settings = AppSettings;
+
+// initial setting
+export const DEFAULT_SETTINGS: Settings = {
+  theme: 'github-light',
+  fontSize: 16,
+  readingWidth: 'default',
+  lineNumbers: false,
+  customCss: '',
+  zoom: 100,
+  recentFilesLimit: 10,
+  showHiddenFiles: false,
+};

--- a/packages/shared-types/src/settings-type.ts
+++ b/packages/shared-types/src/settings-type.ts
@@ -11,17 +11,3 @@ export interface AppSettings {
   recentFilesLimit: number;
   showHiddenFiles: boolean;
 }
-
-export type Settings = AppSettings;
-
-// initial setting
-export const DEFAULT_SETTINGS: Settings = {
-  theme: 'github-light',
-  fontSize: 16,
-  readingWidth: 'default',
-  lineNumbers: false,
-  customCss: '',
-  zoom: 100,
-  recentFilesLimit: 10,
-  showHiddenFiles: false,
-};

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,11 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  serialize-javascript: '>=7.0.3'
+  fast-uri: '>=3.1.2'
+  tmp: '>=0.2.6'
+
 importers:
 
   .:
@@ -19,7 +24,7 @@ importers:
         specifier: ^2.31.0
         version: 2.31.0(@types/node@25.6.0)
       '@commitlint/cli':
-        specifier: ^20.5.0
+        specifier: ^20.5.3
         version: 20.5.3(@types/node@25.6.0)(conventional-commits-parser@6.4.0)(typescript@6.0.3)
       '@commitlint/config-conventional':
         specifier: ^20.5.0
@@ -366,6 +371,10 @@ packages:
     resolution: {integrity: sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/code-frame@7.29.7':
+    resolution: {integrity: sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==}
+    engines: {node: '>=6.9.0'}
+
   '@babel/compat-data@7.29.0':
     resolution: {integrity: sha512-T1NCJqT/j9+cn8fvkt7jtwbLBfLC/1y1c7NtCeXFRgzGTsafi68MRv8yzkYSapBnFA6L3U2VSc02ciDzoAJhJg==}
     engines: {node: '>=6.9.0'}
@@ -455,6 +464,10 @@ packages:
 
   '@babel/helper-validator-identifier@7.28.5':
     resolution: {integrity: sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-validator-identifier@7.29.7':
+    resolution: {integrity: sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==}
     engines: {node: '>=6.9.0'}
 
   '@babel/helper-validator-option@7.27.1':
@@ -936,6 +949,10 @@ packages:
 
   '@babel/runtime@7.29.2':
     resolution: {integrity: sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/runtime@7.29.7':
+    resolution: {integrity: sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==}
     engines: {node: '>=6.9.0'}
 
   '@babel/template@7.28.6':
@@ -5211,8 +5228,8 @@ packages:
   fast-levenshtein@2.0.6:
     resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
 
-  fast-uri@3.1.0:
-    resolution: {integrity: sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==}
+  fast-uri@3.1.2:
+    resolution: {integrity: sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==}
 
   fastq@1.20.1:
     resolution: {integrity: sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==}
@@ -5340,6 +5357,10 @@ packages:
 
   fs-extra@11.3.4:
     resolution: {integrity: sha512-CTXd6rk/M3/ULNQj8FBqBWHYBVYybQ3VPBw0xGKFe3tuH7ytT6ACnvzpIQ3UZtB8yvUKC2cXn1a+x+5EVQLovA==}
+    engines: {node: '>=14.14'}
+
+  fs-extra@11.3.5:
+    resolution: {integrity: sha512-eKpRKAovdpZtR1WopLHxlBWvAgPny3c4gX1G5Jhwmmw4XJj0ifSD5qB5TOo8hmA0wlRKDAOAhEE1yVPgs6Fgcg==}
     engines: {node: '>=14.14'}
 
   fs-extra@7.0.1:
@@ -7555,9 +7576,6 @@ packages:
     resolution: {integrity: sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA==}
     engines: {node: '>=10'}
 
-  randombytes@2.1.0:
-    resolution: {integrity: sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==}
-
   range-parser@1.2.0:
     resolution: {integrity: sha512-kA5WQoNVo4t9lNx2kQNFCxKeBl5IbbSNBl1M/tLkw9WCn+hxNBAW5Qh8gdhs63CJnhjJ2zQWFoqPJP2sK1AV5A==}
     engines: {node: '>= 0.6'}
@@ -7920,8 +7938,9 @@ packages:
     resolution: {integrity: sha512-8I8TjW5KMOKsZQTvoxjuSIa7foAwPWGOts+6o7sgjz41/qMD9VQHEDxi6PBvK2l0MXUmqZyNpUK+T2tQaaElvw==}
     engines: {node: '>=10'}
 
-  serialize-javascript@6.0.2:
-    resolution: {integrity: sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==}
+  serialize-javascript@7.0.5:
+    resolution: {integrity: sha512-F4LcB0UqUl1zErq+1nYEEzSHJnIwb3AF2XWB94b+afhrekOUijwooAYqFyRbjYkm2PAKBabx6oYv/xDxNi8IBw==}
+    engines: {node: '>=20.0.0'}
 
   serve-handler@6.1.7:
     resolution: {integrity: sha512-CinAq1xWb0vR3twAv9evEU8cNWkXCb9kd5ePAHUKJBkOsUpR1wt/CvGdeca7vqumL1U5cSaeVQ6zZMxiJ3yWsg==}
@@ -8345,8 +8364,8 @@ packages:
   tmp-promise@3.0.3:
     resolution: {integrity: sha512-RwM7MoPojPxsOBYnyd2hy0bxtIlVrihNs9pj5SUvY8Zz1sQcQG2tG1hSr8PDxfgEB8RNKDhqbIlroIarSNDNsQ==}
 
-  tmp@0.2.5:
-    resolution: {integrity: sha512-voyz6MApa1rQGUxT3E+BK7/ROe8itEx7vD8/HEvt4xwXucvQ5G5oeEiHkmHZJuBO21RpOf+YYm9MOivj709jow==}
+  tmp@0.2.7:
+    resolution: {integrity: sha512-e0votIpp4Uo2AJYSzVHV6xCcawuiez3DzqDAbrTc3YxBkplN6e+dM13ZeIcZnDg/QpSuU2zfZ3rzwY8ukEnaXw==}
     engines: {node: '>=14.14'}
 
   to-regex-range@5.0.1:
@@ -9110,6 +9129,12 @@ snapshots:
       js-tokens: 4.0.0
       picocolors: 1.1.1
 
+  '@babel/code-frame@7.29.7':
+    dependencies:
+      '@babel/helper-validator-identifier': 7.29.7
+      js-tokens: 4.0.0
+      picocolors: 1.1.1
+
   '@babel/compat-data@7.29.0': {}
 
   '@babel/compat-data@7.29.3': {}
@@ -9244,6 +9269,8 @@ snapshots:
   '@babel/helper-string-parser@7.27.1': {}
 
   '@babel/helper-validator-identifier@7.28.5': {}
+
+  '@babel/helper-validator-identifier@7.29.7': {}
 
   '@babel/helper-validator-option@7.27.1': {}
 
@@ -9850,6 +9877,8 @@ snapshots:
       - supports-color
 
   '@babel/runtime@7.29.2': {}
+
+  '@babel/runtime@7.29.7': {}
 
   '@babel/template@7.28.6':
     dependencies:
@@ -10532,7 +10561,7 @@ snapshots:
       '@babel/preset-env': 7.29.5(@babel/core@7.29.0)
       '@babel/preset-react': 7.28.5(@babel/core@7.29.0)
       '@babel/preset-typescript': 7.28.5(@babel/core@7.29.0)
-      '@babel/runtime': 7.29.2
+      '@babel/runtime': 7.29.7
       '@babel/traverse': 7.29.0
       '@docusaurus/logger': 3.10.1
       '@docusaurus/utils': 3.10.1(@swc/core@1.15.33)(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.14))(html-minifier-terser@7.2.0)(lightningcss@1.32.0)(postcss@8.5.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
@@ -10566,7 +10595,7 @@ snapshots:
       '@babel/preset-env': 7.29.5(@babel/core@7.29.0)
       '@babel/preset-react': 7.28.5(@babel/core@7.29.0)
       '@babel/preset-typescript': 7.28.5(@babel/core@7.29.0)
-      '@babel/runtime': 7.29.2
+      '@babel/runtime': 7.29.7
       '@babel/traverse': 7.29.0
       '@docusaurus/logger': 3.10.1
       '@docusaurus/utils': 3.10.1(@swc/core@1.15.33)(lightningcss@1.32.0)(postcss@8.5.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
@@ -11674,7 +11703,7 @@ snapshots:
     dependencies:
       cross-dirname: 0.1.0
       debug: 4.4.3
-      fs-extra: 11.3.4
+      fs-extra: 11.3.5
       minimist: 1.2.8
       postject: 1.0.0-alpha.6
     transitivePeerDependencies:
@@ -12111,7 +12140,7 @@ snapshots:
 
   '@manypkg/find-root@1.1.0':
     dependencies:
-      '@babel/runtime': 7.29.2
+      '@babel/runtime': 7.29.7
       '@types/node': 12.20.55
       find-up: 4.1.0
       fs-extra: 8.1.0
@@ -12546,7 +12575,7 @@ snapshots:
 
   '@slorber/react-helmet-async@1.3.0(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
     dependencies:
-      '@babel/runtime': 7.29.2
+      '@babel/runtime': 7.29.7
       invariant: 2.2.4
       prop-types: 15.8.1
       react: 19.2.5
@@ -12920,8 +12949,8 @@ snapshots:
 
   '@testing-library/dom@10.4.1':
     dependencies:
-      '@babel/code-frame': 7.29.0
-      '@babel/runtime': 7.29.2
+      '@babel/code-frame': 7.29.7
+      '@babel/runtime': 7.29.7
       '@types/aria-query': 5.0.4
       aria-query: 5.3.0
       dom-accessibility-api: 0.5.16
@@ -13629,7 +13658,7 @@ snapshots:
   ajv@8.20.0:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 3.1.0
+      fast-uri: 3.1.2
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
@@ -14293,7 +14322,7 @@ snapshots:
       globby: 13.2.2
       normalize-path: 3.0.0
       schema-utils: 4.3.3
-      serialize-javascript: 6.0.2
+      serialize-javascript: 7.0.5
       webpack: 5.106.2(@swc/core@1.15.33)(lightningcss@1.32.0)(postcss@8.5.14)
 
   core-js-compat@3.49.0:
@@ -14395,7 +14424,7 @@ snapshots:
       jest-worker: 29.7.0
       postcss: 8.5.14
       schema-utils: 4.3.3
-      serialize-javascript: 6.0.2
+      serialize-javascript: 7.0.5
       webpack: 5.106.2(@swc/core@1.15.33)(lightningcss@1.32.0)(postcss@8.5.14)
     optionalDependencies:
       clean-css: 5.3.3
@@ -15391,7 +15420,7 @@ snapshots:
 
   fast-levenshtein@2.0.6: {}
 
-  fast-uri@3.1.0: {}
+  fast-uri@3.1.2: {}
 
   fastq@1.20.1:
     dependencies:
@@ -15516,6 +15545,13 @@ snapshots:
       graceful-fs: 4.2.11
       jsonfile: 6.2.1
       universalify: 2.0.1
+
+  fs-extra@11.3.5:
+    dependencies:
+      graceful-fs: 4.2.11
+      jsonfile: 6.2.1
+      universalify: 2.0.1
+    optional: true
 
   fs-extra@7.0.1:
     dependencies:
@@ -15838,7 +15874,7 @@ snapshots:
 
   history@4.10.1:
     dependencies:
-      '@babel/runtime': 7.29.2
+      '@babel/runtime': 7.29.7
       loose-envify: 1.4.0
       resolve-pathname: 3.0.0
       tiny-invariant: 1.3.3
@@ -18143,10 +18179,6 @@ snapshots:
 
   quick-lru@5.1.1: {}
 
-  randombytes@2.1.0:
-    dependencies:
-      safe-buffer: 5.2.1
-
   range-parser@1.2.0: {}
 
   range-parser@1.2.1: {}
@@ -18182,7 +18214,7 @@ snapshots:
 
   react-loadable-ssr-addon-v5-slorber@1.0.3(@docusaurus/react-loadable@6.0.0(react@19.2.5))(webpack@5.106.2(@swc/core@1.15.33)(lightningcss@1.32.0)(postcss@8.5.14)):
     dependencies:
-      '@babel/runtime': 7.29.2
+      '@babel/runtime': 7.29.7
       react-loadable: '@docusaurus/react-loadable@6.0.0(react@19.2.5)'
       webpack: 5.106.2(@swc/core@1.15.33)(lightningcss@1.32.0)(postcss@8.5.14)
 
@@ -18190,13 +18222,13 @@ snapshots:
 
   react-router-config@5.1.1(react-router@5.3.4(react@19.2.5))(react@19.2.5):
     dependencies:
-      '@babel/runtime': 7.29.2
+      '@babel/runtime': 7.29.7
       react: 19.2.5
       react-router: 5.3.4(react@19.2.5)
 
   react-router-dom@5.3.4(react@19.2.5):
     dependencies:
-      '@babel/runtime': 7.29.2
+      '@babel/runtime': 7.29.7
       history: 4.10.1
       loose-envify: 1.4.0
       prop-types: 15.8.1
@@ -18207,7 +18239,7 @@ snapshots:
 
   react-router@5.3.4(react@19.2.5):
     dependencies:
-      '@babel/runtime': 7.29.2
+      '@babel/runtime': 7.29.7
       history: 4.10.1
       hoist-non-react-statics: 3.3.2
       loose-envify: 1.4.0
@@ -18627,9 +18659,7 @@ snapshots:
       type-fest: 0.13.1
     optional: true
 
-  serialize-javascript@6.0.2:
-    dependencies:
-      randombytes: 2.1.0
+  serialize-javascript@7.0.5: {}
 
   serve-handler@6.1.7:
     dependencies:
@@ -19082,9 +19112,9 @@ snapshots:
 
   tmp-promise@3.0.3:
     dependencies:
-      tmp: 0.2.5
+      tmp: 0.2.7
 
-  tmp@0.2.5: {}
+  tmp@0.2.7: {}
 
   to-regex-range@5.0.1:
     dependencies:


### PR DESCRIPTION
## Description

This PR fixe several critical, high and medium level issues related to security and UI.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor (no functional change)
- [ ] Documentation update
- [ ] Style / UI change
- [ ] Build / CI change

## Related Issue

Closes #42 ,#76,#77, #82, #83

## Checklist

- [x] My code follows the project's coding guidelines
- [x] I have tested my changes locally
- [x] I have used [conventional commit](https://www.conventionalcommits.org/) messages
- [ ] I have updated documentation if needed
- [x] My changes do not introduce new warnings or errors


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
- Electron main/preload
  - watchFile: extended API to accept options (onChange/onDeleted/onError), per-path debounce, unWatchFile clears timers, added getWatcherDiagnostics()
  - getFolder: depth-limited traversal (MAX_FOLDER_DEPTH=10), realpath cycle detection, skips dotfiles and symlink descent
  - IPC: added GET_SETTINGS, SAVE_SETTINGS, GET_APP_VERSION handlers with sender validation
  - Menu: added Settings menu item and Theme radio submenu; createMenuSender now supports payloads; sendFilePathToRenderer made async with error handling
  - Preload bridge: onMenuEvent now accepts optional payload and returns an unsubscribe function

- Renderer UI
  - New SettingsPanel component (reading width, line numbers, custom CSS, version)
  - useSettings: manages full AppSettings, persists via IPC (getSettings/saveSettings), injects custom CSS into document head, exposes updateSettings
  - Theme: system theme detection (getSystemTheme), persist user theme to localStorage, theme UI wiring and menu/shortcut support
  - TOC/Sidebar: extract TOC from rawMarkdown, Sidebar auto-scrolls active item, updated collapse defaults and styling; useCollapsibleToc default-collapsing behavior for deeper items
  - App: loads appVersion, controlled SettingsPanel, passes active tab TOC into TOC hooks
  - Minor: useFileActions/useFilePersistence include toc field when available

- Markdown rendering
  - extractTOC rewritten to use marked lexer/token parsing (avoids headings in code blocks; preserves link text)
  - heading-helper: added headingText and isHeadingToken; ID generation uses stripped plain text
  - inlineImages: fixed regex group usage for image src capture

- Shared packages
  - packages/shared-types: introduced AppSettings and ReadingWidth types; DEFAULT_SETTINGS moved to settings-default; MarkdownReaderAPI updated (getSettings/saveSettings and onMenuEvent signatures changed)
  - packages/shared-constants: THEMES converted from object to array with derived Theme type; exported additional font/width constants; menu constants extended with SETTINGS/SET_THEME
  - package.json: pnpm.overrides added; packages/shared-types set "type":"module"

- Tests
  - Expanded/added tests: file watcher debounce/cleanup, folder depth enforcement, TOC extraction (Markdown inputs, links, code-block isolation), settings validation, export inline-image test
  - Vitest setup: added test.setupFiles to load test setup importing mocked electron app where needed

- Tooling / CI
  - Workflows (dev & prod): updated pnpm/action-setup to v4, added security job running pnpm audit --audit-level=high and Trivy fs scan (CRITICAL,HIGH) failing on findings; build jobs now run pnpm dist
  - Pre-push hook runs pnpm test
  - Updated commitlint devDependency

- Docs
  - index.html: added favicon and meta description
  - Added unsigned-install-notice.txt with installation guidance for unsigned builds

- Packaging
  - electron-builder: added extraResources to include unsigned-install-notice and NSIS license pointing to it
  - packages/shared-types switched to ESM ("type":"module")

Breaking changes:
- Public IPC and preload API changed: MarkdownReaderAPI signatures updated (getSettings(): Promise<AppSettings>, saveSettings(settings: Partial<AppSettings>): Promise<AppSettings>), onMenuEvent callback now accepts optional payload and returns unsubscribe; preload bridge reflects these changes — these are breaking for external integrators.
- Shared types/constants changed: THEMES shape changed from object to array and Theme type moved; DEFAULT_SETTINGS re-export location changed; AppSettings shape renamed/expanded (replaces old Settings) — consumers must update imports/types and any code that relied on the old shapes.
- Package type change: packages/shared-types now ESM ("type":"module") — may affect tooling/consumers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->