### PR TITLE
Fix/system hardening

### DIFF
--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -21,8 +21,6 @@ jobs:
  
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
-        with:
-          version: 10
  
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
@@ -51,8 +49,6 @@ jobs:
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
-        with:
-          version: 10
 
       - name: Setup Node
         uses: actions/setup-node@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,9 @@ on:
     
 permissions:
   contents: write
+
+env:
+  HUSKY: 0
   
 jobs:
   # add change set 

--- a/apps/main-processor/src/export/exportDocx.ts
+++ b/apps/main-processor/src/export/exportDocx.ts
@@ -1,10 +1,12 @@
 import HTMLtoDOCX from 'html-to-docx';
 import { writeFile } from 'node:fs/promises';
 import { buildDocument } from './buildDocument';
+import { inlineImages } from './inlineImage';
 import { sanitizeCss } from './sanitizeCss';
 
 export async function exportDOCX(bodyHtml: string, css: string, outputPath: string): Promise<void> {
-  const html = buildDocument(bodyHtml, sanitizeCss(css));
+  const htmlWithInlineImages = await inlineImages(bodyHtml);
+  const html = buildDocument(htmlWithInlineImages, sanitizeCss(css));
 
   const result = await HTMLtoDOCX(html, null, {
     table: { row: { cantSplit: true } },

--- a/apps/main-processor/src/export/exportPdf.ts
+++ b/apps/main-processor/src/export/exportPdf.ts
@@ -8,7 +8,7 @@ export async function exportPDF(bodyHtml: string, css: string, outputPath: strin
   const pdfWindow = new BrowserWindow({
     show: false,
     webPreferences: {
-      sandbox: false,
+      sandbox: true,
     },
   });
 

--- a/apps/main-processor/src/export/sanitizeCss.ts
+++ b/apps/main-processor/src/export/sanitizeCss.ts
@@ -2,9 +2,14 @@ import { EXPORT_CONST } from '../utils/constants/export-constants';
 
 export function sanitizeCss(css: string): string {
   if (!css || typeof css !== 'string') return '';
-  const sanitized = EXPORT_CONST.DANGEROUS_CSS_PATTERNS.reduce(
-    (safeCss, pattern) => safeCss.replace(pattern, ''),
-    css
-  );
+  let sanitized = css;
+  let previous: string;
+  do {
+    previous = sanitized;
+    sanitized = EXPORT_CONST.DANGEROUS_CSS_PATTERNS.reduce(
+      (safeCss, pattern) => safeCss.replace(pattern, ''),
+      sanitized
+    );
+  } while (sanitized !== previous);
   return sanitized;
 }

--- a/apps/main-processor/src/file.ts
+++ b/apps/main-processor/src/file.ts
@@ -41,7 +41,9 @@ export async function watchFile(
     watcher.on('error', (error) => {
       const watcherError = error instanceof Error ? error : new Error(String(error));
 
-      void unWatchFile(filePath).then(() => onError?.(watcherError));
+      void unWatchFile(filePath)
+        .catch(() => {})
+        .finally(() => onError?.(watcherError));
 
       reject(watcherError);
     });
@@ -63,7 +65,9 @@ export async function watchFile(
     debounceTimers.set(filePath, timer);
   });
   watcher.on('unlink', () => {
-    void unWatchFile(filePath).then(() => onDeleted?.());
+    void unWatchFile(filePath)
+      .catch(() => {})
+      .finally(() => onDeleted?.());
   });
 }
 

--- a/apps/main-processor/src/file.ts
+++ b/apps/main-processor/src/file.ts
@@ -34,8 +34,17 @@ export async function watchFile(
       pollInterval: 50,
     },
   });
-  await new Promise<void>((resolve) => {
-    watcher.on('ready', resolve);
+  currentWatchers.set(filePath, watcher);
+  await new Promise<void>((resolve, reject) => {
+    watcher.once('ready', resolve);
+
+    watcher.on('error', (error) => {
+      const watcherError = error instanceof Error ? error : new Error(String(error));
+
+      void unWatchFile(filePath).then(() => onError?.(watcherError));
+
+      reject(watcherError);
+    });
   });
   watcher.on('change', () => {
     const existingTimer = debounceTimers.get(filePath);
@@ -56,11 +65,6 @@ export async function watchFile(
   watcher.on('unlink', () => {
     void unWatchFile(filePath).then(() => onDeleted?.());
   });
-  watcher.on('error', (error) => {
-    const watcherError = error instanceof Error ? error : new Error(String(error));
-    void unWatchFile(filePath).then(() => onError?.(watcherError));
-  });
-  currentWatchers.set(filePath, watcher);
 }
 
 //unwatch file

--- a/apps/main-processor/src/file.ts
+++ b/apps/main-processor/src/file.ts
@@ -36,9 +36,16 @@ export async function watchFile(
   });
   currentWatchers.set(filePath, watcher);
   await new Promise<void>((resolve, reject) => {
-    watcher.once('ready', resolve);
+    const timeout = setTimeout(() => {
+      resolve();
+    }, 1000);
+    watcher.once('ready', () => {
+      clearTimeout(timeout);
+      resolve();
+    });
 
-    watcher.on('error', (error) => {
+    watcher.once('error', (error) => {
+      clearTimeout(timeout);
       const watcherError = error instanceof Error ? error : new Error(String(error));
 
       void unWatchFile(filePath)

--- a/apps/main-processor/src/ipc.ts
+++ b/apps/main-processor/src/ipc.ts
@@ -1,7 +1,12 @@
 import { app, ipcMain, dialog } from 'electron';
 import { readFile, unWatchFile, watchFile } from './file';
 import { getFolder } from './folder';
-import { validatePath, validateSender, allowedFolderRoots } from './utils/constants/ipc-validation';
+import {
+  validatePath,
+  validateSender,
+  allowedFolderRoots,
+  allowedMarkdownFiles,
+} from './utils/constants/ipc-validation';
 import { IPC_CONSTANTS } from '@package/shared-constants';
 import { getRecentFiles } from './recent/getRecentFile';
 import { addRecentFile } from './recent/addRecentFile';
@@ -26,6 +31,7 @@ export function registerIPCHandlers(): void {
       throw new Error('Untrusted sender');
     }
     const safeFilePath = await resolveMarkdownFilePath(filePath);
+    allowedMarkdownFiles.add(safeFilePath);
     return await readFile(safeFilePath);
   });
 
@@ -47,7 +53,9 @@ export function registerIPCHandlers(): void {
     }
     const selected = result.filePaths[0];
     if (!selected) return null;
-    return await resolveMarkdownFilePath(selected);
+    const safeFilePath = await resolveMarkdownFilePath(selected);
+    allowedMarkdownFiles.add(safeFilePath);
+    return safeFilePath;
   });
 
   // watches a file

--- a/apps/main-processor/src/ipc.ts
+++ b/apps/main-processor/src/ipc.ts
@@ -199,9 +199,7 @@ export function registerIPCHandlers(): void {
     if (!validateSender(event)) {
       throw new Error('Untrusted sender');
     }
-
     const safeFolderPath = await resolveDirectoryPath(folderPath);
-    allowedFolderRoots.add(safeFolderPath);
     const isAllowed = Array.from(allowedFolderRoots).some(
       (root) => safeFolderPath === root || safeFolderPath.startsWith(`${root}/`)
     );

--- a/apps/main-processor/src/utils/constants/ipc-validation.ts
+++ b/apps/main-processor/src/utils/constants/ipc-validation.ts
@@ -2,14 +2,26 @@ import path from 'path';
 import { IpcMainInvokeEvent } from 'electron';
 
 // production and dev urls
-const allowedOrigin = ['file://', 'http://localhost'];
 export const ALLOWED_MARKDOWN_EXTENSIONS = new Set(['.md', '.markdown']);
 export const allowedFolderRoots = new Set<string>();
 
 //validate the sender
 export function validateSender(event: IpcMainInvokeEvent): boolean {
-  const url = event.senderFrame?.url || '';
-  return allowedOrigin.some((origin) => url.startsWith(origin));
+  const url = event.senderFrame?.url;
+
+  if (!url) return false;
+
+  try {
+    const parsedUrl = new URL(url);
+
+    if (parsedUrl.protocol === 'file:') {
+      return true;
+    }
+
+    return parsedUrl.protocol === 'http:' && parsedUrl.hostname === 'localhost';
+  } catch {
+    return false;
+  }
 }
 
 //validate path type

--- a/apps/main-processor/src/utils/constants/ipc-validation.ts
+++ b/apps/main-processor/src/utils/constants/ipc-validation.ts
@@ -4,6 +4,7 @@ import { IpcMainInvokeEvent } from 'electron';
 // production and dev urls
 export const ALLOWED_MARKDOWN_EXTENSIONS = new Set(['.md', '.markdown']);
 export const allowedFolderRoots = new Set<string>();
+export const allowedMarkdownFiles = new Set<string>();
 
 //validate the sender
 export function validateSender(event: IpcMainInvokeEvent): boolean {

--- a/apps/main-processor/src/utils/helper/ipc-path-resolver.ts
+++ b/apps/main-processor/src/utils/helper/ipc-path-resolver.ts
@@ -5,6 +5,7 @@ import {
   isPathInside,
   ALLOWED_MARKDOWN_EXTENSIONS,
   allowedFolderRoots,
+  allowedMarkdownFiles,
 } from '../constants/ipc-validation';
 
 /* Validates, resolves symlink and ensures a path is a valid Markdown file inside an optional root directory */
@@ -54,16 +55,17 @@ export async function resolveDirectoryPath(folderPath: string): Promise<string> 
 
 /*Resolves a Markdown file path against a dynamic set of allowed root folders throwing an error if it matches none*/
 export async function resolveWatchedMarkdownPath(filePath: string): Promise<string> {
-  let lastError: unknown;
+  const safeFilePath = await resolveMarkdownFilePath(filePath);
+
+  if (allowedMarkdownFiles.has(safeFilePath)) {
+    return safeFilePath;
+  }
   for (const allowedRoot of allowedFolderRoots) {
     try {
       return await resolveMarkdownFilePath(filePath, allowedRoot);
-    } catch (error) {
-      lastError = error;
+    } catch {
+      continue;
     }
   }
-  if (allowedFolderRoots.size > 0) {
-    throw lastError instanceof Error ? lastError : new Error('Path escapes allowed directory');
-  }
-  return await resolveMarkdownFilePath(filePath);
+  throw new Error('Path escapes allowed directory');
 }

--- a/apps/preload/src/index.ts
+++ b/apps/preload/src/index.ts
@@ -54,9 +54,11 @@ const apiContract: MarkdownReaderAPI = {
   getPathForFile: (file: File) => webUtils.getPathForFile(file),
 
   onUpdateAvailable: (callback: (version: string) => void) => {
-    ipcRenderer.on(IPC_CONSTANTS.UPDATE_AVAILABLE, (_event, version: string) => {
-      callback(version);
-    });
+    const handler = (_event: IpcRendererEvent, version: string) => callback(version);
+    ipcRenderer.on(IPC_CONSTANTS.UPDATE_AVAILABLE, handler);
+    return () => {
+      ipcRenderer.removeListener(IPC_CONSTANTS.UPDATE_AVAILABLE, handler);
+    };
   },
   downloadUpdate: () => ipcRenderer.send(IPC_CONSTANTS.DOWNLOAD_UPDATE),
 };

--- a/apps/renderer/__tests__/components/TabBar.test.tsx
+++ b/apps/renderer/__tests__/components/TabBar.test.tsx
@@ -31,7 +31,7 @@ describe('TabBar', () => {
 
   it('marks the active tab', () => {
     render(<TabBar tabs={tabs} activeTabId="tab-1" onSwitch={() => {}} onClose={() => {}} />);
-    expect(screen.getByRole('tab', { name: /README/i })).toHaveAttribute('aria-current', 'true');
+    expect(screen.getByRole('tab', { name: /README/i })).toHaveAttribute('aria-selected', 'true');
   });
 
   it('switches tab when a tab is clicked', () => {
@@ -49,7 +49,7 @@ describe('TabBar', () => {
 
     render(<TabBar tabs={tabs} activeTabId="tab-1" onSwitch={() => {}} onClose={onClose} />);
 
-    fireEvent.click(screen.getAllByRole('button', { name: /close tab/i })[0]);
+    fireEvent.click(screen.getAllByRole('button', { name: /close .* tab/i })[0]);
 
     expect(onClose).toHaveBeenCalledWith('tab-1');
   });

--- a/apps/renderer/__tests__/hooks/useSettings.test.ts
+++ b/apps/renderer/__tests__/hooks/useSettings.test.ts
@@ -12,34 +12,45 @@ describe('useSettings font size', () => {
     expect(result.current.fontSize).toBe(16);
   });
 
-  it('should increase font size by adding 2px', () => {
+  it('should increase font size by adding 2px', async () => {
     const { result } = renderHook(() => useSettings());
-    act(() => result.current.increaseFontSize());
+    await act(async () => {
+      result.current.increaseFontSize();
+    });
     expect(result.current.fontSize).toBe(18);
   });
 
-  it('should decrease font size by subracting 2px', () => {
+  it('should decrease font size by subracting 2px', async () => {
     const { result } = renderHook(() => useSettings());
-    act(() => result.current.decreaseFontSize());
+    await act(async () => {
+      result.current.decreaseFontSize();
+    });
     expect(result.current.fontSize).toBe(14);
   });
 
-  it('should not exceed 24px', () => {
+  it('should not exceed 24px', async () => {
     const { result } = renderHook(() => useSettings());
-    act(() => {
-      for (let i = 0; i < 10; i++) {
+
+    for (let i = 0; i < 10; i++) {
+      await act(async () => {
         result.current.increaseFontSize();
-      }
-    });
+      });
+    }
+
     expect(result.current.fontSize).toBe(24);
   });
 
-  it('should return recent font size as 16', () => {
+  it('should return recent font size as 16', async () => {
     const { result } = renderHook(() => useSettings());
-    act(() => {
+
+    await act(async () => {
       result.current.increaseFontSize();
+    });
+
+    await act(async () => {
       result.current.resetFontSize();
     });
+
     expect(result.current.fontSize).toBe(16);
   });
 });

--- a/apps/renderer/setup.ts
+++ b/apps/renderer/setup.ts
@@ -22,18 +22,19 @@ if (typeof window !== 'undefined' && window.SVGElement) {
   }
 }
 
+let mockSettings = {
+  fontSize: 16,
+  readingWidth: 'default',
+  customCss: '',
+};
+
 Object.defineProperty(window, 'api', {
   value: {
-    getSettings: vi.fn(async () => ({
-      fontSize: 16,
-      readingWidth: 'default',
-      customCss: '',
-    })),
-    saveSettings: vi.fn(async (partial) => ({
-      fontSize: partial.fontSize ?? 16,
-      readingWidth: 'default',
-      customCss: '',
-    })),
+    getSettings: vi.fn(async () => mockSettings),
+    saveSettings: vi.fn(async (partial) => {
+      mockSettings = { ...mockSettings, ...partial };
+      return mockSettings;
+    }),
   },
   writable: true,
 });

--- a/apps/renderer/setup.ts
+++ b/apps/renderer/setup.ts
@@ -1,4 +1,5 @@
 import '@testing-library/jest-dom';
+import { vi } from 'vitest';
 
 // mock svg measurments for jsdom environment for mermaid testing
 if (typeof window !== 'undefined' && window.SVGElement) {
@@ -20,3 +21,19 @@ if (typeof window !== 'undefined' && window.SVGElement) {
     proto.getComputedTextLength = () => 100;
   }
 }
+
+Object.defineProperty(window, 'api', {
+  value: {
+    getSettings: vi.fn(async () => ({
+      fontSize: 16,
+      readingWidth: 'default',
+      customCss: '',
+    })),
+    saveSettings: vi.fn(async (partial) => ({
+      fontSize: partial.fontSize ?? 16,
+      readingWidth: 'default',
+      customCss: '',
+    })),
+  },
+  writable: true,
+});

--- a/apps/renderer/src/App.tsx
+++ b/apps/renderer/src/App.tsx
@@ -1,4 +1,4 @@
-import React,{ useEffect, useState, useRef } from 'react';
+import { useEffect, useState, useRef } from 'react';
 import { useFile } from './hooks/useFile';
 import { Welcome } from './components/Welcome';
 import { Reader } from './components/Reader';
@@ -31,6 +31,7 @@ import { useFilePersistence } from './hooks/useFilePersistence';
 import { ReaderToolbar } from './components/ReaderToolbar';
 import { useFolderSearch } from './hooks/useFolderSearch';
 import { SettingsPanel } from './components/SettingsPanel';
+import { ErrorBoundary } from './components/ErrorBoundary';
 
 export default function App() {
   const {  error, isLoading, openFile, toc,recentFiles,loadFile } =useFile();
@@ -212,7 +213,9 @@ useShortcuts({
             className="flex-1 overflow-y-auto" 
             onScroll={scroll}
             >
-              <Reader html={activeTab.html} getHiglightedHtml={getHiglightedHtml} />
+              <ErrorBoundary>
+                <Reader html={activeTab.html} getHiglightedHtml={getHiglightedHtml} />
+              </ErrorBoundary>
             </main>
           </div>
         )}

--- a/apps/renderer/src/App.tsx
+++ b/apps/renderer/src/App.tsx
@@ -162,6 +162,7 @@ useShortcuts({
             activeTabId={state.activeTabId}
             onSwitch={(id) => dispatch({ type: 'SWITCH_TAB', payload: { tabId: id } })}
             onClose={(id) => dispatch({ type: 'CLOSE_TAB', payload: { tabId: id } })}
+            plusOpen={openFileDialog}
           />
         )}
         <UpdateBanner/>

--- a/apps/renderer/src/components/DragDrop.tsx
+++ b/apps/renderer/src/components/DragDrop.tsx
@@ -4,7 +4,7 @@ when a file is dragged and dropped on the application */
 
 export function DragDrop() {
   return (
-    <div className='pointer-events-none fixed inset-0 z-50 flex items-center justify-center border-2 border-dashed border-accent bg-bg/80ntext-text-base'>
+    <div role="status" aria-live="polite" className='pointer-events-none fixed inset-0 z-50 flex items-center justify-center border-2 border-dashed border-accent bg-bg/80ntext-text-base'>
       <div className='rounded-xl border border-border-theme bg-surface px-6 py-4 text-sm font-medium shadow-lg'>
         Drop Markdown file to open
       </div>

--- a/apps/renderer/src/components/DragDrop.tsx
+++ b/apps/renderer/src/components/DragDrop.tsx
@@ -4,7 +4,7 @@ when a file is dragged and dropped on the application */
 
 export function DragDrop() {
   return (
-    <div role="status" aria-live="polite" className='pointer-events-none fixed inset-0 z-50 flex items-center justify-center border-2 border-dashed border-accent bg-bg/80ntext-text-base'>
+    <div role="status" aria-live="polite" className='pointer-events-none fixed inset-0 z-50 flex items-center justify-center border-2 border-dashed border-accent bg-bg/80 text-text-base'>
       <div className='rounded-xl border border-border-theme bg-surface px-6 py-4 text-sm font-medium shadow-lg'>
         Drop Markdown file to open
       </div>

--- a/apps/renderer/src/components/Error.tsx
+++ b/apps/renderer/src/components/Error.tsx
@@ -3,9 +3,10 @@ import { ErrorProps } from "../types/component-types"
 //error message display function
 export function Error({message,onRetry}:ErrorProps){
   return (
-   <div className="m-6 p-4 rounded-lg bg-error-bg text-error border border-error-border">
+   <div role="alert" className="m-6 p-4 rounded-lg bg-error-bg text-error border border-error-border">
       <p className="mb-3 font-medium text-sm">Error: {message}</p>
       <button
+        type="button"
         onClick={onRetry}
         className="px-3 py-1.5 text-sm rounded bg-error-border text-white hover:opacity-90 transition-opacity"
       >

--- a/apps/renderer/src/components/ErrorBoundary.tsx
+++ b/apps/renderer/src/components/ErrorBoundary.tsx
@@ -1,0 +1,42 @@
+import React from 'react';
+import { ErrorBoundaryState } from '../types/component-types';
+
+
+export class ErrorBoundary extends React.Component<React.PropsWithChildren, ErrorBoundaryState> {
+  state: ErrorBoundaryState = { hasError: false, error: null };
+
+  static getDerivedStateFromError(error: Error): ErrorBoundaryState {
+    return { hasError: true, error };
+  }
+
+  componentDidCatch(error: unknown): void {
+    console.error('Renderer error boundary caught an error:', error);
+  }
+
+  render(): React.ReactNode {
+    if (this.state.hasError) {
+      return (
+        <div className="flex min-h-screen flex-col items-center justify-center gap-3 bg-bg p-6 text-text-base">
+          <h1 className="text-xl font-semibold">Something went wrong</h1>
+          <p className="max-w-md text-center text-sm text-text-muted">
+            The renderer hit an unexpected error. You can try rendering the app again.
+          </p>
+          {import.meta.env.DEV && this.state.error && (
+            <pre className="max-w-xl overflow-auto rounded border border-border-theme bg-surface p-3 text-xs">
+              {this.state.error.message}
+            </pre>
+          )}
+          <button
+            type="button"
+            className="rounded border border-border-theme bg-surface px-3 py-2 text-sm hover:bg-accent-bg"
+            onClick={() => this.setState({ hasError: false, error: null })}
+          >
+            Try again
+          </button>
+        </div>
+      );
+    }
+
+    return this.props.children;
+  }
+}

--- a/apps/renderer/src/components/FileBrowser.tsx
+++ b/apps/renderer/src/components/FileBrowser.tsx
@@ -1,6 +1,5 @@
 import { FileBrowserProps } from '../types/component-types';
 import { FileTree } from './FileTree';
-import { Icons } from '../utils/constants/icon-contants';
 
 export function FileBrowser({
   tree,
@@ -16,7 +15,6 @@ export function FileBrowser({
     >
       <div className="flex items-center justify-between border-b border-border-theme px-4 py-3">
         <div className="flex items-center gap-2">
-          <Icons.Hamburger size={16} className="text-text-muted" />
           <h2 className="text-sm font-semibold tracking-wide text-text-base">
             Explorer
           </h2>

--- a/apps/renderer/src/components/FileBrowser.tsx
+++ b/apps/renderer/src/components/FileBrowser.tsx
@@ -11,6 +11,7 @@ export function FileBrowser({
   return (
     <aside
       aria-label="File browser"
+      role="complementary"
       className="flex w-72 shrink-0 flex-col border-r border-border-theme bg-surface"
     >
       <div className="flex items-center justify-between border-b border-border-theme px-4 py-3">

--- a/apps/renderer/src/components/FileTree.tsx
+++ b/apps/renderer/src/components/FileTree.tsx
@@ -7,6 +7,8 @@ export function FileTree({node,depth,activeFilePath,onOpenFile}:FileTreeProps) {
     return (
       <div className="mb-1">
         <div
+          role='group'
+          aria-label={`${node.name} folder`}
           style={{ paddingLeft }}
           className="flex items-center gap-2 py-2 text-[11px] font-semibold uppercase tracking-wider text-text-muted"
         >
@@ -31,6 +33,7 @@ export function FileTree({node,depth,activeFilePath,onOpenFile}:FileTreeProps) {
   const isActive = node.path === activeFilePath;
   return(
     <button type="button" onClick={() => onOpenFile(node.path)}
+      aria-current={isActive ? 'location' : undefined}
       style={{ paddingLeft }}
       className={[
         'group flex w-full items-center gap-2 rounded-r-xl py-2 pr-3 text-left text-sm transition-all',
@@ -40,6 +43,7 @@ export function FileTree({node,depth,activeFilePath,onOpenFile}:FileTreeProps) {
       ].join(' ')}
     >
       <div
+        aria-hidden="true" 
         className={[
           'h-2 w-2 rounded-full transition-colors',
           isActive ? 'bg-accent' : 'bg-border-theme',

--- a/apps/renderer/src/components/Loading.tsx
+++ b/apps/renderer/src/components/Loading.tsx
@@ -1,9 +1,9 @@
 //loading function
 export function Loading(){
   return(
-    <div className="fixed inset-0 z-50 flex items-center justify-center backdrop-blur-sm">
+    <div role="status" aria-live="polite" className="fixed inset-0 z-50 flex items-center justify-center backdrop-blur-sm">
       <div className="flex flex-col items-center gap-3 p-5 rounded-lg bg-surface border border-border-theme shadow-sm">
-        <div className="w-5 h-5 border-2 border-border-theme border-t-accent rounded-full animate-spin" />
+        <div aria-hidden="true" className="w-5 h-5 border-2 border-border-theme border-t-accent rounded-full animate-spin" />
         <p className="text-sm text-text-muted">Loading…</p>
       </div>
     </div>

--- a/apps/renderer/src/components/ReaderToolbar.tsx
+++ b/apps/renderer/src/components/ReaderToolbar.tsx
@@ -11,8 +11,9 @@ export function ReaderToolbar({
   onToggleTheme,
 }: ReaderToolbarProps) {
   return (
-    <div className="absolute right-5 top-5 z-30 flex items-center gap-1 rounded-xl border border-border-theme bg-surface px-2 py-1 shadow-sm">
+    <div role="toolbar" aria-label="Text settings toolbar" className="absolute right-5 top-5 z-30 flex items-center gap-1 rounded-xl border border-border-theme bg-surface px-2 py-1 shadow-sm">
       <button
+        type='button'
         onClick={onZoomOut}
         className="rounded-md p-2 text-text-muted transition-colors hover:bg-accent-bg hover:text-text-base"
         aria-label="Zoom out"
@@ -20,20 +21,24 @@ export function ReaderToolbar({
         <Icons.ZoomOut size={18} />
       </button>
       <button
+        type='button'
         onClick={onZoomReset}
         className="min-w-12 rounded-md px-2 py-1 text-xs font-medium text-text-muted transition-colors hover:bg-accent-bg hover:text-text-base"
+        aria-label={`Reset zoom, current size ${fontSize} pixels`}
       >
         {fontSize}px
       </button>
       <button
+        type="button"
         onClick={onZoomIn}
         className="rounded-md p-2 text-text-muted transition-colors hover:bg-accent-bg hover:text-text-base"
         aria-label="Zoom in"
       >
         <Icons.ZoomIn size={18} />
       </button>
-      <div className="mx-1 h-5 w-px bg-border-theme" />
+      <div aria-hidden="true" className="mx-1 h-5 w-px bg-border-theme" />
       <button
+        type="button"
         onClick={onToggleTheme}
         className="rounded-md p-2 text-text-muted transition-colors hover:bg-accent-bg hover:text-text-base"
         aria-label="Toggle theme"

--- a/apps/renderer/src/components/SearchBar.tsx
+++ b/apps/renderer/src/components/SearchBar.tsx
@@ -79,7 +79,7 @@ export function SearchBar({
       />
 
      {query && !isFolderMode && (
-        <div role="status" aria-live="polite" className="flex items-center gap-2">
+        <div id={statusId} role="status" aria-live="polite" className="flex items-center gap-2">
           {matchCount > 0 ? (
             <span className="min-w-15 font-mono text-sm text-text-muted">
               <span className="sr-only">Match</span> {currentMatch} 

--- a/apps/renderer/src/components/SearchBar.tsx
+++ b/apps/renderer/src/components/SearchBar.tsx
@@ -60,6 +60,7 @@ export function SearchBar({
 
 
   const newButtonClass=(isDisable:boolean)=>`${btnClass} ${isDisable? 'cursor-not-allowed opacity-50' : 'cursor-pointer'}`;
+  const statusId = "search-status-msg";
 
   return (
     <div role="search" aria-label={isFolderMode ? 'Folder Search' : 'Document Search'} className={`fixed top-0 right-0 z-50 p-2 bg-surface border border-border-theme rounded-bl-lg shadow-lg ${isFolderMode ? 'w-96' : 'flex items-center gap-2'}`}>
@@ -73,6 +74,8 @@ export function SearchBar({
         onKeyDown={handleKeyDown}
         placeholder={isFolderMode ? "Search in folder" : "Search in the document"}
         aria-label={isFolderMode ? "Search in folder" : "Search in document"}
+        aria-describedby={query && !isFolderMode ? statusId : undefined} 
+        aria-invalid={!isFolderMode && query && matchCount === 0 ? "true" : undefined} 
       />
 
      {query && !isFolderMode && (
@@ -110,6 +113,7 @@ export function SearchBar({
             </>
           )}
           <button
+            type='button'
             onClick={onClose}
             aria-label="Close search"
             className={newButtonClass(false)}
@@ -119,9 +123,9 @@ export function SearchBar({
         </div>
       </div>
       {isFolderMode && (
-        <div className="mt-2 max-h-80 overflow-y-auto border-t border-border-theme pt-2">
+        <div role="region" aria-label="Folder search results" className="mt-2 max-h-80 overflow-y-auto border-t border-border-theme pt-2">
           {!hasFolder && (
-            <div className="px-2 py-3 text-sm text-text-muted">
+            <div role="status" aria-live="polite" className="px-2 py-3 text-sm text-text-muted">
               Open a folder to search.
             </div>
           )}
@@ -142,6 +146,7 @@ export function SearchBar({
             <button
               key={`${result.filePath}:${result.line}:${result.preview}`}
               type="button"
+              aria-label={`Open file ${result.fileName} at line ${result.line}, match preview: ${result.preview}`}
               className="block w-full rounded px-2 py-2 text-left hover:bg-accent-bg"
               onClick={() => onOpenFolderResult?.(result)}
             >

--- a/apps/renderer/src/components/SettingsPanel.tsx
+++ b/apps/renderer/src/components/SettingsPanel.tsx
@@ -54,7 +54,7 @@ export function SettingsPanel({
         <div className="space-y-5 p-4">
           <fieldset>
             <legend className="mb-2 text-sm font-medium text-text-base">Reading width</legend>
-            <div className="grid grid-cols-3 gap-2">
+            <div className="grid grid-cols-3 gap-2" role="radiogroup" aria-label="Reading width choices">
               {(['narrow', 'default', 'wide'] as const).map((width) => (
                 <label
                   key={width}
@@ -68,7 +68,7 @@ export function SettingsPanel({
                     onChange={() => onChange({ readingWidth: width })}
                   />
                   <span className="capitalize">{width}</span>
-                  <span className="text-xs text-text-muted">{WIDTH_MAP[width]}</span>
+                  <span className="text-xs text-text-muted" aria-label={`Width value: ${WIDTH_MAP[width]}`}>{WIDTH_MAP[width]}</span>
                 </label>
               ))}
             </div>
@@ -89,13 +89,14 @@ export function SettingsPanel({
               value={settings.customCss}
               onChange={(event) => onChange({ customCss: event.target.value })}
               rows={8}
-              aria-label="Custom CSS"
+              aria-labelledby="custom-css-title"
               className="w-full resize-y rounded border border-border-theme bg-surface p-3 font-mono text-sm text-text-base outline-none focus:ring-2 focus:ring-accent"
               placeholder="Add custom reader CSS here "
             />
+            <span id="custom-css-title" className="sr-only">Custom CSS input editor</span> 
           </label>
 
-          {appVersion && <p className="text-xs text-text-muted">Version {appVersion}</p>}
+          {appVersion && <p className="text-xs text-text-muted" aria-label={`Application Version ${appVersion}`}>Version {appVersion}</p>}
         </div>
       </section>
     </div>

--- a/apps/renderer/src/components/StatusBar.tsx
+++ b/apps/renderer/src/components/StatusBar.tsx
@@ -7,9 +7,9 @@ export function StatusBar({ filePath, theme, fontSize }: StatusBarProps) {
   const displayName = filePath ? basename(filePath) : '_';
 
   return (
-    <footer className="flex h-8 shrink-0 items-center justify-between border-t border-border-theme bg-surface px-4 text-[11px] text-text-muted backdrop-blur">
+    <footer role="status" aria-live="polite"  className="flex h-8 shrink-0 items-center justify-between border-t border-border-theme bg-surface px-4 text-[11px] text-text-muted backdrop-blur">
       <div className="flex min-w-0 items-center gap-2">
-        <div className="h-2 w-2 rounded-full bg-accent"/>
+        <div aria-hidden="true" className="h-2 w-2 rounded-full bg-accent"/>
         <span className="truncate  hover:text-text-base" title={filePath}>
           {displayName}
         </span>
@@ -18,9 +18,9 @@ export function StatusBar({ filePath, theme, fontSize }: StatusBarProps) {
       <div className="flex items-center gap-4">
         <div className="flex items-center gap-1 rounded-md px-2 py-1">
           {theme === 'github-dark' ||theme === 'dracula' ||theme === 'nord' ? (
-            <Icons.Moon size={13} />
+            <Icons.Moon aria-hidden="true" size={13} />
           ) : (
-            <Icons.Sun size={13} />
+            <Icons.Sun aria-hidden="true" size={13} />
           )}
 
           <span className="capitalize">
@@ -28,7 +28,7 @@ export function StatusBar({ filePath, theme, fontSize }: StatusBarProps) {
           </span>
         </div>
         <div className="flex items-center gap-1 rounded-md px-2 py-1">
-          <Icons.ZoomIn size={13} />
+          <Icons.ZoomIn aria-hidden="true" size={13} />
           <span>{zoomPercent}%</span>
         </div>
       </div>

--- a/apps/renderer/src/components/TabBar.tsx
+++ b/apps/renderer/src/components/TabBar.tsx
@@ -1,7 +1,7 @@
 import type { TabBarProps } from '../types/component-types';
 import { Icons } from '../utils/constants/icon-contants';
 
-export function TabBar({ tabs, activeTabId, onSwitch, onClose }: TabBarProps) {
+export function TabBar({ tabs, activeTabId, onSwitch, onClose ,plusOpen}: TabBarProps) {
   if (tabs.length === 0) return null;
 
   return (
@@ -33,7 +33,7 @@ export function TabBar({ tabs, activeTabId, onSwitch, onClose }: TabBarProps) {
               ].join(' ')}
             >
               <span className="truncate">{tab.fileName}</span>
-            </button>
+            </button>   
 
             <button
               type="button"
@@ -46,9 +46,19 @@ export function TabBar({ tabs, activeTabId, onSwitch, onClose }: TabBarProps) {
             >
               <Icons.X size={13} />
             </button>
-          </div>
+          </div>          
         );
       })}
+      <div className="flex shrink-0 items-center pl-1">
+        <button 
+          type="button"
+          onClick={plusOpen}
+          aria-label="Open new tab"
+          className="flex h-7 w-7 items-center justify-center rounded-md text-text-muted transition-all hover:bg-accent-bg hover:text-text-base"
+        >
+          <Icons.Plus size={16} />
+        </button>
+      </div>
     </div>
   );
 }

--- a/apps/renderer/src/components/TabBar.tsx
+++ b/apps/renderer/src/components/TabBar.tsx
@@ -7,6 +7,7 @@ export function TabBar({ tabs, activeTabId, onSwitch, onClose ,plusOpen}: TabBar
   return (
     <div
       role="tablist"
+      aria-label="Document tabs"
       className="flex h-11 shrink-0 items-center overflow-x-auto border-b border-border-theme bg-surface px-2"
     >
       {tabs.map((tab) => {
@@ -22,8 +23,11 @@ export function TabBar({ tabs, activeTabId, onSwitch, onClose ,plusOpen}: TabBar
           >
             <button
               role="tab"
-              aria-current={isActive ? 'true' : undefined}
+              id={`tab-${tab.id}`}
+              aria-selected={isActive}
+              aria-controls={`tabpanel-${tab.id}`}
               aria-label={tab.fileName}
+              tabIndex={isActive ? 0 : -1}
               onClick={() => onSwitch(tab.id)}
               className={[
                 'flex h-10 items-center truncate px-4 text-sm transition-colors',
@@ -37,7 +41,7 @@ export function TabBar({ tabs, activeTabId, onSwitch, onClose ,plusOpen}: TabBar
 
             <button
               type="button"
-              aria-label="close tab"
+              aria-label={`Close ${tab.fileName} tab`}
               onClick={(event) => {
                 event.stopPropagation();
                 onClose(tab.id);

--- a/apps/renderer/src/components/Toast.tsx
+++ b/apps/renderer/src/components/Toast.tsx
@@ -13,7 +13,7 @@ export function Toast({ message, show, onDone, duration = 2000 }: ToastProps) {
   if (!show) return null;
 
   return (
-    <div className="fixed top-4 right-4 z-50 bg-toast-bg text-white px-4 py-2 rounded-lg text-sm shadow-lg">
+    <div role="status" aria-live="polite" className="fixed top-4 right-4 z-50 bg-toast-bg text-white px-4 py-2 rounded-lg text-sm shadow-lg">
       {message}
     </div>
   );

--- a/apps/renderer/src/components/UpdateBanner.tsx
+++ b/apps/renderer/src/components/UpdateBanner.tsx
@@ -4,9 +4,10 @@ import { Icons } from '../utils/constants/icon-contants';
 export function UpdateBanner() {
   const [updateVersion, setUpdateVersion] = useState<string | null>(null);
   useEffect(() => {
-    window.api.onUpdateAvailable((version: string) => {
+    const removeUpdateAvailable=window.api.onUpdateAvailable((version: string) => {
       setUpdateVersion(version);
     });
+    return removeUpdateAvailable;
   }, []);
   if (!updateVersion) {
     return null;

--- a/apps/renderer/src/components/UpdateBanner.tsx
+++ b/apps/renderer/src/components/UpdateBanner.tsx
@@ -4,6 +4,7 @@ import { Icons } from '../utils/constants/icon-contants';
 export function UpdateBanner() {
   const [updateVersion, setUpdateVersion] = useState<string | null>(null);
   useEffect(() => {
+    if(!window.api?.onUpdateAvailable) return;
     const removeUpdateAvailable=window.api.onUpdateAvailable((version: string) => {
       setUpdateVersion(version);
     });

--- a/apps/renderer/src/components/UpdateBanner.tsx
+++ b/apps/renderer/src/components/UpdateBanner.tsx
@@ -15,7 +15,7 @@ export function UpdateBanner() {
   }
 
   return (
-    <div className="bg-accent-bg border-b border-border-theme px-4 py-2 flex items-center gap-3 text-sm">
+    <div role="region" aria-label="Application update banner" className="bg-accent-bg border-b border-border-theme px-4 py-2 flex items-center gap-3 text-sm">
       <span className="text-text-base font-medium">
         Update available: v{updateVersion}
       </span>
@@ -25,6 +25,7 @@ export function UpdateBanner() {
           void window.api.downloadUpdate();
         }}
         className="text-accent hover:underline"
+        aria-label={`Download update version ${updateVersion} and install on quit`}
       >
         Download & install on quit
       </button>

--- a/apps/renderer/src/hooks/useFolderSearch.ts
+++ b/apps/renderer/src/hooks/useFolderSearch.ts
@@ -1,4 +1,4 @@
-import { useCallback, useState, useRef } from 'react';
+import { useCallback, useState, useRef, useEffect } from 'react';
 import { FolderSearchResult } from '@package/shared-types';
 
 export function useFolderSearch(folderPath: string | null) {
@@ -38,6 +38,12 @@ export function useFolderSearch(folderPath: string | null) {
     },
     [folderPath]
   );
+
+  useEffect(() => {
+    return () => {
+      requestId.current += 1;
+    };
+  }, []);
 
   return {
     isFolderSearchOpen,

--- a/apps/renderer/src/hooks/useSettings.ts
+++ b/apps/renderer/src/hooks/useSettings.ts
@@ -56,19 +56,19 @@ export function useSettings() {
   }, []);
 
   const increaseFontSize = useCallback(() => {
-    void updateSettings({
+    return updateSettings({
       fontSize: Math.min(FONT_SIZE.MAX, settings.fontSize + FONT_SIZE.INCREMENT),
     });
   }, [settings.fontSize, updateSettings]);
 
   const decreaseFontSize = useCallback(() => {
-    void updateSettings({
+    return updateSettings({
       fontSize: Math.max(FONT_SIZE.MIN, settings.fontSize - FONT_SIZE.INCREMENT),
     });
   }, [settings.fontSize, updateSettings]);
 
   const resetFontSize = useCallback(() => {
-    void updateSettings({ fontSize: FONT_SIZE.DEFAULT });
+    return updateSettings({ fontSize: FONT_SIZE.DEFAULT });
   }, [updateSettings]);
 
   return {

--- a/apps/renderer/src/hooks/useSettings.ts
+++ b/apps/renderer/src/hooks/useSettings.ts
@@ -40,24 +40,6 @@ export function useSettings() {
     style.textContent = settings.customCss || '';
   }, [settings.customCss]);
 
-  const increaseFontSize = useCallback(() => {
-    setSettings((current) => ({
-      ...current,
-      fontSize: Math.min(FONT_SIZE.MAX, current.fontSize + FONT_SIZE.INCREMENT),
-    }));
-  }, []);
-
-  const decreaseFontSize = useCallback(() => {
-    setSettings((current) => ({
-      ...current,
-      fontSize: Math.max(FONT_SIZE.MIN, current.fontSize - FONT_SIZE.INCREMENT),
-    }));
-  }, []);
-
-  const resetFontSize = useCallback(() => {
-    setSettings((current) => ({ ...current, fontSize: FONT_SIZE.DEFAULT }));
-  }, []);
-
   const updateSettings = useCallback(async (partial: Partial<AppSettings>) => {
     if (!window.api) {
       setSettings((current) => ({ ...current, ...partial }));
@@ -67,10 +49,28 @@ export function useSettings() {
     try {
       const next = await window.api.saveSettings(partial);
       setSettings(next);
-    } catch {
-      setSettings((current) => ({ ...current, ...partial }));
+    } catch (error) {
+      console.error('Failed to save settings:', error);
+      throw error;
     }
   }, []);
+
+  const increaseFontSize = useCallback(() => {
+    void updateSettings({
+      fontSize: Math.min(FONT_SIZE.MAX, settings.fontSize + FONT_SIZE.INCREMENT),
+    });
+  }, [settings.fontSize, updateSettings]);
+
+  const decreaseFontSize = useCallback(() => {
+    void updateSettings({
+      fontSize: Math.max(FONT_SIZE.MIN, settings.fontSize - FONT_SIZE.INCREMENT),
+    });
+  }, [settings.fontSize, updateSettings]);
+
+  const resetFontSize = useCallback(() => {
+    void updateSettings({ fontSize: FONT_SIZE.DEFAULT });
+  }, [updateSettings]);
+
   return {
     settings,
     fontSize,

--- a/apps/renderer/src/hooks/useShortcuts.ts
+++ b/apps/renderer/src/hooks/useShortcuts.ts
@@ -73,12 +73,14 @@ export function useShortcuts({
         return;
       }
 
-      if (e.key === '[') {
+      if (mod && e.key === '[') {
+        e.preventDefault();
         onToggleSidebar();
         return;
       }
 
-      if (e.key === '\\') {
+      if (mod && e.key === '\\') {
+        e.preventDefault();
         onToggleFileBrowser();
         return;
       }

--- a/apps/renderer/src/main.tsx
+++ b/apps/renderer/src/main.tsx
@@ -7,13 +7,16 @@ import "./index.css";
 import { ThemeProvider } from './context/ThemeProvider'
 import 'katex/dist/katex.min.css';
 import { TabProvider } from './context/TabProvider';
+import { ErrorBoundary } from './components/ErrorBoundary';
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
+    <ErrorBoundary>
     <ThemeProvider>
       <TabProvider>
         <App />
       </TabProvider>
     </ThemeProvider>
+    </ErrorBoundary>
   </StrictMode>
 )

--- a/apps/renderer/src/types/component-types.ts
+++ b/apps/renderer/src/types/component-types.ts
@@ -108,6 +108,7 @@ export interface TabBarProps {
   activeTabId: string | null;
   onSwitch: (id: string) => void;
   onClose: (id: string) => void;
+  plusOpen: () => void;
 }
 
 export interface Tab {

--- a/apps/renderer/src/types/component-types.ts
+++ b/apps/renderer/src/types/component-types.ts
@@ -183,3 +183,8 @@ export interface SettingsPanelProps {
   onChange: (settings: Partial<AppSettings>) => void;
   appVersion?: string;
 }
+
+export type ErrorBoundaryState = {
+  hasError: boolean;
+  error: Error | null;
+};

--- a/apps/renderer/src/utils/constants/icon-contants.tsx
+++ b/apps/renderer/src/utils/constants/icon-contants.tsx
@@ -155,7 +155,19 @@ const ArrowDown = ({ size = 20, ...props }: IconProps) => (
   </svg>
 );
 
+const Plus = ({ size = 20, ...props }: IconProps) => (
+  <svg
+    width={size}
+    height={size}
+    viewBox="0 0 24 24"
+    {...defaultProps}
+    {...props}
+  >
+    <line x1="12" y1="5" x2="12" y2="19" />
+    <line x1="5" y1="12" x2="19" y2="12" />
+  </svg>
+);
 
 export const Icons = {
-X,Hamburger,ZoomIn,ZoomOut,Sun,Moon,Folder,ChevronRight,ChevronDown,ArrowUp,ArrowDown
+X,Hamburger,ZoomIn,ZoomOut,Sun,Moon,Folder,ChevronRight,ChevronDown,ArrowUp,ArrowDown,Plus
 };

--- a/apps/renderer/src/utils/helpers/heading-helper.ts
+++ b/apps/renderer/src/utils/helpers/heading-helper.ts
@@ -14,10 +14,10 @@ export function getHeadingId(text: string): string {
 
 // assigns id to the headings
 export function heading({ text, depth }: HeadingProps) {
-  const plainText = stripHtml(text);
-  const id = getHeadingId(plainText);
-  const safeText = escapeHtml(plainText);
-  return `<h${depth} id="${id}">${safeText}</h${depth}>\n`;
+  const parsedInline = parseInline(text) as string;
+  const idText = decodeHtml(stripHtml(parsedInline));
+  const id = getHeadingId(idText);
+  return `<h${depth} id="${id}">${parseInline}</h${depth}>\n`;
 }
 
 //removes inline html
@@ -28,7 +28,7 @@ export function stripHtml(html: string): string {
 
 export function headingText(token: Tokens.Heading): string {
   const inlineHtml = parseInline(token.text) as string;
-  return stripHtml(inlineHtml).trim();
+  return decodeHtml(stripHtml(inlineHtml).trim());
 }
 
 export function isHeadingToken(token: unknown): token is Tokens.Heading {

--- a/apps/renderer/src/utils/helpers/heading-helper.ts
+++ b/apps/renderer/src/utils/helpers/heading-helper.ts
@@ -14,10 +14,10 @@ export function getHeadingId(text: string): string {
 
 // assigns id to the headings
 export function heading({ text, depth }: HeadingProps) {
-  const parsedInline = parseInline(text) as string;
-  const idText = decodeHtml(stripHtml(parsedInline));
-  const id = getHeadingId(idText);
-  return `<h${depth} id="${id}">${parseInline}</h${depth}>\n`;
+  const plainText = stripHtml(text);
+  const id = getHeadingId(plainText);
+  const safeText = escapeHtml(plainText);
+  return `<h${depth} id="${id}">${safeText}</h${depth}>\n`;
 }
 
 //removes inline html
@@ -28,7 +28,7 @@ export function stripHtml(html: string): string {
 
 export function headingText(token: Tokens.Heading): string {
   const inlineHtml = parseInline(token.text) as string;
-  return decodeHtml(stripHtml(inlineHtml).trim());
+  return stripHtml(inlineHtml).trim();
 }
 
 export function isHeadingToken(token: unknown): token is Tokens.Heading {

--- a/docs/src/components/Homepage/hero.tsx
+++ b/docs/src/components/Homepage/hero.tsx
@@ -53,7 +53,7 @@ export function HeroSection() {
                   </Link>
 
                   <a
-                    href="/docs/introduction"
+                    href="https://github.com/mindfiredigital/markdown-reader"
                     className="no-underline"
                     target="_blank"
                     rel="noreferrer"

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
   },
   "pnpm": {
     "overrides": {
-      "serialize-javascript": ">=7.0.3",
+      "serialize-javascript": ">=7.0.5",
       "fast-uri": ">=3.1.2",
       "tmp": ">=0.2.6"
     }

--- a/packages/shared-types/src/markdown-type.ts
+++ b/packages/shared-types/src/markdown-type.ts
@@ -29,6 +29,6 @@ export type MarkdownReaderAPI = {
   exportPDF(html: string, css: string, outputPath: string): Promise<void>;
   exportDOCX(html: string, css: string, outputPath: string): Promise<void>;
   getPathForFile(file: File): string;
-  onUpdateAvailable: (callback: (version: string) => void) => void;
+  onUpdateAvailable: (callback: (version: string) => void) => () => void;
   downloadUpdate: () => void;
 };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,7 +5,7 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
-  serialize-javascript: '>=7.0.3'
+  serialize-javascript: '>=7.0.5'
   fast-uri: '>=3.1.2'
   tmp: '>=0.2.6'
 


### PR DESCRIPTION
## Description

This PR fixes ipc clean up issues and package override issues.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor (no functional change)
- [ ] Documentation update
- [ ] Style / UI change
- [ ] Build / CI change



## Checklist

- [x] My code follows the project's coding guidelines
- [x] I have tested my changes locally
- [x] I have used [conventional commit](https://www.conventionalcommits.org/) messages
- [ ] I have updated documentation if needed
- [x] My changes do not introduce new warnings or errors


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Electron main/preload
- IPC security hardening: `SEARCH_FOLDER` resolves the folder and rejects requests unless the path is already authorized (no longer auto-adds resolved folder paths to `allowedFolderRoots`).
- Sender validation tightened: `validateSender` now parses `event.senderFrame?.url` and accepts only `file:` URLs or `http:` with hostname `localhost` (removed startsWith whitelist).
- File watcher robustness: `watchFile` stores the watcher before awaiting readiness, centralizes error handling (normalizes errors, unwatches on error), and ensures `onDeleted` runs even if unwatch fails.
- Preload update subscription: `apiContract.onUpdateAvailable` registers a named handler and now returns an unsubscribe function for proper removal.

## Renderer UI
- UpdateBanner: guards against missing `window.api.onUpdateAvailable` and uses the returned unsubscribe for cleanup; adds ARIA attributes.
- Tab bar: `TabBar` accepts a new `plusOpen` prop and renders a plus button that calls it to open files; accessibility attributes added to tabs and close buttons.
- FileBrowser: removed hamburger icon; header shows only “Explorer”.
- Shortcuts: `useShortcuts` now requires modifier key (mod) for `[` and `\` shortcuts and prevents default for `[` (behavior changed).
- useFolderSearch: registers unmount cleanup that increments `requestId` to ignore stale in-flight results.
- useSettings (renderer): on save failure, errors are logged and rethrown; font-size actions compute next size from `settings.fontSize` and include it in dependencies.
- Multiple UI components: numerous accessibility improvements (aria roles/labels) across UpdateBanner, DragDrop, Error, FileTree, Loading, ReaderToolbar, SearchBar, SettingsPanel, StatusBar, Toast.

## Markdown rendering
- DOCX export: `exportDOCX` inlines referenced images before building document markup.
- PDF export: PDF rendering `BrowserWindow` uses `webPreferences.sandbox: true`.
- CSS sanitization: `sanitizeCss` repeatedly strips dangerous CSS patterns until a fixed point is reached.

## Shared packages
- API type change: `packages/shared-types` updates `MarkdownReaderAPI.onUpdateAvailable` to return an unsubscribe function `() => void` instead of `void`.

## Tests
- Test environment: `apps/renderer/setup.ts` mocks `window.api` using Vitest `vi` with async `getSettings`/`saveSettings`.
- Hook/component tests updated: `useSettings` tests use `await act(async ...)`; `TabBar` tests updated to match new accessibility attributes.

## Tooling/CI
- GitHub Actions: removed pinned `pnpm` version from `.github/workflows/production.yml` (now relies on the action default for pnpm).
- Release workflow: `.github/workflows/release.yml` adds `env: HUSKY=0` to disable Husky during workflow runs.
- package.json pnpm overrides: `serialize-javascript` override bumped from `>=7.0.3` to `>=7.0.5`.

## Docs
- Homepage: GitHub button now points to the external GitHub repository URL.

## Packaging
- No user-facing packaging behavior changes beyond the pnpm override bump.

Breaking changes:
- `onUpdateAvailable` API (shared types + preload) now returns an unsubscribe function `() => void`; callers expecting `void` must handle/use the returned unsubscriber.
- `SEARCH_FOLDER` IPC behavior changed: folder paths are no longer auto-registered; requests for folder paths not already present in `allowedFolderRoots` are rejected.
- Keyboard shortcuts for `[` and `\` now require the modifier key (mod); existing shortcut behavior for these keys has changed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->