### PR TITLE
Feature/extension

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # Dependencies
 node_modules/
+**/node_modules/
 
 # Build outputs
 out/

--- a/apps/extension/manifest.json
+++ b/apps/extension/manifest.json
@@ -1,0 +1,26 @@
+{
+  "manifest_version": 3,
+  "name": "Markdown Reader",
+  "description": "Read and render Markdown files in Chrome.",
+  "version": "1.0.0",
+  "action": {
+    "default_title": "Markdown Reader",
+    "default_icon": {
+      "16": "icons/icon-16x16px.png",
+      "32": "icons/icon-32x32px.png",
+      "48": "icons/icon-48x48px.png",
+      "128": "icons/icon-128x128px.png"
+    }
+  },
+  "background": {
+    "service_worker": "background.js",
+    "type": "module"
+  },
+  "permissions": ["storage"],
+  "icons": {
+    "16": "icons/icon-16x16px.png",
+    "32": "icons/icon-32x32px.png",
+    "48": "icons/icon-48x48px.png",
+    "128": "icons/icon-128x128px.png"
+  }
+}

--- a/apps/extension/package.json
+++ b/apps/extension/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "extension",
+  "version": "1.0.0",
+  "description": "Chrome extension for markdown reader",
+  "main": "index.js",
+  "scripts": {
+    "build": "vite build --config vite.config.ts",
+    "typecheck": "tsc --noEmit",
+    "lint": "eslint ."
+  },
+  "type": "module",
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "packageManager": "pnpm@10.33.0",
+  "dependencies": {
+    "@package/platform-adapters": "workspace:*"
+  }
+}

--- a/apps/extension/popup.html
+++ b/apps/extension/popup.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html>
+<html lang="en">
   <head>
     <meta charset="UTF-8" />
     <title>Markdown Reader</title>
@@ -8,7 +8,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta
       http-equiv="Content-Security-Policy"
-      content="default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; font-src 'self' data:"
+      content="default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; font-src 'self' data:; connect-src 'self'; object-src 'none'; frame-src 'none'; base-uri 'self';"
     />
   </head>
 

--- a/apps/extension/popup.html
+++ b/apps/extension/popup.html
@@ -1,0 +1,19 @@
+<!doctype html>
+<html>
+  <head>
+    <meta charset="UTF-8" />
+    <title>Markdown Reader</title>
+    <link rel="icon" type="image/svg+xml" href="../renderer/public/icons/app-icon.svg" />
+    <meta name="description" content="A beautiful, offline-first Markdown reader" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta
+      http-equiv="Content-Security-Policy"
+      content="default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; font-src 'self' data:"
+    />
+  </head>
+
+  <body>
+    <div id="root"></div>
+    <script type="module" src="./src/popup/popup.ts"></script>
+  </body>
+</html>

--- a/apps/extension/src/background.ts
+++ b/apps/extension/src/background.ts
@@ -12,7 +12,11 @@ if (!runtime?.onMessage) {
 // extension opens the full reader tab
 chromeApi?.action?.onClicked.addListener(() => {
   const viewerUrl = runtime.getURL('viewer.html');
-  void chromeApi.tabs?.create({ url: viewerUrl });
+  if (chromeApi?.tabs) {
+    Promise.resolve(chromeApi.tabs.create({ url: viewerUrl })).catch((error) => {
+      console.error('Failed to create tab:', error);
+    });
+  }
 });
 
 // listens for any messages coming from our React ui, checks if they are valid and passes them to handler.

--- a/apps/extension/src/background.ts
+++ b/apps/extension/src/background.ts
@@ -1,0 +1,35 @@
+import { handleExtensionMessage, isExtensionMessage } from './utils/helpers/message-handler';
+import type { ChromeExtensionApi, SendResponse } from './types';
+
+// Collects the global chrome api ,so extension background worker doesn't crash
+const chromeApi = (globalThis as typeof globalThis & { chrome?: ChromeExtensionApi }).chrome;
+const runtime = chromeApi?.runtime;
+
+if (!runtime?.onMessage) {
+  throw new Error('Chrome runtime messaging is unavailable.');
+}
+
+// extension opens the full reader tab
+chromeApi?.action?.onClicked.addListener(() => {
+  const viewerUrl = runtime.getURL('viewer.html');
+  void chromeApi.tabs?.create({ url: viewerUrl });
+});
+
+// listens for any messages coming from our React ui, checks if they are valid and passes them to handler.
+runtime.onMessage.addListener((message: unknown, _sender: unknown, sendResponse: SendResponse) => {
+  if (!isExtensionMessage(message)) {
+    sendResponse({ ok: false, error: 'Invalid extension message.' });
+    return false;
+  }
+
+  void handleExtensionMessage(message)
+    .then(sendResponse)
+    .catch((error: unknown) => {
+      sendResponse({
+        ok: false,
+        error: error instanceof Error ? error.message : String(error),
+      });
+    });
+
+  return true;
+});

--- a/apps/extension/src/popup/popup.css
+++ b/apps/extension/src/popup/popup.css
@@ -10,5 +10,5 @@ body,
 }
 
 body {
-  background: var(--color-bg);
+  background: var(--color-bg, #ffffff);
 }

--- a/apps/extension/src/popup/popup.css
+++ b/apps/extension/src/popup/popup.css
@@ -1,0 +1,14 @@
+html,
+body,
+#root {
+  width: 780px;
+  height: 560px;
+  min-width: 780px;
+  min-height: 560px;
+  margin: 0;
+  overflow: hidden;
+}
+
+body {
+  background: var(--color-bg);
+}

--- a/apps/extension/src/popup/popup.ts
+++ b/apps/extension/src/popup/popup.ts
@@ -1,0 +1,2 @@
+import '../../../renderer/src/main';
+import './popup.css';

--- a/apps/extension/src/types.ts
+++ b/apps/extension/src/types.ts
@@ -1,0 +1,40 @@
+import type { PlatformMessage } from '@package/platform-adapters';
+
+export type ExtensionMessage = PlatformMessage<Record<string, unknown>>;
+
+export type ExtensionMessageResponse<TData = unknown> =
+  | {
+      ok: true;
+      data: TData;
+    }
+  | {
+      ok: false;
+      error: string;
+    };
+
+export type SendResponse = (response: ExtensionMessageResponse) => void;
+
+export type ChromeRuntime = {
+  getURL(path: string): string;
+  onMessage: {
+    addListener(
+      listener: (message: unknown, sender: unknown, sendResponse: SendResponse) => boolean | void
+    ): void;
+  };
+};
+
+export type ChromeAction = {
+  onClicked: {
+    addListener(listener: () => void): void;
+  };
+};
+
+export type ChromeTabs = {
+  create(properties: { url: string }): Promise<unknown> | void;
+};
+
+export type ChromeExtensionApi = {
+  runtime?: ChromeRuntime;
+  action?: ChromeAction;
+  tabs?: ChromeTabs;
+};

--- a/apps/extension/src/utils/helpers/message-handler.ts
+++ b/apps/extension/src/utils/helpers/message-handler.ts
@@ -1,0 +1,45 @@
+import { CHROME_MESSAGE_TYPES } from '@package/platform-adapters';
+import type { ExtensionMessage, ExtensionMessageResponse } from '../../types';
+
+// List of all desktop stuff that browser extensions simply aren't allowed to touch
+const unsupportedDesktopOperations = new Set<string>([
+  CHROME_MESSAGE_TYPES.READ_FILE,
+  CHROME_MESSAGE_TYPES.OPEN_FILE_DIALOG,
+  CHROME_MESSAGE_TYPES.OPEN_FOLDER_DIALOG,
+  CHROME_MESSAGE_TYPES.READ_FOLDER,
+  CHROME_MESSAGE_TYPES.SEARCH_FOLDER,
+  CHROME_MESSAGE_TYPES.WATCH_FILE,
+  CHROME_MESSAGE_TYPES.UNWATCH_FILE,
+  CHROME_MESSAGE_TYPES.SHOW_SAVE_DIALOG,
+  CHROME_MESSAGE_TYPES.EXPORT_HTML,
+  CHROME_MESSAGE_TYPES.EXPORT_PDF,
+  CHROME_MESSAGE_TYPES.EXPORT_DOCX,
+  CHROME_MESSAGE_TYPES.DOWNLOAD_UPDATE,
+]);
+
+// It catches incoming messages from the UI and blocks them if they ask for desktop only features
+export async function handleExtensionMessage(
+  message: ExtensionMessage
+): Promise<ExtensionMessageResponse> {
+  if (unsupportedDesktopOperations.has(message.type)) {
+    return {
+      ok: false,
+      error: `${message.type} is not available in the Chrome extension background worker yet.`,
+    };
+  }
+
+  return {
+    ok: false,
+    error: `Unsupported extension message type: ${message.type}`,
+  };
+}
+
+// checks if the message object has a valid type string before read
+export function isExtensionMessage(message: unknown): message is ExtensionMessage {
+  return (
+    typeof message === 'object' &&
+    message !== null &&
+    'type' in message &&
+    typeof (message as { type?: unknown }).type === 'string'
+  );
+}

--- a/apps/extension/src/viewer/viewer.css
+++ b/apps/extension/src/viewer/viewer.css
@@ -1,0 +1,14 @@
+html,
+body,
+#root {
+  width: 100%;
+  min-width: 100%;
+  height: 100%;
+  min-height: 100%;
+  margin: 0;
+}
+
+body {
+  overflow: hidden;
+  background: var(--color-bg);
+}

--- a/apps/extension/src/viewer/viewer.css
+++ b/apps/extension/src/viewer/viewer.css
@@ -10,5 +10,5 @@ body,
 
 body {
   overflow: hidden;
-  background: var(--color-bg);
+  background: var(--color-bg, #ffffff);
 }

--- a/apps/extension/src/viewer/viewer.ts
+++ b/apps/extension/src/viewer/viewer.ts
@@ -1,0 +1,2 @@
+import '../../../renderer/src/main';
+import './viewer.css';

--- a/apps/extension/tsconfig.json
+++ b/apps/extension/tsconfig.json
@@ -8,6 +8,6 @@
     "moduleResolution": "Bundler",
     "types": ["vite/client"]
   },
-  "include": ["src", "vite.config.ts", "../../renderer/src"],
+  "include": ["src", "vite.config.ts", "../renderer/src"],
   "exclude": ["node_modules", "dist"]
 }

--- a/apps/extension/tsconfig.json
+++ b/apps/extension/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "jsx": "react-jsx",
+    "rootDir": "../../../",
+    "outDir": "./dist",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "types": ["vite/client"]
+  },
+  "include": ["src", "vite.config.ts", "../../renderer/src"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/apps/extension/viewer.html
+++ b/apps/extension/viewer.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html>
+<html lang="en">
   <head>
     <meta charset="UTF-8" />
     <title>Markdown Reader</title>
@@ -8,7 +8,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta
       http-equiv="Content-Security-Policy"
-      content="default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; font-src 'self' data:"
+      content="default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; font-src 'self' data:; connect-src 'self'; object-src 'none'; frame-src 'none'; base-uri 'self';"
     />
   </head>
 

--- a/apps/extension/viewer.html
+++ b/apps/extension/viewer.html
@@ -1,0 +1,19 @@
+<!doctype html>
+<html>
+  <head>
+    <meta charset="UTF-8" />
+    <title>Markdown Reader</title>
+    <link rel="icon" type="image/svg+xml" href="../renderer/public/icons/app-icon.svg" />
+    <meta name="description" content="A beautiful, offline-first Markdown reader" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta
+      http-equiv="Content-Security-Policy"
+      content="default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; font-src 'self' data:"
+    />
+  </head>
+
+  <body>
+    <div id="root"></div>
+    <script type="module" src="./src/viewer/viewer.ts"></script>
+  </body>
+</html>

--- a/apps/extension/vite.config.ts
+++ b/apps/extension/vite.config.ts
@@ -25,7 +25,11 @@ export default defineConfig({
         try {
           cpSync(iconSourceDir, resolve(extensionOutDir, 'icons'), { recursive: true });
         } catch (e) {
-          console.warn('Icon directory not found, skipping copy step.');
+          if ((e as NodeJS.ErrnoException).code === 'ENOENT') {
+            console.warn('Icon directory not found, skipping copy step.');
+          } else {
+            throw e;
+          }
         }
       },
     },

--- a/apps/extension/vite.config.ts
+++ b/apps/extension/vite.config.ts
@@ -1,0 +1,55 @@
+import { copyFileSync, cpSync, mkdirSync } from 'fs';
+import { resolve } from 'path';
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+import tailwindcss from '@tailwindcss/vite';
+
+const chromeExtensionRoot = __dirname;
+const rendererRoot = resolve(chromeExtensionRoot, '../../renderer');
+const extensionOutDir = resolve(chromeExtensionRoot, '../../dist/extensions/chrome');
+const manifestSource = resolve(chromeExtensionRoot, 'manifest.json');
+const iconSourceDir = resolve(chromeExtensionRoot, '../../assets/icons');
+
+export default defineConfig({
+  root: chromeExtensionRoot,
+  base: './',
+  publicDir: resolve(rendererRoot, 'public'),
+  plugins: [
+    tailwindcss(),
+    react({}),
+    {
+      name: 'copy-chrome-extension-assets',
+      closeBundle() {
+        mkdirSync(extensionOutDir, { recursive: true });
+        copyFileSync(manifestSource, resolve(extensionOutDir, 'manifest.json'));
+        try {
+          cpSync(iconSourceDir, resolve(extensionOutDir, 'icons'), { recursive: true });
+        } catch (e) {
+          console.warn('Icon directory not found, skipping copy step.');
+        }
+      },
+    },
+  ],
+  build: {
+    outDir: extensionOutDir,
+    emptyOutDir: true,
+    sourcemap: false,
+    rollupOptions: {
+      input: {
+        popup: resolve(chromeExtensionRoot, 'popup.html'),
+        viewer: resolve(chromeExtensionRoot, 'viewer.html'),
+        background: resolve(chromeExtensionRoot, 'src/background.ts'),
+      },
+      output: {
+        entryFileNames: (chunkInfo) => {
+          if (chunkInfo.name === 'background') {
+            return 'background.js';
+          }
+          return 'assets/[name].js';
+        },
+        chunkFileNames: 'assets/[name]-[hash].js',
+        assetFileNames: 'assets/[name]-[hash][extname]',
+      },
+    },
+  },
+});

--- a/apps/main-processor/test-file.md
+++ b/apps/main-processor/test-file.md
@@ -1,0 +1,1 @@
+change before immediate unwatch

--- a/apps/main-processor/test-file.md
+++ b/apps/main-processor/test-file.md
@@ -1,1 +1,0 @@
-change before immediate unwatch

--- a/apps/renderer/__tests__/hooks/useSettings.test.ts
+++ b/apps/renderer/__tests__/hooks/useSettings.test.ts
@@ -1,54 +1,59 @@
 import { describe, it, expect, vi } from 'vitest';
-import { renderHook, act } from '@testing-library/react';
+import { renderHook, act, waitFor } from '@testing-library/react';
 import { useSettings } from '../../src/hooks/useSettings';
+import { createMockPlatform, createPlatformWrapper } from '../test-utils';
 
-vi.mock('../../src/hooks/useSettings', async (importOg) => {
-  return importOg();
-});
+function renderUseSettings(platform = createMockPlatform()) {
+  return renderHook(() => useSettings(), {
+    wrapper: createPlatformWrapper(platform),
+  });
+}
 
 describe('useSettings font size', () => {
-  it('should initialize with font size 16', () => {
-    const { result } = renderHook(() => useSettings());
-    expect(result.current.fontSize).toBe(16);
+  it('should initialize with font size 16', async () => {
+    const { result } = renderUseSettings();
+    await waitFor(() => {
+      expect(result.current.fontSize).toBe(16);
+    });
   });
 
   it('should increase font size by adding 2px', async () => {
-    const { result } = renderHook(() => useSettings());
+    const { result } = renderUseSettings();
     await act(async () => {
-      result.current.increaseFontSize();
+      await result.current.increaseFontSize();
     });
     expect(result.current.fontSize).toBe(18);
   });
 
-  it('should decrease font size by subracting 2px', async () => {
-    const { result } = renderHook(() => useSettings());
+  it('should decrease font size by subtracting 2px', async () => {
+    const { result } = renderUseSettings();
     await act(async () => {
-      result.current.decreaseFontSize();
+      await result.current.decreaseFontSize();
     });
     expect(result.current.fontSize).toBe(14);
   });
 
   it('should not exceed 24px', async () => {
-    const { result } = renderHook(() => useSettings());
+    const { result } = renderUseSettings();
 
-    for (let i = 0; i < 10; i++) {
+    for (let i = 0; i < 10; i += 1) {
       await act(async () => {
-        result.current.increaseFontSize();
+        await result.current.increaseFontSize();
       });
     }
 
     expect(result.current.fontSize).toBe(24);
   });
 
-  it('should return recent font size as 16', async () => {
-    const { result } = renderHook(() => useSettings());
+  it('should reset font size to 16', async () => {
+    const { result } = renderUseSettings();
 
     await act(async () => {
-      result.current.increaseFontSize();
+      await result.current.increaseFontSize();
     });
 
     await act(async () => {
-      result.current.resetFontSize();
+      await result.current.resetFontSize();
     });
 
     expect(result.current.fontSize).toBe(16);

--- a/apps/renderer/__tests__/test-utils.tsx
+++ b/apps/renderer/__tests__/test-utils.tsx
@@ -1,0 +1,55 @@
+import type { ReactNode } from 'react';
+import { vi } from 'vitest';
+import { DEFAULT_SETTINGS, type AppSettings } from '@package/shared-types';
+import type { PlatformAdapter } from '@package/platform-adapters';
+import { PlatformProvider } from '../src/context/PlatformProvider'
+
+export function createMockPlatform(settings: AppSettings = DEFAULT_SETTINGS): PlatformAdapter {
+  let savedSettings = settings;
+
+  return {
+    kind: 'electron',
+    storage: {
+      getItem: vi.fn(async () => null),
+      setItem: vi.fn(async () => undefined),
+      removeItem: vi.fn(async () => undefined),
+      clear: vi.fn(async () => undefined),
+    },
+    readFile: vi.fn(),
+    watchFile: vi.fn(),
+    unWatchFile: vi.fn(),
+    openFileDialog: vi.fn(),
+    openFolderDialog: vi.fn(),
+    readFolder: vi.fn(),
+    getRecentFiles: vi.fn(),
+    addRecentFile: vi.fn(),
+    clearRecentFiles: vi.fn(),
+    getSettings: vi.fn(async () => savedSettings),
+    saveSettings: vi.fn(async (partial) => {
+      savedSettings = { ...savedSettings, ...partial };
+      return savedSettings;
+    }),
+    getAppVersion: vi.fn(),
+    searchFolder: vi.fn(),
+    onFileChanged: vi.fn(),
+    removeFileChangedListener: vi.fn(),
+    onMenuEvent: vi.fn(() => vi.fn()),
+    removeMenuListeners: vi.fn(),
+    onOpenFilePath: vi.fn(),
+    removeOpenFilePathListener: vi.fn(),
+    showSaveDialog: vi.fn(),
+    exportHTML: vi.fn(),
+    exportPDF: vi.fn(),
+    exportDOCX: vi.fn(),
+    getPathForFile: vi.fn(),
+    onUpdateAvailable: vi.fn(() => vi.fn()),
+    downloadUpdate: vi.fn(),
+    sendMessage: vi.fn(),
+  } as PlatformAdapter;
+}
+
+export function createPlatformWrapper(platform: PlatformAdapter = createMockPlatform()) {
+  return function PlatformTestWrapper({ children }: { children: ReactNode }) {
+    return <PlatformProvider platform={platform}>{children}</PlatformProvider>;
+  };
+}

--- a/apps/renderer/package.json
+++ b/apps/renderer/package.json
@@ -18,6 +18,7 @@
   "dependencies": {
     "@package/shared-constants": "workspace:*",
     "@package/shared-types": "workspace:*",
+    "@package/platform-adapters": "workspace:*",
     "dompurify": "^3.4.0",
     "katex": "^0.16.45",
     "marked": "^18.0.0",

--- a/apps/renderer/src/App.tsx
+++ b/apps/renderer/src/App.tsx
@@ -57,7 +57,7 @@ export default function App() {
   const [appVersion, setAppVersion] = useState('');
 
   useEffect(()=>{
-    if(!api?.getAppVersion) return;
+    if(!api.getAppVersion) return;
     void api.getAppVersion().then(setAppVersion).catch(()=>{});
   },[api])
   

--- a/apps/renderer/src/App.tsx
+++ b/apps/renderer/src/App.tsx
@@ -31,8 +31,10 @@ import { ReaderToolbar } from './components/ReaderToolbar';
 import { useFolderSearch } from './hooks/useFolderSearch';
 import { SettingsPanel } from './components/SettingsPanel';
 import { ErrorBoundary } from './components/ErrorBoundary';
+import { usePlatformAPI } from './hooks/usePlatform';
 
 export default function App() {
+  const api = usePlatformAPI();
   const {  error, isLoading, openFile, toc,recentFiles,loadFile } =useFile();
   const { state, dispatch } = useTabStore();
   const activeTab = state.tabs.find((tab) => tab.id === state.activeTabId) ?? null;
@@ -55,9 +57,9 @@ export default function App() {
   const [appVersion, setAppVersion] = useState('');
 
   useEffect(()=>{
-    if(!window.api?.getAppVersion) return;
-    void window.api.getAppVersion().then(setAppVersion).catch(()=>{});
-  },[])
+    if(!api?.getAppVersion) return;
+    void api.getAppVersion().then(setAppVersion).catch(()=>{});
+  },[api])
   
   useEffect(()=>{
     if(folderTree){

--- a/apps/renderer/src/components/PlatformInitializer.tsx
+++ b/apps/renderer/src/components/PlatformInitializer.tsx
@@ -1,0 +1,21 @@
+import { useState } from "react";
+import {type PlatformAdapter } from "@package/platform-adapters";
+import App from "../App";
+import { ThemeProvider } from "../context/ThemeProvider";
+import { TabProvider } from "../context/TabProvider";
+import { PlatformProvider } from "../context/PlatformProvider";
+import { createPlatformAdapter } from "../utils/helpers/platform-helper";
+
+// handles runtime platform detection and sets cross platform application inside react lifecycle
+export function PlatformInitializer(){
+    const [platform]=useState<PlatformAdapter>(()=>createPlatformAdapter());
+    return(
+        <PlatformProvider platform={platform}>
+            <ThemeProvider>
+                <TabProvider>
+                    <App/>
+                </TabProvider>
+            </ThemeProvider>
+        </PlatformProvider>
+    );
+}

--- a/apps/renderer/src/components/UpdateBanner.tsx
+++ b/apps/renderer/src/components/UpdateBanner.tsx
@@ -6,7 +6,7 @@ export function UpdateBanner() {
   const [updateVersion, setUpdateVersion] = useState<string | null>(null);
   const api=usePlatformAPI();
   useEffect(() => {
-    if(!api?.onUpdateAvailable) return;
+    if(!api.onUpdateAvailable) return;
     const removeUpdateAvailable=api.onUpdateAvailable((version: string) => {
       setUpdateVersion(version);
     });

--- a/apps/renderer/src/components/UpdateBanner.tsx
+++ b/apps/renderer/src/components/UpdateBanner.tsx
@@ -1,15 +1,17 @@
 import { useEffect, useState } from 'react';
 import { Icons } from '../utils/constants/icon-contants';
+import { usePlatformAPI } from '../hooks/usePlatform';
 
 export function UpdateBanner() {
   const [updateVersion, setUpdateVersion] = useState<string | null>(null);
+  const api=usePlatformAPI();
   useEffect(() => {
-    if(!window.api?.onUpdateAvailable) return;
-    const removeUpdateAvailable=window.api.onUpdateAvailable((version: string) => {
+    if(!api?.onUpdateAvailable) return;
+    const removeUpdateAvailable=api.onUpdateAvailable((version: string) => {
       setUpdateVersion(version);
     });
     return removeUpdateAvailable;
-  }, []);
+  }, [api]);
   if (!updateVersion) {
     return null;
   }
@@ -22,7 +24,9 @@ export function UpdateBanner() {
       <button
         type="button"
         onClick={() => {
-          void window.api.downloadUpdate();
+          if (api.downloadUpdate) {
+            api.downloadUpdate();
+          }
         }}
         className="text-accent hover:underline"
         aria-label={`Download update version ${updateVersion} and install on quit`}

--- a/apps/renderer/src/context/PlatformProvider.tsx
+++ b/apps/renderer/src/context/PlatformProvider.tsx
@@ -1,0 +1,15 @@
+import React, { createContext} from 'react';
+import type { PlatformAdapter } from '@package/platform-adapters';
+
+export const PlatformContext = createContext<PlatformAdapter | null>(null);
+
+export function PlatformProvider({
+  platform,
+  children,
+}: {
+  platform: PlatformAdapter;
+  children: React.ReactNode;
+}) {
+  return <PlatformContext.Provider value={platform}>{children}</PlatformContext.Provider>;
+}
+

--- a/apps/renderer/src/hooks/useDragDrop.ts
+++ b/apps/renderer/src/hooks/useDragDrop.ts
@@ -1,8 +1,10 @@
 import React, { useState, useEffect, useCallback } from 'react';
 import { extractDroppedMdpath } from '../renderer/drag-drop';
+import { usePlatformAPI } from './usePlatform';
 
 export function useDragDrop(loadFileInTab: (path: string) => Promise<void>) {
   const [isDraggingFile, setIsDraggingFile] = useState(false);
+  const api = usePlatformAPI();
   useEffect(() => {
     const preventDefaultDrag = (e: DragEvent) => {
       e.preventDefault();
@@ -43,12 +45,12 @@ export function useDragDrop(loadFileInTab: (path: string) => Promise<void>) {
       e.preventDefault();
       e.stopPropagation();
       setIsDraggingFile(false);
-      const droppedPath = extractDroppedMdpath(e.dataTransfer);
+      const droppedPath = extractDroppedMdpath(e.dataTransfer, api);
       if (droppedPath) {
         void loadFileInTab(droppedPath);
       }
     },
-    [loadFileInTab]
+    [loadFileInTab, api]
   );
 
   return {

--- a/apps/renderer/src/hooks/useExport.ts
+++ b/apps/renderer/src/hooks/useExport.ts
@@ -1,34 +1,36 @@
 import { useCallback } from 'react';
 import { ActiveTab } from '../types/component-types';
 import exportCss from '../styles/export.css?raw';
+import { usePlatformAPI } from '../hooks/usePlatform';
 
 export function useExport(activeTab: ActiveTab) {
+  const api = usePlatformAPI();
   const exportHtml = useCallback(async () => {
-    if (!activeTab) return;
-    const outPath = await window.api.showSaveDialog({ defaultExt: 'html' });
+    if (!activeTab || !api.showSaveDialog || !api.exportHTML) return;
+    const outPath = await api.showSaveDialog({ defaultExt: 'html' });
     if (!outPath) return;
     const css = exportCss;
-    await window.api.exportHTML(activeTab.html, css, outPath);
-  }, [activeTab]);
+    await api.exportHTML(activeTab.html, css, outPath);
+  }, [activeTab, api]);
 
   const exportPdf = useCallback(async () => {
-    if (!activeTab) return;
-    const outPath = await window.api.showSaveDialog({ defaultExt: 'pdf' });
+    if (!activeTab || !api.showSaveDialog || !api.exportPDF) return;
+    const outPath = await api.showSaveDialog({ defaultExt: 'pdf' });
     if (!outPath) return;
     const css = exportCss;
-    await window.api.exportPDF(activeTab.html, css, outPath);
-  }, [activeTab]);
+    await api.exportPDF(activeTab.html, css, outPath);
+  }, [activeTab, api]);
 
   const exportDocx = useCallback(async () => {
-    if (!activeTab) return;
+    if (!activeTab || !api.showSaveDialog || !api.exportDOCX) return;
 
-    const outPath = await window.api.showSaveDialog({
+    const outPath = await api.showSaveDialog({
       defaultExt: 'docx',
     });
     if (!outPath) return;
     const css = exportCss;
-    await window.api.exportDOCX(activeTab.html, css, outPath);
-  }, [activeTab]);
+    await api.exportDOCX(activeTab.html, css, outPath);
+  }, [activeTab, api]);
 
   return { exportHtml, exportPdf, exportDocx };
 }

--- a/apps/renderer/src/hooks/useFile.ts
+++ b/apps/renderer/src/hooks/useFile.ts
@@ -4,8 +4,10 @@ import { renderMarkdown } from '../renderer/markdown';
 import { extractTOC } from '../renderer/toc';
 import { TOCType } from '../types/component-types';
 import { RecentFile } from '@package/shared-types';
+import { usePlatformAPI } from '../hooks/usePlatform';
 
 export function useFile() {
+  const api = usePlatformAPI();
   const [html, setHtml] = useState<string>('');
   const [filePath, setFilePath] = useState<string>('');
   const [error, setError] = useState<string>('');
@@ -14,46 +16,50 @@ export function useFile() {
   const [recentFiles, setRecentFiles] = useState<RecentFile[]>([]);
 
   useEffect(() => {
-    window.api
+    if (!api.getRecentFiles) return;
+    api
       .getRecentFiles()
       .then(setRecentFiles)
       .catch(() => {});
-  }, []);
+  }, [api]);
 
-  const loadFile = useCallback(async (path: string) => {
-    setIsLoading(true);
-    setError('');
-    setFilePath(path);
-    try {
-      const rawMarkdown = await window.api.readFile(path);
-      const renderHtml = await renderMarkdown(rawMarkdown);
-      const safeHtml = DOMpurify.sanitize(renderHtml);
-      setHtml(safeHtml);
-      const nextToc = extractTOC(rawMarkdown);
-      setToc(nextToc);
-      await window.api.addRecentFile(path);
-      const updated = await window.api.getRecentFiles();
-      setRecentFiles(updated);
-      return {
-        html: safeHtml,
-        toc: nextToc,
-        filePath: path,
-      };
-    } catch (error: unknown) {
-      if (error instanceof Error) {
-        setError(error.message);
-      } else {
-        setError(String(error));
+  const loadFile = useCallback(
+    async (path: string) => {
+      setIsLoading(true);
+      setError('');
+      setFilePath(path);
+      try {
+        const rawMarkdown = (await api.readFile?.(path)) ?? '';
+        const renderHtml = await renderMarkdown(rawMarkdown);
+        const safeHtml = DOMpurify.sanitize(renderHtml);
+        setHtml(safeHtml);
+        const nextToc = extractTOC(rawMarkdown);
+        setToc(nextToc);
+        await api.addRecentFile?.(path);
+        const updated = (await api.getRecentFiles?.()) ?? [];
+        setRecentFiles(updated);
+        return {
+          html: safeHtml,
+          toc: nextToc,
+          filePath: path,
+        };
+      } catch (error: unknown) {
+        if (error instanceof Error) {
+          setError(error.message);
+        } else {
+          setError(String(error));
+        }
+      } finally {
+        setIsLoading(false);
       }
-    } finally {
-      setIsLoading(false);
-    }
-  }, []);
+    },
+    [api]
+  );
   const openFile = useCallback(async () => {
-    const chosenPath = await window.api.openFileDialog();
+    const chosenPath = await api.openFileDialog?.();
     if (!chosenPath) return;
     await loadFile(chosenPath);
-  }, [loadFile]);
+  }, [loadFile, api]);
   const reloadFile = useCallback(async () => {
     if (!filePath) return;
     await loadFile(filePath);

--- a/apps/renderer/src/hooks/useFile.ts
+++ b/apps/renderer/src/hooks/useFile.ts
@@ -16,7 +16,6 @@ export function useFile() {
   const [recentFiles, setRecentFiles] = useState<RecentFile[]>([]);
 
   useEffect(() => {
-    if (!api.getRecentFiles) return;
     api
       .getRecentFiles()
       .then(setRecentFiles)
@@ -35,8 +34,8 @@ export function useFile() {
         setHtml(safeHtml);
         const nextToc = extractTOC(rawMarkdown);
         setToc(nextToc);
-        await api.addRecentFile?.(path);
-        const updated = (await api.getRecentFiles?.()) ?? [];
+        await api.addRecentFile(path);
+        const updated = await api.getRecentFiles();
         setRecentFiles(updated);
         return {
           html: safeHtml,

--- a/apps/renderer/src/hooks/useFileActions.ts
+++ b/apps/renderer/src/hooks/useFileActions.ts
@@ -1,19 +1,21 @@
 import { useCallback, useState } from 'react';
 import { FileType } from '@package/shared-types';
 import { FileActionProps } from '../types/hook-types';
+import { usePlatformAPI } from '../hooks/usePlatform';
 
 export function useFileActions({ loadFile, dispatch }: FileActionProps) {
+  const api = usePlatformAPI();
   const [folderTree, setFolderTree] = useState<FileType | null>(null);
   const [folderPath, setFolderPath] = useState<string | null>(null);
 
   const openFolder = useCallback(async () => {
-    if (!window.api) return;
-    const folderPath = await window.api.openFolderDialog();
+    if (!api.openFolderDialog || !api.readFolder) return;
+    const folderPath = await api.openFolderDialog();
     if (!folderPath) return;
-    const tree = await window.api.readFolder(folderPath);
+    const tree = await api.readFolder(folderPath);
     setFolderTree(tree);
     setFolderPath(folderPath);
-  }, []);
+  }, [api]);
 
   const loadFileInTab = useCallback(
     async (path: string) => {
@@ -32,13 +34,13 @@ export function useFileActions({ loadFile, dispatch }: FileActionProps) {
   );
 
   const openFileDialog = useCallback(() => {
-    if (!window.api) return;
-    void window.api.openFileDialog().then((chosenPath) => {
+    if (!api.openFileDialog) return;
+    void api.openFileDialog().then((chosenPath) => {
       if (chosenPath) {
         void loadFileInTab(chosenPath);
       }
     });
-  }, [loadFileInTab]);
+  }, [loadFileInTab, api]);
 
   return { folderTree, folderPath, setFolderTree, openFolder, loadFileInTab, openFileDialog };
 }

--- a/apps/renderer/src/hooks/useFilePersistence.ts
+++ b/apps/renderer/src/hooks/useFilePersistence.ts
@@ -10,8 +10,8 @@ export function useFilePersistence({
   contentRef,
   setShowToast,
 }: FilePersistenceProps) {
-  const debounceTimer = useRef<ReturnType<typeof window.setTimeout> | undefined>(undefined);
-  const scrollTimer = useRef<ReturnType<typeof window.setTimeout> | undefined>(undefined);
+  const debounceTimer = useRef<number | undefined>(undefined);
+  const scrollTimer = useRef<number | undefined>(undefined);
   const isMounted = useRef<boolean>(true);
 
   useEffect(() => {

--- a/apps/renderer/src/hooks/useFolderSearch.ts
+++ b/apps/renderer/src/hooks/useFolderSearch.ts
@@ -1,7 +1,9 @@
 import { useCallback, useState, useRef, useEffect } from 'react';
 import { FolderSearchResult } from '@package/shared-types';
+import { usePlatformAPI } from '../hooks/usePlatform';
 
 export function useFolderSearch(folderPath: string | null) {
+  const api = usePlatformAPI();
   const [isFolderSearchOpen, setIsFolderSearchOpen] = useState(false);
   const [folderQuery, setFolderQuery] = useState('');
   const [folderResults, setFolderResults] = useState<FolderSearchResult[]>([]);
@@ -20,7 +22,7 @@ export function useFolderSearch(folderPath: string | null) {
     async (query: string) => {
       setFolderQuery(query);
       const current = ++requestId.current;
-      if (!folderPath || !query.trim() || !window.api?.searchFolder) {
+      if (!folderPath || !query.trim() || !api.searchFolder) {
         setFolderResults([]);
         setIsSearchingFolder(false);
         return;
@@ -28,7 +30,7 @@ export function useFolderSearch(folderPath: string | null) {
 
       setIsSearchingFolder(true);
       try {
-        const results = await window.api.searchFolder(folderPath, query);
+        const results = await api.searchFolder(folderPath, query);
         if (current === requestId.current) setFolderResults(results);
       } catch {
         if (current === requestId.current) setFolderResults([]);
@@ -36,7 +38,7 @@ export function useFolderSearch(folderPath: string | null) {
         if (current === requestId.current) setIsSearchingFolder(false);
       }
     },
-    [folderPath]
+    [folderPath, api]
   );
 
   useEffect(() => {

--- a/apps/renderer/src/hooks/useMenuEvents.ts
+++ b/apps/renderer/src/hooks/useMenuEvents.ts
@@ -2,6 +2,7 @@ import { useEffect } from 'react';
 import { MENU_EVENTS } from '@package/shared-constants';
 import { UseMenuEventsProps } from '../types/hook-types';
 import { Theme } from '../types/component-types';
+import { usePlatformAPI } from '../hooks/usePlatform';
 export function useMenuEvents({
   onOpenFile,
   onOpenFolder,
@@ -23,37 +24,39 @@ export function useMenuEvents({
   onOpenSettings,
   onSetTheme,
 }: UseMenuEventsProps) {
+  const api = usePlatformAPI();
   useEffect(() => {
-    if (!window.api?.onMenuEvent) return;
+    if (!api.onMenuEvent) return;
 
-    window.api.onMenuEvent(MENU_EVENTS.OPEN_FILE, onOpenFile);
-    window.api.onMenuEvent(MENU_EVENTS.OPEN_FOLDER, onOpenFolder);
-    window.api.onMenuEvent(MENU_EVENTS.SEARCH_DOCUMENT, onSearchDocument);
-    window.api.onMenuEvent(MENU_EVENTS.SEARCH_FOLDER, onSearchFolder);
-    window.api.onMenuEvent(MENU_EVENTS.TOGGLE_TOC, onToggleToc);
-    window.api.onMenuEvent(MENU_EVENTS.TOGGLE_BROWSER, onToggleBrowser);
-    window.api.onMenuEvent(MENU_EVENTS.FOCUS_MODE, onFocusMode);
-    window.api.onMenuEvent(MENU_EVENTS.CYCLE_THEME, onCycleTheme);
-    window.api.onMenuEvent(MENU_EVENTS.ZOOM_IN, onZoomIn);
-    window.api.onMenuEvent(MENU_EVENTS.ZOOM_OUT, onZoomOut);
-    window.api.onMenuEvent(MENU_EVENTS.ZOOM_RESET, onZoomReset);
-    window.api.onMenuEvent(MENU_EVENTS.NEXT_TAB, onNextTab);
-    window.api.onMenuEvent(MENU_EVENTS.PREVIOUS_TAB, onPreviousTab);
-    window.api.onMenuEvent(MENU_EVENTS.CLOSE_TAB, onCloseTab);
-    window.api.onMenuEvent(MENU_EVENTS.EXPORT_HTML, onExportHtml);
-    window.api.onMenuEvent(MENU_EVENTS.EXPORT_PDF, onExportPdf);
-    window.api.onMenuEvent(MENU_EVENTS.EXPORT_DOCX, onExportDocx);
-    window.api.onMenuEvent(MENU_EVENTS.OPEN_SETTINGS, onOpenSettings);
-    window.api.onMenuEvent(MENU_EVENTS.SET_THEME, (theme) => {
+    api.onMenuEvent(MENU_EVENTS.OPEN_FILE, onOpenFile);
+    api.onMenuEvent(MENU_EVENTS.OPEN_FOLDER, onOpenFolder);
+    api.onMenuEvent(MENU_EVENTS.SEARCH_DOCUMENT, onSearchDocument);
+    api.onMenuEvent(MENU_EVENTS.SEARCH_FOLDER, onSearchFolder);
+    api.onMenuEvent(MENU_EVENTS.TOGGLE_TOC, onToggleToc);
+    api.onMenuEvent(MENU_EVENTS.TOGGLE_BROWSER, onToggleBrowser);
+    api.onMenuEvent(MENU_EVENTS.FOCUS_MODE, onFocusMode);
+    api.onMenuEvent(MENU_EVENTS.CYCLE_THEME, onCycleTheme);
+    api.onMenuEvent(MENU_EVENTS.ZOOM_IN, onZoomIn);
+    api.onMenuEvent(MENU_EVENTS.ZOOM_OUT, onZoomOut);
+    api.onMenuEvent(MENU_EVENTS.ZOOM_RESET, onZoomReset);
+    api.onMenuEvent(MENU_EVENTS.NEXT_TAB, onNextTab);
+    api.onMenuEvent(MENU_EVENTS.PREVIOUS_TAB, onPreviousTab);
+    api.onMenuEvent(MENU_EVENTS.CLOSE_TAB, onCloseTab);
+    api.onMenuEvent(MENU_EVENTS.EXPORT_HTML, onExportHtml);
+    api.onMenuEvent(MENU_EVENTS.EXPORT_PDF, onExportPdf);
+    api.onMenuEvent(MENU_EVENTS.EXPORT_DOCX, onExportDocx);
+    api.onMenuEvent(MENU_EVENTS.OPEN_SETTINGS, onOpenSettings);
+    api.onMenuEvent(MENU_EVENTS.SET_THEME, (theme) => {
       if (typeof theme === 'string') {
         onSetTheme(theme as Theme);
       }
     });
 
     return () => {
-      window.api.removeMenuListeners?.();
+      api.removeMenuListeners?.();
     };
   }, [
+    api,
     onOpenFile,
     onOpenFolder,
     onSearchDocument,

--- a/apps/renderer/src/hooks/useOpenFilePath.ts
+++ b/apps/renderer/src/hooks/useOpenFilePath.ts
@@ -1,12 +1,15 @@
 import { useEffect } from 'react';
+import { usePlatformAPI } from '../hooks/usePlatform';
 
 export function useOpenFilePath(loadFileInTab: (path: string) => Promise<void>) {
+  const api = usePlatformAPI();
   useEffect(() => {
-    window.api.onOpenFilePath((path) => {
+    if (!api.onOpenFilePath || !api.removeOpenFilePathListener) return;
+    api.onOpenFilePath((path) => {
       void loadFileInTab(path);
     });
     return () => {
-      window.api.removeOpenFilePathListener();
+      api.removeOpenFilePathListener?.();
     };
-  }, [loadFileInTab]);
+  }, [loadFileInTab, api]);
 }

--- a/apps/renderer/src/hooks/usePlatform.ts
+++ b/apps/renderer/src/hooks/usePlatform.ts
@@ -1,0 +1,12 @@
+import { useContext } from 'react';
+import { PlatformAdapter } from '@package/platform-adapters';
+import { PlatformContext } from '../context/PlatformProvider';
+
+export function usePlatformAPI(): PlatformAdapter {
+  const platform = useContext(PlatformContext);
+  if (!platform) {
+    throw new Error('usePlatform must be used inside PlatformProvider.');
+  }
+
+  return platform;
+}

--- a/apps/renderer/src/hooks/useSettings.ts
+++ b/apps/renderer/src/hooks/useSettings.ts
@@ -1,22 +1,24 @@
 import { useCallback, useEffect, useState } from 'react';
 import { FONT_SIZE, WIDTH_MAP } from '../types/component-types';
 import { AppSettings, DEFAULT_SETTINGS } from '@package/shared-types';
+import { usePlatformAPI } from '../hooks/usePlatform';
 
 export function useSettings() {
+  const api = usePlatformAPI();
   const [settings, setSettings] = useState<AppSettings>(DEFAULT_SETTINGS);
   const fontSize = settings.fontSize;
   const readingWidth = settings.readingWidth;
 
   useEffect(() => {
-    if (!window.api) return;
+    if (!api.getSettings) return;
 
-    void window.api
+    void api
       .getSettings()
       .then((savedSettings) => {
         setSettings(savedSettings);
       })
       .catch(() => {});
-  }, []);
+  }, [api]);
 
   useEffect(() => {
     document.documentElement.style.setProperty('--font-size-content', `${fontSize}px`);
@@ -40,20 +42,23 @@ export function useSettings() {
     style.textContent = settings.customCss || '';
   }, [settings.customCss]);
 
-  const updateSettings = useCallback(async (partial: Partial<AppSettings>) => {
-    if (!window.api) {
-      setSettings((current) => ({ ...current, ...partial }));
-      return;
-    }
+  const updateSettings = useCallback(
+    async (partial: Partial<AppSettings>) => {
+      if (!api.saveSettings) {
+        setSettings((current) => ({ ...current, ...partial }));
+        return;
+      }
 
-    try {
-      const next = await window.api.saveSettings(partial);
-      setSettings(next);
-    } catch (error) {
-      console.error('Failed to save settings:', error);
-      throw error;
-    }
-  }, []);
+      try {
+        const next = await api.saveSettings(partial);
+        setSettings(next);
+      } catch (error) {
+        console.error('Failed to save settings:', error);
+        throw error;
+      }
+    },
+    [api]
+  );
 
   const increaseFontSize = useCallback(() => {
     return updateSettings({

--- a/apps/renderer/src/hooks/useSettings.ts
+++ b/apps/renderer/src/hooks/useSettings.ts
@@ -17,7 +17,9 @@ export function useSettings() {
       .then((savedSettings) => {
         setSettings(savedSettings);
       })
-      .catch(() => {});
+      .catch((error) => {
+        console.error('Failed to load settings using defaults', error);
+      });
   }, [api]);
 
   useEffect(() => {

--- a/apps/renderer/src/hooks/useWatcher.ts
+++ b/apps/renderer/src/hooks/useWatcher.ts
@@ -1,16 +1,18 @@
 import { useEffect } from 'react';
+import { usePlatformAPI } from '../hooks/usePlatform';
 
 export function useWatcher(filePath: string, onFileChanged: (path: string) => void) {
+  const api = usePlatformAPI();
   useEffect(() => {
     if (!filePath) return;
-    window.api.watchFile(filePath);
+    void api.watchFile(filePath).catch(() => {});
     const handler = (path: string) => {
       onFileChanged(path);
     };
-    window.api.onFileChanged(handler);
+    api.onFileChanged(handler);
     return () => {
-      window.api.unWatchFile(filePath);
-      window.api.removeFileChangedListener();
+      void api.unWatchFile(filePath).catch(() => {});
+      api.removeFileChangedListener();
     };
-  }, [filePath, onFileChanged]);
+  }, [filePath, onFileChanged, api]);
 }

--- a/apps/renderer/src/index.css
+++ b/apps/renderer/src/index.css
@@ -1,6 +1,6 @@
 @import "tailwindcss";
 @plugin "@tailwindcss/typography";
-
+@source "./**/*.{ts,tsx}";
 
 :root,
 [data-theme="github-light"] {

--- a/apps/renderer/src/main.tsx
+++ b/apps/renderer/src/main.tsx
@@ -2,21 +2,39 @@
 
 import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
+import { ChromeAdapter,ElectronAdapter,isChromeExtensionRuntime,isElectronRuntime ,type PlatformAdapter} from '@package/platform-adapters';
 import App from './App'
 import "./index.css";
 import { ThemeProvider } from './context/ThemeProvider'
 import 'katex/dist/katex.min.css';
 import { TabProvider } from './context/TabProvider';
 import { ErrorBoundary } from './components/ErrorBoundary';
+import {PlatformProvider} from './context/PlatformProvider';
+
+function createPlatformAdapter(): PlatformAdapter {
+  if (isElectronRuntime()) {
+    return new ElectronAdapter();
+  }
+
+  if (isChromeExtensionRuntime()) {
+    return new ChromeAdapter();
+  }
+
+  throw new Error('No supported platform adapter was detected.');
+}
+
+const platform = createPlatformAdapter();
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
     <ErrorBoundary>
+    <PlatformProvider platform={platform}>
     <ThemeProvider>
       <TabProvider>
         <App />
       </TabProvider>
     </ThemeProvider>
+    </PlatformProvider>
     </ErrorBoundary>
   </StrictMode>
 )

--- a/apps/renderer/src/main.tsx
+++ b/apps/renderer/src/main.tsx
@@ -2,39 +2,16 @@
 
 import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
-import { ChromeAdapter,ElectronAdapter,isChromeExtensionRuntime,isElectronRuntime ,type PlatformAdapter} from '@package/platform-adapters';
-import App from './App'
 import "./index.css";
-import { ThemeProvider } from './context/ThemeProvider'
 import 'katex/dist/katex.min.css';
-import { TabProvider } from './context/TabProvider';
 import { ErrorBoundary } from './components/ErrorBoundary';
-import {PlatformProvider} from './context/PlatformProvider';
+import { PlatformInitializer } from './components/PlatformInitializer';
 
-function createPlatformAdapter(): PlatformAdapter {
-  if (isElectronRuntime()) {
-    return new ElectronAdapter();
-  }
-
-  if (isChromeExtensionRuntime()) {
-    return new ChromeAdapter();
-  }
-
-  throw new Error('No supported platform adapter was detected.');
-}
-
-const platform = createPlatformAdapter();
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
     <ErrorBoundary>
-    <PlatformProvider platform={platform}>
-    <ThemeProvider>
-      <TabProvider>
-        <App />
-      </TabProvider>
-    </ThemeProvider>
-    </PlatformProvider>
+      <PlatformInitializer/>
     </ErrorBoundary>
   </StrictMode>
-)
+);

--- a/apps/renderer/src/renderer/drag-drop.ts
+++ b/apps/renderer/src/renderer/drag-drop.ts
@@ -1,6 +1,10 @@
 import { ElectronFile } from '../types/component-types';
 import { MARKDOWN_FILE_PATTERN } from '@package/shared-constants';
-export function extractDroppedMdpath(dt: DataTransfer): string | null {
+import { MarkdownReaderAPI } from '@package/shared-types';
+export function extractDroppedMdpath(
+  dt: DataTransfer,
+  api: Partial<MarkdownReaderAPI>
+): string | null {
   if (!dt.files || dt.files.length === 0) return null;
   const files = Array.from(dt.files) as ElectronFile[];
   for (const f of files) {
@@ -10,9 +14,6 @@ export function extractDroppedMdpath(dt: DataTransfer): string | null {
     if (f.path) {
       return f.path;
     }
-    const api = window.api as typeof window.api & {
-      getPathForFile?: (file: File) => string;
-    };
     const filePath = api.getPathForFile?.(f);
     if (filePath) {
       return filePath;

--- a/apps/renderer/src/utils/helpers/platform-helper.ts
+++ b/apps/renderer/src/utils/helpers/platform-helper.ts
@@ -1,0 +1,20 @@
+import {
+  ChromeAdapter,
+  ElectronAdapter,
+  isChromeExtensionRuntime,
+  isElectronRuntime,
+  type PlatformAdapter,
+} from '@package/platform-adapters';
+
+// Detects the current execution environment and instantiates the  adapter.
+export function createPlatformAdapter(): PlatformAdapter {
+  if (isElectronRuntime()) {
+    return new ElectronAdapter();
+  }
+
+  if (isChromeExtensionRuntime()) {
+    return new ChromeAdapter();
+  }
+
+  throw new Error('No supported platform adapter was detected.');
+}

--- a/package.json
+++ b/package.json
@@ -70,7 +70,12 @@
     "overrides": {
       "serialize-javascript": ">=7.0.5",
       "fast-uri": ">=3.1.2",
-      "tmp": ">=0.2.6"
+      "tmp": ">=0.2.6",
+      "shell-quote": ">=1.8.4",
+      "esbuild": ">=0.28.1",
+      "ws": ">=8.21.0",
+      "form-data": ">=4.0.6",
+      "vite": ">=7.3.5"
     }
   }
 }

--- a/packages/platform-adapters/__tests__/chrome-adapter.test.ts
+++ b/packages/platform-adapters/__tests__/chrome-adapter.test.ts
@@ -1,0 +1,211 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { DEFAULT_SETTINGS } from '@package/shared-types';
+import { ChromeAdapter } from '../src/adapters/chrome-adapter.js';
+import {
+  CHROME_MESSAGE_TYPES,
+  DEFAULT_APP_VERSION,
+  STORAGE_KEYS,
+} from '../src/utils/constants/adapter-constants.js';
+import { makeChromeApi } from './test-utils.js';
+
+describe('chrome adapter', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-06-15T10:00:00.000Z'));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('does not start without chrome runtime and storage', () => {
+    expect(() => new ChromeAdapter(null)).toThrow(
+      'ChromeAdapter requires chrome.runtime and chrome.storage.local.'
+    );
+  });
+
+  it('should store simple values in chrome local storage', async () => {
+    const { api } = makeChromeApi();
+    const adapter = new ChromeAdapter(api);
+
+    await adapter.storage.setItem('theme', 'github-dark');
+
+    expect(await adapter.storage.getItem('theme')).toBe('github-dark');
+  });
+
+  it('should remove and clear stord values', async () => {
+    const { api } = makeChromeApi({ theme: 'github-dark', zoom: 18 });
+    const adapter = new ChromeAdapter(api);
+
+    await adapter.storage.removeItem('theme');
+    expect(await adapter.storage.getItem('theme')).toBeNull();
+
+    await adapter.storage.clear();
+    expect(await adapter.storage.getItem('zoom')).toBeNull();
+  });
+
+  it('should keep the latest recent file first without duplicate', async () => {
+    const { api } = makeChromeApi({
+      [STORAGE_KEYS.RECENT_FILES]: [
+        { path: 'old.md', name: 'old.md', openedAt: 1 },
+        { path: 'notes.md', name: 'notes.md', openedAt: 2 },
+      ],
+    });
+    const adapter = new ChromeAdapter(api);
+
+    await adapter.addRecentFile('notes.md');
+
+    expect(await adapter.getRecentFiles()).toEqual([
+      { path: 'notes.md', name: 'notes.md', openedAt: Date.now() },
+      { path: 'old.md', name: 'old.md', openedAt: 1 },
+    ]);
+  });
+
+  it('should fill missing settings from defaults', async () => {
+    const { api } = makeChromeApi({
+      [STORAGE_KEYS.SETTINGS]: { theme: 'github-dark' },
+    });
+    const adapter = new ChromeAdapter(api);
+
+    expect(await adapter.getSettings()).toEqual({
+      ...DEFAULT_SETTINGS,
+      theme: 'github-dark',
+    });
+  });
+
+  it('should save settings back to chrome storage', async () => {
+    const { api } = makeChromeApi({
+      [STORAGE_KEYS.SETTINGS]: { theme: 'github-light', fontSize: 16 },
+    });
+    const adapter = new ChromeAdapter(api);
+
+    const saved = await adapter.saveSettings({ theme: 'github-dark' });
+
+    expect(saved.theme).toBe('github-dark');
+    expect(await adapter.storage.getItem(STORAGE_KEYS.SETTINGS)).toEqual(saved);
+  });
+
+  it('should clear recent files', async () => {
+    const { api } = makeChromeApi({
+      [STORAGE_KEYS.RECENT_FILES]: [{ path: 'notes.md', name: 'notes.md', openedAt: 1 }],
+    });
+    const adapter = new ChromeAdapter(api);
+
+    await adapter.clearRecentFiles();
+
+    expect(await adapter.getRecentFiles()).toEqual([]);
+  });
+
+  it('shouses cached file content before the worker', async () => {
+    const { api } = makeChromeApi({
+      [`${STORAGE_KEYS.FILE_CONTENT_PREFIX}cached.md`]: '# Cached',
+    });
+    const adapter = new ChromeAdapter(api);
+
+    expect(await adapter.readFile('cached.md')).toBe('# Cached');
+    expect(api.runtime?.sendMessage).not.toHaveBeenCalled();
+  });
+
+  it('opens a markdown file with the browser file picker', async () => {
+    vi.useRealTimers();
+    const { api } = makeChromeApi();
+    const adapter = new ChromeAdapter(api);
+
+    const filePathPromise = adapter.openFileDialog();
+    const input = document.querySelector('input[type="file"]') as HTMLInputElement;
+    const file = new File(['# Picked'], 'picked.md', { type: 'text/markdown' });
+
+    Object.defineProperty(input, 'files', { value: [file] });
+    input.dispatchEvent(new Event('change'));
+
+    await expect(filePathPromise).resolves.toBe('picked.md');
+    await expect(adapter.readFile('picked.md')).resolves.toBe('# Picked');
+  });
+
+  it('returns null when the file picker is cancelled', async () => {
+    const { api } = makeChromeApi();
+    const adapter = new ChromeAdapter(api);
+
+    const filePathPromise = adapter.openFileDialog();
+    const input = document.querySelector('input[type="file"]') as HTMLInputElement;
+
+    Object.defineProperty(input, 'files', { value: [] });
+    input.dispatchEvent(new Event('change'));
+
+    await expect(filePathPromise).resolves.toBeNull();
+  });
+
+  it('forward file changed events', () => {
+    const { api, listeners } = makeChromeApi();
+    const adapter = new ChromeAdapter(api);
+    const onChange = vi.fn();
+
+    adapter.onFileChanged(onChange);
+    listeners.forEach((listener) => listener({ type: 'file-changed', payload: 'notes.md' }));
+
+    expect(onChange).toHaveBeenCalledWith('notes.md');
+
+    adapter.removeFileChangedListener();
+    expect(api.runtime?.onMessage?.removeListener).toHaveBeenCalled();
+  });
+
+  it('forward menu events and removes them later', () => {
+    const { api, listeners } = makeChromeApi();
+    const adapter = new ChromeAdapter(api);
+    const onOpen = vi.fn();
+
+    const cleanup = adapter.onMenuEvent('open-file', onOpen);
+    listeners.forEach((listener) => listener({ type: 'open-file', payload: { source: 'menu' } }));
+
+    expect(onOpen).toHaveBeenCalledWith({ source: 'menu' });
+
+    cleanup();
+    expect(api.runtime?.onMessage?.removeListener).toHaveBeenCalled();
+  });
+
+  it('removes all registered menu listener', () => {
+    const { api } = makeChromeApi();
+    const adapter = new ChromeAdapter(api);
+
+    adapter.onMenuEvent('open-file', vi.fn());
+    adapter.onMenuEvent('toggle-theme', vi.fn());
+    adapter.removeMenuListeners();
+
+    expect(api.runtime?.onMessage?.removeListener).toHaveBeenCalledTimes(2);
+  });
+
+  it('forwards open file path events', () => {
+    const { api, listeners } = makeChromeApi();
+    const adapter = new ChromeAdapter(api);
+    const onOpen = vi.fn();
+
+    adapter.onOpenFilePath(onOpen);
+    listeners.forEach((listener) => listener({ type: 'open-file-path', payload: 'notes.md' }));
+
+    expect(onOpen).toHaveBeenCalledWith('notes.md');
+
+    adapter.removeOpenFilePathListener();
+    expect(api.runtime?.onMessage?.removeListener).toHaveBeenCalled();
+  });
+
+  it('uses browser friendly update and file path behavor', async () => {
+    const { api } = makeChromeApi();
+    const adapter = new ChromeAdapter(api);
+    const cleanup = adapter.onUpdateAvailable();
+
+    expect(await adapter.getAppVersion()).toBe(DEFAULT_APP_VERSION);
+    expect(adapter.getPathForFile(new File(['hello'], 'notes.md'))).toBe('notes.md');
+    expect(cleanup()).toBeUndefined();
+  });
+
+  it('sends download update as a background message', () => {
+    const { api } = makeChromeApi();
+    const adapter = new ChromeAdapter(api);
+
+    adapter.downloadUpdate();
+
+    expect(api.runtime?.sendMessage).toHaveBeenCalledWith({
+      type: CHROME_MESSAGE_TYPES.DOWNLOAD_UPDATE,
+    });
+  });
+});

--- a/packages/platform-adapters/__tests__/chrome-adapter.test.ts
+++ b/packages/platform-adapters/__tests__/chrome-adapter.test.ts
@@ -33,7 +33,7 @@ describe('chrome adapter', () => {
     expect(await adapter.storage.getItem('theme')).toBe('github-dark');
   });
 
-  it('should remove and clear stord values', async () => {
+  it('should remove and clear stored values', async () => {
     const { api } = makeChromeApi({ theme: 'github-dark', zoom: 18 });
     const adapter = new ChromeAdapter(api);
 
@@ -96,7 +96,7 @@ describe('chrome adapter', () => {
     expect(await adapter.getRecentFiles()).toEqual([]);
   });
 
-  it('shouses cached file content before the worker', async () => {
+  it('chooses cached file content before the worker', async () => {
     const { api } = makeChromeApi({
       [`${STORAGE_KEYS.FILE_CONTENT_PREFIX}cached.md`]: '# Cached',
     });
@@ -188,7 +188,7 @@ describe('chrome adapter', () => {
     expect(api.runtime?.onMessage?.removeListener).toHaveBeenCalled();
   });
 
-  it('uses browser friendly update and file path behavor', async () => {
+  it('uses browser friendly update and file path behavior', async () => {
     const { api } = makeChromeApi();
     const adapter = new ChromeAdapter(api);
     const cleanup = adapter.onUpdateAvailable();

--- a/packages/platform-adapters/__tests__/electron-adapter.test.ts
+++ b/packages/platform-adapters/__tests__/electron-adapter.test.ts
@@ -1,0 +1,133 @@
+import { describe, expect, it, vi } from 'vitest';
+import { ElectronAdapter } from '../src/adapters/electron-adapter.js';
+import { PLATFORM_KIND } from '../src/utils/constants/adapter-constants.js';
+import { makeElectronApi } from './test-utils.js';
+
+describe('electron adapter', () => {
+  it('should fail when preload api is not available', () => {
+    expect(() => new ElectronAdapter(null)).toThrow('ElectronAdapter requires window.api');
+  });
+
+  it('should read a file through the electron bridge', async () => {
+    const api = makeElectronApi();
+    const adapter = new ElectronAdapter(api);
+
+    const content = await adapter.readFile('notes.md');
+
+    expect(content).toBe('# Hello');
+    expect(adapter.kind).toBe(PLATFORM_KIND.ELECTRON);
+    expect(api.readFile).toHaveBeenCalledWith('notes.md');
+  });
+
+  it('should pass settings changes to the desktop api', async () => {
+    const api = makeElectronApi();
+    const adapter = new ElectronAdapter(api);
+
+    const saved = await adapter.saveSettings({ theme: 'github-dark' });
+
+    expect(saved).toEqual({ theme: 'github-dark' });
+    expect(api.saveSettings).toHaveBeenCalledWith({ theme: 'github-dark' });
+  });
+
+  it('should pass common file actions to the desktop api', async () => {
+    const api = makeElectronApi();
+    const adapter = new ElectronAdapter(api);
+
+    await adapter.openFileDialog();
+    await adapter.openFolderDialog();
+    await adapter.readFolder('docs');
+    await adapter.watchFile('notes.md');
+    await adapter.unWatchFile('notes.md');
+
+    expect(api.openFileDialog).toHaveBeenCalled();
+    expect(api.openFolderDialog).toHaveBeenCalled();
+    expect(api.readFolder).toHaveBeenCalledWith('docs');
+    expect(api.watchFile).toHaveBeenCalledWith('notes.md');
+    expect(api.unWatchFile).toHaveBeenCalledWith('notes.md');
+  });
+
+  it('should pass recent file actions to the desktop api', async () => {
+    const api = makeElectronApi();
+    const adapter = new ElectronAdapter(api);
+
+    await adapter.getRecentFiles();
+    await adapter.addRecentFile('notes.md');
+    await adapter.clearRecentFiles();
+
+    expect(api.getRecentFiles).toHaveBeenCalled();
+    expect(api.addRecentFile).toHaveBeenCalledWith('notes.md');
+    expect(api.clearRecentFiles).toHaveBeenCalled();
+  });
+
+  it('should pass search and listener actions to the desktop api', async () => {
+    const api = makeElectronApi();
+    const adapter = new ElectronAdapter(api);
+    const onFileChanged = vi.fn();
+    const onOpenPath = vi.fn();
+
+    await adapter.searchFolder('docs', 'hello');
+    adapter.onFileChanged(onFileChanged);
+    adapter.removeFileChangedListener();
+    adapter.onOpenFilePath(onOpenPath);
+    adapter.removeOpenFilePathListener();
+    adapter.removeMenuListeners();
+
+    expect(api.searchFolder).toHaveBeenCalledWith('docs', 'hello');
+    expect(api.onFileChanged).toHaveBeenCalledWith(onFileChanged);
+    expect(api.removeFileChangedListener).toHaveBeenCalled();
+    expect(api.onOpenFilePath).toHaveBeenCalledWith(onOpenPath);
+    expect(api.removeOpenFilePathListener).toHaveBeenCalled();
+    expect(api.removeMenuListeners).toHaveBeenCalled();
+  });
+
+  it('should pass export actions to the desktop api', async () => {
+    const api = makeElectronApi();
+    const adapter = new ElectronAdapter(api);
+
+    await adapter.showSaveDialog({ defaultExt: 'html' });
+    await adapter.exportHTML('<h1>Hello</h1>', 'body{}', 'out.html');
+    await adapter.exportPDF('<h1>Hello</h1>', 'body{}', 'out.pdf');
+    await adapter.exportDOCX('<h1>Hello</h1>', 'body{}', 'out.docx');
+
+    expect(api.showSaveDialog).toHaveBeenCalledWith({ defaultExt: 'html' });
+    expect(api.exportHTML).toHaveBeenCalledWith('<h1>Hello</h1>', 'body{}', 'out.html');
+    expect(api.exportPDF).toHaveBeenCalledWith('<h1>Hello</h1>', 'body{}', 'out.pdf');
+    expect(api.exportDOCX).toHaveBeenCalledWith('<h1>Hello</h1>', 'body{}', 'out.docx');
+  });
+
+  it('should pass update and path helpers to the desktop api', async () => {
+    const api = makeElectronApi();
+    const adapter = new ElectronAdapter(api);
+    const file = new File(['hello'], 'dropped.md');
+    const onUpdate = vi.fn();
+
+    await adapter.getAppVersion();
+    adapter.getPathForFile(file);
+    adapter.onUpdateAvailable(onUpdate);
+    adapter.downloadUpdate();
+
+    expect(api.getAppVersion).toHaveBeenCalled();
+    expect(api.getPathForFile).toHaveBeenCalledWith(file);
+    expect(api.onUpdateAvailable).toHaveBeenCalledWith(onUpdate);
+    expect(api.downloadUpdate).toHaveBeenCalled();
+  });
+
+  it('should keep menu cleanup by electron', () => {
+    const cleanup = vi.fn();
+    const api = makeElectronApi({
+      onMenuEvent: vi.fn(() => cleanup),
+    });
+    const adapter = new ElectronAdapter(api);
+
+    const returnedCleanup = adapter.onMenuEvent('open-file', vi.fn());
+
+    expect(returnedCleanup).toBe(cleanup);
+  });
+
+  it('should return the message object for generic messages', async () => {
+    const adapter = new ElectronAdapter(makeElectronApi());
+    const message = { type: 'ping', payload: { ok: true } };
+
+    await expect(adapter.sendMessage(message)).resolves.toBe(message);
+  });
+});

--- a/packages/platform-adapters/__tests__/electron-adapter.test.ts
+++ b/packages/platform-adapters/__tests__/electron-adapter.test.ts
@@ -128,6 +128,8 @@ describe('electron adapter', () => {
     const adapter = new ElectronAdapter(makeElectronApi());
     const message = { type: 'ping', payload: { ok: true } };
 
-    await expect(adapter.sendMessage(message)).resolves.toBe(message);
+    await expect(adapter.sendMessage(message)).rejects.toThrow(
+      'send message is an unsupported operation in the electron runtime environment'
+    );
   });
 });

--- a/packages/platform-adapters/__tests__/helper.test.ts
+++ b/packages/platform-adapters/__tests__/helper.test.ts
@@ -1,0 +1,51 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import {
+  createUnsupportedPlatformMethod,
+  getChromeApi,
+  getElectronApi,
+  isChromeExtensionRuntime,
+  isElectronRuntime,
+  toErrorMessage,
+} from '../src/utils/helpers/adapter-helper';
+
+describe('runtime helpers', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('should find the electron preload api', () => {
+    const api = { readFile: vi.fn() };
+    vi.stubGlobal('window', { api });
+
+    expect(getElectronApi()).toBe(api);
+    expect(isElectronRuntime()).toBe(true);
+  });
+
+  it('should find a usable chrome extension api', () => {
+    const chrome = {
+      runtime: { sendMessage: vi.fn() },
+      storage: { local: {} },
+    };
+    vi.stubGlobal('chrome', chrome);
+
+    expect(getChromeApi()).toBe(chrome);
+    expect(isChromeExtensionRuntime()).toBe(true);
+  });
+
+  it('should reject an incomplete chrome api', () => {
+    vi.stubGlobal('chrome', { runtime: { sendMessage: vi.fn() } });
+
+    expect(isChromeExtensionRuntime()).toBe(false);
+  });
+
+  it('should keep unsupported method errors readable', () => {
+    expect(() => createUnsupportedPlatformMethod('chrome.storage.local.get')).toThrow(
+      'chrome.storage.local.get is not supported by this platform adapter.'
+    );
+  });
+
+  it('should normalize error messages', () => {
+    expect(toErrorMessage(new Error('failed'))).toBe('failed');
+    expect(toErrorMessage('plain failure')).toBe('plain failure');
+  });
+});

--- a/packages/platform-adapters/__tests__/helper.test.ts
+++ b/packages/platform-adapters/__tests__/helper.test.ts
@@ -34,7 +34,10 @@ describe('runtime helpers', () => {
 
   it('should reject an incomplete chrome api', () => {
     vi.stubGlobal('chrome', { runtime: { sendMessage: vi.fn() } });
-
+    expect(isChromeExtensionRuntime()).toBe(false);
+  });
+  it('should reject chrome api without sendMessage', () => {
+    vi.stubGlobal('chrome', { storage: { local: {} } });
     expect(isChromeExtensionRuntime()).toBe(false);
   });
 

--- a/packages/platform-adapters/__tests__/test-utils.ts
+++ b/packages/platform-adapters/__tests__/test-utils.ts
@@ -1,0 +1,79 @@
+import { vi } from 'vitest';
+import type { MarkdownReaderAPI } from '@package/shared-types';
+import type { ChromeExtensionApi } from '../src/types/chrome-type';
+
+type ChromeListener = (message: unknown) => void;
+
+// shared adapter mocks
+export function makeElectronApi(overrides: Partial<MarkdownReaderAPI> = {}): MarkdownReaderAPI {
+  return {
+    readFile: vi.fn(async () => '# Hello'),
+    watchFile: vi.fn(async () => undefined),
+    unWatchFile: vi.fn(async () => undefined),
+    openFileDialog: vi.fn(async () => 'notes.md'),
+    openFolderDialog: vi.fn(async () => 'docs'),
+    readFolder: vi.fn(async () => null),
+    getRecentFiles: vi.fn(async () => []),
+    addRecentFile: vi.fn(async () => undefined),
+    clearRecentFiles: vi.fn(async () => undefined),
+    getSettings: vi.fn(async () => ({ theme: 'github-light' }) as never),
+    saveSettings: vi.fn(async (settings) => settings as never),
+    getAppVersion: vi.fn(async () => '1.0.0'),
+    searchFolder: vi.fn(async () => []),
+    onFileChanged: vi.fn(),
+    removeFileChangedListener: vi.fn(),
+    onMenuEvent: vi.fn(() => vi.fn()),
+    removeMenuListeners: vi.fn(),
+    onOpenFilePath: vi.fn(),
+    removeOpenFilePathListener: vi.fn(),
+    showSaveDialog: vi.fn(async () => 'export.html'),
+    exportHTML: vi.fn(async () => undefined),
+    exportPDF: vi.fn(async () => undefined),
+    exportDOCX: vi.fn(async () => undefined),
+    getPathForFile: vi.fn(() => 'dropped.md'),
+    onUpdateAvailable: vi.fn(() => vi.fn()),
+    downloadUpdate: vi.fn(),
+    ...overrides,
+  };
+}
+
+export function makeChromeApi(initialStorage: Record<string, unknown> = {}) {
+  const storage = { ...initialStorage };
+  const listeners = new Set<ChromeListener>();
+
+  const api: ChromeExtensionApi = {
+    runtime: {
+      sendMessage: vi.fn(async () => ({ ok: true, data: undefined })),
+      onMessage: {
+        addListener: vi.fn((listener) => listeners.add(listener)),
+        removeListener: vi.fn((listener) => listeners.delete(listener)),
+      },
+    },
+    storage: {
+      local: {
+        get: vi.fn(async (key?: string | string[] | Record<string, unknown> | null) => {
+          if (typeof key === 'string') {
+            return { [key]: storage[key] };
+          }
+
+          return { ...storage };
+        }),
+        set: vi.fn(async (items: Record<string, unknown>) => {
+          Object.assign(storage, items);
+        }),
+        remove: vi.fn(async (keys: string | string[]) => {
+          for (const key of Array.isArray(keys) ? keys : [keys]) {
+            delete storage[key];
+          }
+        }),
+        clear: vi.fn(async () => {
+          for (const key of Object.keys(storage)) {
+            delete storage[key];
+          }
+        }),
+      },
+    },
+  };
+
+  return { api, storage, listeners };
+}

--- a/packages/platform-adapters/package.json
+++ b/packages/platform-adapters/package.json
@@ -1,0 +1,31 @@
+{
+  "name": "@package/platform-adapters",
+  "version": "1.0.0",
+  "description": "Cross platform adaptorers for Markdown Reader",
+  "main": "dist/src/index.js",
+  "types": "dist/src/index.d.ts",
+  "scripts": {
+    "build": "pnpm exec tsc",
+    "lint": "eslint .",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "test:coverage": "vitest --coverage"
+  },
+  "type": "module",
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "packageManager": "pnpm@10.33.0",
+  "dependencies": {
+    "@package/shared-types": "workspace:*"
+  },
+  "devDependencies": {
+    "@testing-library/jest-dom": "^6.9.1",
+    "@testing-library/react": "^16.3.2",
+    "@testing-library/user-event": "^14.6.1",
+    "@vitest/coverage-v8": "^4.1.5",
+    "jsdom": "^29.1.1",
+    "vitest": "^4.1.5"
+  }
+}

--- a/packages/platform-adapters/setup.ts
+++ b/packages/platform-adapters/setup.ts
@@ -1,0 +1,7 @@
+import '@testing-library/jest-dom';
+import { afterEach, vi } from 'vitest';
+
+afterEach(() => {
+  vi.clearAllMocks();
+  vi.unstubAllGlobals();
+});

--- a/packages/platform-adapters/src/adapters/chrome-adapter.ts
+++ b/packages/platform-adapters/src/adapters/chrome-adapter.ts
@@ -203,7 +203,8 @@ export class ChromeAdapter implements PlatformAdapter {
   }
 
   async getAppVersion(): Promise<string> {
-    return DEFAULT_APP_VERSION;
+    const version = this.chromeApi?.runtime?.getManifest?.()?.version;
+    return version ?? DEFAULT_APP_VERSION;
   }
 
   searchFolder(path: string, query: string): Promise<FolderSearchResult[]> {

--- a/packages/platform-adapters/src/adapters/chrome-adapter.ts
+++ b/packages/platform-adapters/src/adapters/chrome-adapter.ts
@@ -119,12 +119,30 @@ export class ChromeAdapter implements PlatformAdapter {
           }
 
           const reader = new FileReader();
-          reader.onload = () => {
+          reader.onload = async () => {
             const content = String(reader.result ?? '');
             const path = file.name;
             this.openedFiles.set(path, content);
-            void this.storage.setItem(`${STORAGE_KEYS.FILE_CONTENT_PREFIX}${path}`, content);
-            resolve(path);
+            try {
+              await this.storage.setItem(`${STORAGE_KEYS.FILE_CONTENT_PREFIX}${path}`, content);
+              resolve(path);
+            } catch (error: unknown) {
+              const errorMessage = error instanceof Error ? error.message : '';
+              const errorName =
+                typeof error === 'object' && error !== null && 'name' in error
+                  ? String((error as Record<string, unknown>).name)
+                  : '';
+
+              if (errorMessage.includes('QUOTA_BYTES') || errorName === 'QuotaExceededError') {
+                reject(
+                  new Error(
+                    'Extension storage limit (10MB) exceeded. Please clear some files to free up space.'
+                  )
+                );
+              } else {
+                reject(error instanceof Error ? error : new Error('Failed to cache file content.'));
+              }
+            }
           };
           reader.onerror = () => {
             reject(reader.error ?? new Error('Failed to read selected Markdown file.'));

--- a/packages/platform-adapters/src/adapters/chrome-adapter.ts
+++ b/packages/platform-adapters/src/adapters/chrome-adapter.ts
@@ -305,7 +305,12 @@ export class ChromeAdapter implements PlatformAdapter {
   }
 
   downloadUpdate(): void {
-    void this.sendMessage<void>({ type: CHROME_MESSAGE_TYPES.DOWNLOAD_UPDATE });
+    this.sendMessage<void>({ type: CHROME_MESSAGE_TYPES.DOWNLOAD_UPDATE }).catch(
+      (error: unknown) => {
+        const message = error instanceof Error ? error.message : String(error);
+        console.warn(`Chrome adapter download update message skipped: ${message}`);
+      }
+    );
   }
 
   async sendMessage<TResponse = unknown, TPayload = unknown>(

--- a/packages/platform-adapters/src/adapters/chrome-adapter.ts
+++ b/packages/platform-adapters/src/adapters/chrome-adapter.ts
@@ -125,7 +125,6 @@ export class ChromeAdapter implements PlatformAdapter {
             this.openedFiles.set(path, content);
             try {
               await this.storage.setItem(`${STORAGE_KEYS.FILE_CONTENT_PREFIX}${path}`, content);
-              resolve(path);
             } catch (error: unknown) {
               const errorMessage = error instanceof Error ? error.message : '';
               const errorName =
@@ -134,15 +133,16 @@ export class ChromeAdapter implements PlatformAdapter {
                   : '';
 
               if (errorMessage.includes('QUOTA_BYTES') || errorName === 'QuotaExceededError') {
-                reject(
-                  new Error(
-                    'Extension storage limit (10MB) exceeded. Please clear some files to free up space.'
-                  )
+                console.warn(
+                  'Extension storage limit (10MB) exceeded. File opened for this session but not persisted.'
                 );
               } else {
-                reject(error instanceof Error ? error : new Error('Failed to cache file content.'));
+                console.warn(
+                  error instanceof Error ? error : new Error('Failed to cache file content.')
+                );
               }
             }
+            resolve(path);
           };
           reader.onerror = () => {
             reject(reader.error ?? new Error('Failed to read selected Markdown file.'));

--- a/packages/platform-adapters/src/adapters/chrome-adapter.ts
+++ b/packages/platform-adapters/src/adapters/chrome-adapter.ts
@@ -1,0 +1,314 @@
+import { DEFAULT_SETTINGS } from '@package/shared-types';
+import type { AppSettings, FileType, FolderSearchResult, RecentFile } from '@package/shared-types';
+import {
+  CHROME_MESSAGE_TYPES,
+  DEFAULT_APP_VERSION,
+  PLATFORM_KIND,
+  STORAGE_KEYS,
+} from '../utils/constants/adapter-constants';
+import { createUnsupportedPlatformMethod, getChromeApi } from '../utils/helpers/adapter-helper';
+import type { PlatformAdapter, PlatformMessage } from '../types/platform-type';
+import type { StorageAdapter } from '../types/storage-type';
+import type {
+  ChromeMessageResponse,
+  ChromeExtensionApi,
+  ChromeRuntimeEvent,
+} from '../types/chrome-type';
+
+class ChromeStorageAdapter implements StorageAdapter {
+  constructor(private readonly chromeApi: ChromeExtensionApi) {}
+
+  async getItem<T>(key: string): Promise<T | null> {
+    const area = this.chromeApi.storage?.local;
+    if (!area) createUnsupportedPlatformMethod('chrome.storage.local.get');
+
+    const result = await area.get(key);
+    return (result[key] as T | undefined) ?? null;
+  }
+
+  async setItem<T>(key: string, value: T): Promise<void> {
+    const area = this.chromeApi.storage?.local;
+    if (!area) createUnsupportedPlatformMethod('chrome.storage.local.set');
+
+    await area.set({ [key]: value });
+  }
+
+  async removeItem(key: string): Promise<void> {
+    const area = this.chromeApi.storage?.local;
+    if (!area) createUnsupportedPlatformMethod('chrome.storage.local.remove');
+
+    await area.remove(key);
+  }
+
+  async clear(): Promise<void> {
+    const area = this.chromeApi.storage?.local;
+    if (!area) createUnsupportedPlatformMethod('chrome.storage.local.clear');
+
+    await area.clear();
+  }
+}
+
+export class ChromeAdapter implements PlatformAdapter {
+  readonly kind = PLATFORM_KIND.CHROME;
+  readonly storage: StorageAdapter;
+  private readonly chromeApi: ChromeExtensionApi;
+  private readonly openedFiles = new Map<string, string>();
+  private fileChangedListener: ((message: unknown) => void) | null = null;
+  private openFilePathListener: ((message: unknown) => void) | null = null;
+  private readonly menuListeners = new Map<string, (message: unknown) => void>();
+
+  constructor(chromeApi: ChromeExtensionApi | null = getChromeApi()) {
+    if (!chromeApi?.runtime?.sendMessage || !chromeApi.storage?.local) {
+      throw new Error('ChromeAdapter requires chrome.runtime and chrome.storage.local.');
+    }
+
+    this.chromeApi = chromeApi;
+    this.storage = new ChromeStorageAdapter(chromeApi);
+  }
+
+  async readFile(path: string): Promise<string> {
+    const inMemoryContent = this.openedFiles.get(path);
+    if (inMemoryContent !== undefined) {
+      return inMemoryContent;
+    }
+
+    const storedContent = await this.storage.getItem<string>(
+      `${STORAGE_KEYS.FILE_CONTENT_PREFIX}${path}`
+    );
+    if (storedContent !== null) {
+      this.openedFiles.set(path, storedContent);
+      return storedContent;
+    }
+
+    return this.sendMessage<string>({
+      type: CHROME_MESSAGE_TYPES.READ_FILE,
+      payload: { path },
+    });
+  }
+
+  async watchFile(): Promise<void> {
+    return undefined;
+  }
+
+  async unWatchFile(): Promise<void> {
+    return undefined;
+  }
+
+  async openFileDialog(): Promise<string | null> {
+    if (typeof document === 'undefined') {
+      return this.sendMessage<string | null>({
+        type: CHROME_MESSAGE_TYPES.OPEN_FILE_DIALOG,
+      });
+    }
+
+    return new Promise((resolve, reject) => {
+      const input = document.createElement('input');
+      input.type = 'file';
+      input.accept = '.md,.markdown,text/markdown,text/plain';
+      input.style.display = 'none';
+
+      input.addEventListener(
+        'change',
+        () => {
+          const file = input.files?.[0];
+          input.remove();
+
+          if (!file) {
+            resolve(null);
+            return;
+          }
+
+          const reader = new FileReader();
+          reader.onload = () => {
+            const content = String(reader.result ?? '');
+            const path = file.name;
+            this.openedFiles.set(path, content);
+            void this.storage.setItem(`${STORAGE_KEYS.FILE_CONTENT_PREFIX}${path}`, content);
+            resolve(path);
+          };
+          reader.onerror = () => {
+            reject(reader.error ?? new Error('Failed to read selected Markdown file.'));
+          };
+          reader.readAsText(file);
+        },
+        { once: true }
+      );
+
+      document.body.appendChild(input);
+      input.click();
+    });
+  }
+
+  openFolderDialog(): Promise<string | null> {
+    return this.sendMessage<string | null>({
+      type: CHROME_MESSAGE_TYPES.OPEN_FOLDER_DIALOG,
+    });
+  }
+
+  readFolder(path: string): Promise<FileType | null> {
+    return this.sendMessage<FileType | null>({
+      type: CHROME_MESSAGE_TYPES.READ_FOLDER,
+      payload: { path },
+    });
+  }
+
+  async getRecentFiles(): Promise<RecentFile[]> {
+    return (await this.storage.getItem<RecentFile[]>(STORAGE_KEYS.RECENT_FILES)) ?? [];
+  }
+
+  async addRecentFile(path: string): Promise<void> {
+    const recentFiles = await this.getRecentFiles();
+    const next: RecentFile[] = [
+      { path, name: path.split(/[\\/]/).pop() || path, openedAt: Date.now() },
+      ...recentFiles.filter((file) => file.path !== path),
+    ];
+
+    await this.storage.setItem(
+      STORAGE_KEYS.RECENT_FILES,
+      next.slice(0, DEFAULT_SETTINGS.recentFilesLimit)
+    );
+  }
+
+  clearRecentFiles(): Promise<void> {
+    return this.storage.setItem(STORAGE_KEYS.RECENT_FILES, []);
+  }
+
+  async getSettings(): Promise<AppSettings> {
+    const stored = await this.storage.getItem<Partial<AppSettings>>(STORAGE_KEYS.SETTINGS);
+    return { ...DEFAULT_SETTINGS, ...stored };
+  }
+
+  async saveSettings(settings: Partial<AppSettings>): Promise<AppSettings> {
+    const next = { ...(await this.getSettings()), ...settings };
+    await this.storage.setItem(STORAGE_KEYS.SETTINGS, next);
+    return next;
+  }
+
+  async getAppVersion(): Promise<string> {
+    return DEFAULT_APP_VERSION;
+  }
+
+  searchFolder(path: string, query: string): Promise<FolderSearchResult[]> {
+    return this.sendMessage<FolderSearchResult[]>({
+      type: CHROME_MESSAGE_TYPES.SEARCH_FOLDER,
+      payload: { path, query },
+    });
+  }
+
+  onFileChanged(callback: (path: string) => void): void {
+    this.fileChangedListener = (message) => {
+      if (isRuntimeEvent(message, 'file-changed') && typeof message.payload === 'string') {
+        callback(message.payload);
+      }
+    };
+    this.chromeApi.runtime?.onMessage?.addListener(this.fileChangedListener);
+  }
+
+  removeFileChangedListener(): void {
+    if (this.fileChangedListener) {
+      this.chromeApi.runtime?.onMessage?.removeListener(this.fileChangedListener);
+      this.fileChangedListener = null;
+    }
+  }
+
+  onMenuEvent(event: string, callback: (payload?: unknown) => void): () => void {
+    const listener = (message: unknown) => {
+      if (isRuntimeEvent(message, event)) {
+        callback(message.payload);
+      }
+    };
+
+    this.menuListeners.set(event, listener);
+    this.chromeApi.runtime?.onMessage?.addListener(listener);
+    return () => {
+      this.chromeApi.runtime?.onMessage?.removeListener(listener);
+      this.menuListeners.delete(event);
+    };
+  }
+
+  removeMenuListeners(): void {
+    this.menuListeners.forEach((listener) => {
+      this.chromeApi.runtime?.onMessage?.removeListener(listener);
+    });
+    this.menuListeners.clear();
+  }
+
+  onOpenFilePath(callback: (path: string) => void): void {
+    this.openFilePathListener = (message) => {
+      if (isRuntimeEvent(message, 'open-file-path') && typeof message.payload === 'string') {
+        callback(message.payload);
+      }
+    };
+    this.chromeApi.runtime?.onMessage?.addListener(this.openFilePathListener);
+  }
+
+  removeOpenFilePathListener(): void {
+    if (this.openFilePathListener) {
+      this.chromeApi.runtime?.onMessage?.removeListener(this.openFilePathListener);
+      this.openFilePathListener = null;
+    }
+  }
+
+  showSaveDialog(options?: { defaultExt?: string; defaultPath?: string }): Promise<string | null> {
+    return this.sendMessage<string | null>({
+      type: CHROME_MESSAGE_TYPES.SHOW_SAVE_DIALOG,
+      payload: options,
+    });
+  }
+
+  exportHTML(html: string, css: string, outputPath: string): Promise<void> {
+    return this.sendMessage<void>({
+      type: CHROME_MESSAGE_TYPES.EXPORT_HTML,
+      payload: { html, css, outputPath },
+    });
+  }
+
+  exportPDF(html: string, css: string, outputPath: string): Promise<void> {
+    return this.sendMessage<void>({
+      type: CHROME_MESSAGE_TYPES.EXPORT_PDF,
+      payload: { html, css, outputPath },
+    });
+  }
+
+  exportDOCX(html: string, css: string, outputPath: string): Promise<void> {
+    return this.sendMessage<void>({
+      type: CHROME_MESSAGE_TYPES.EXPORT_DOCX,
+      payload: { html, css, outputPath },
+    });
+  }
+
+  getPathForFile(file: File): string {
+    return file.name;
+  }
+
+  onUpdateAvailable(): () => void {
+    return () => {};
+  }
+
+  downloadUpdate(): void {
+    void this.sendMessage<void>({ type: CHROME_MESSAGE_TYPES.DOWNLOAD_UPDATE });
+  }
+
+  async sendMessage<TResponse = unknown, TPayload = unknown>(
+    message: PlatformMessage<TPayload>
+  ): Promise<TResponse> {
+    const runtime = this.chromeApi.runtime;
+    if (!runtime?.sendMessage) createUnsupportedPlatformMethod('chrome.runtime.sendMessage');
+
+    const response = await runtime.sendMessage<ChromeMessageResponse<TResponse>>(message);
+    if (!response.ok) {
+      throw new Error(response.error);
+    }
+
+    return response.data;
+  }
+}
+
+function isRuntimeEvent(message: unknown, type: string): message is ChromeRuntimeEvent {
+  return (
+    typeof message === 'object' &&
+    message !== null &&
+    'type' in message &&
+    (message as { type?: unknown }).type === type
+  );
+}

--- a/packages/platform-adapters/src/adapters/electron-adapter.ts
+++ b/packages/platform-adapters/src/adapters/electron-adapter.ts
@@ -13,7 +13,12 @@ import type { StorageAdapter } from '../types/storage-type';
 class BrowserLocalStorageAdapter implements StorageAdapter {
   async getItem<T>(key: string): Promise<T | null> {
     const value = globalThis.localStorage?.getItem(key);
-    return value ? (JSON.parse(value) as T) : null;
+    if (!value) return null;
+    try {
+      return JSON.parse(value) as T;
+    } catch {
+      return null;
+    }
   }
 
   async setItem<T>(key: string, value: T): Promise<void> {
@@ -148,8 +153,8 @@ export class ElectronAdapter implements PlatformAdapter {
   }
 
   async sendMessage<TResponse = unknown, TPayload = unknown>(
-    message: PlatformMessage<TPayload>
+    _message: PlatformMessage<TPayload>
   ): Promise<TResponse> {
-    return message as TResponse;
+    throw new Error('send message is an unsupported operation in the electron runtime environment');
   }
 }

--- a/packages/platform-adapters/src/adapters/electron-adapter.ts
+++ b/packages/platform-adapters/src/adapters/electron-adapter.ts
@@ -1,0 +1,155 @@
+import type {
+  AppSettings,
+  FileType,
+  FolderSearchResult,
+  MarkdownReaderAPI,
+  RecentFile,
+} from '@package/shared-types';
+import { PLATFORM_KIND } from '../utils/constants/adapter-constants';
+import { getElectronApi } from '../utils/helpers/adapter-helper';
+import type { PlatformAdapter, PlatformMessage } from '../types/platform-type';
+import type { StorageAdapter } from '../types/storage-type';
+
+class BrowserLocalStorageAdapter implements StorageAdapter {
+  async getItem<T>(key: string): Promise<T | null> {
+    const value = globalThis.localStorage?.getItem(key);
+    return value ? (JSON.parse(value) as T) : null;
+  }
+
+  async setItem<T>(key: string, value: T): Promise<void> {
+    globalThis.localStorage?.setItem(key, JSON.stringify(value));
+  }
+
+  async removeItem(key: string): Promise<void> {
+    globalThis.localStorage?.removeItem(key);
+  }
+
+  async clear(): Promise<void> {
+    globalThis.localStorage?.clear();
+  }
+}
+
+export class ElectronAdapter implements PlatformAdapter {
+  readonly kind = PLATFORM_KIND.ELECTRON;
+  readonly storage: StorageAdapter;
+  private readonly api: MarkdownReaderAPI;
+
+  constructor(api: MarkdownReaderAPI | null = getElectronApi()) {
+    if (!api) {
+      throw new Error('ElectronAdapter requires window.api from the preload bridge.');
+    }
+
+    this.api = api;
+    this.storage = new BrowserLocalStorageAdapter();
+  }
+
+  readFile(path: string): Promise<string> {
+    return this.api.readFile(path);
+  }
+
+  watchFile(path: string): Promise<void> {
+    return this.api.watchFile(path);
+  }
+
+  unWatchFile(path: string): Promise<void> {
+    return this.api.unWatchFile(path);
+  }
+
+  openFileDialog(): Promise<string | null> {
+    return this.api.openFileDialog();
+  }
+
+  openFolderDialog(): Promise<string | null> {
+    return this.api.openFolderDialog();
+  }
+
+  readFolder(path: string): Promise<FileType | null> {
+    return this.api.readFolder(path);
+  }
+
+  getRecentFiles(): Promise<RecentFile[]> {
+    return this.api.getRecentFiles();
+  }
+
+  addRecentFile(path: string): Promise<void> {
+    return this.api.addRecentFile(path);
+  }
+
+  clearRecentFiles(): Promise<void> {
+    return this.api.clearRecentFiles();
+  }
+
+  getSettings(): Promise<AppSettings> {
+    return this.api.getSettings();
+  }
+
+  saveSettings(settings: Partial<AppSettings>): Promise<AppSettings> {
+    return this.api.saveSettings(settings);
+  }
+
+  getAppVersion(): Promise<string> {
+    return this.api.getAppVersion();
+  }
+
+  searchFolder(path: string, query: string): Promise<FolderSearchResult[]> {
+    return this.api.searchFolder(path, query);
+  }
+
+  onFileChanged(callback: (path: string) => void): void {
+    this.api.onFileChanged(callback);
+  }
+
+  removeFileChangedListener(): void {
+    this.api.removeFileChangedListener();
+  }
+
+  onMenuEvent(event: string, callback: (payload?: unknown) => void): () => void {
+    return this.api.onMenuEvent(event, callback);
+  }
+
+  removeMenuListeners(): void {
+    this.api.removeMenuListeners();
+  }
+
+  onOpenFilePath(callback: (path: string) => void): void {
+    this.api.onOpenFilePath(callback);
+  }
+
+  removeOpenFilePathListener(): void {
+    this.api.removeOpenFilePathListener();
+  }
+
+  showSaveDialog(options?: { defaultExt?: string; defaultPath?: string }): Promise<string | null> {
+    return this.api.showSaveDialog(options);
+  }
+
+  exportHTML(html: string, css: string, outputPath: string): Promise<void> {
+    return this.api.exportHTML(html, css, outputPath);
+  }
+
+  exportPDF(html: string, css: string, outputPath: string): Promise<void> {
+    return this.api.exportPDF(html, css, outputPath);
+  }
+
+  exportDOCX(html: string, css: string, outputPath: string): Promise<void> {
+    return this.api.exportDOCX(html, css, outputPath);
+  }
+
+  getPathForFile(file: File): string {
+    return this.api.getPathForFile(file);
+  }
+
+  onUpdateAvailable(callback: (version: string) => void): () => void {
+    return this.api.onUpdateAvailable(callback);
+  }
+
+  downloadUpdate(): void {
+    this.api.downloadUpdate();
+  }
+
+  async sendMessage<TResponse = unknown, TPayload = unknown>(
+    message: PlatformMessage<TPayload>
+  ): Promise<TResponse> {
+    return message as TResponse;
+  }
+}

--- a/packages/platform-adapters/src/index.ts
+++ b/packages/platform-adapters/src/index.ts
@@ -1,0 +1,17 @@
+export { ChromeAdapter } from './adapters/chrome-adapter';
+export { ElectronAdapter } from './adapters/electron-adapter';
+export {
+  PLATFORM_KIND,
+  STORAGE_KEYS,
+  CHROME_MESSAGE_TYPES,
+} from './utils/constants/adapter-constants';
+export {
+  isChromeExtensionRuntime,
+  getChromeApi,
+  getElectronApi,
+  isElectronRuntime,
+  createUnsupportedPlatformMethod,
+  toErrorMessage,
+} from './utils/helpers/adapter-helper';
+export type { StorageAdapter } from './types/storage-type';
+export type { PlatformKind, PlatformAdapter, PlatformMessage } from './types/platform-type';

--- a/packages/platform-adapters/src/types/chrome-type.ts
+++ b/packages/platform-adapters/src/types/chrome-type.ts
@@ -9,8 +9,20 @@ export type ChromeRuntime = {
   lastError?: { message?: string };
   sendMessage<TResponse = unknown>(message: unknown): Promise<TResponse>;
   onMessage?: {
-    addListener(listener: (message: unknown) => void): void;
-    removeListener(listener: (message: unknown) => void): void;
+    addListener(
+      listener: (
+        message: unknown,
+        sender: unknown,
+        sendResponse: (response?: unknown) => void
+      ) => boolean | void
+    ): void;
+    removeListener(
+      listener: (
+        message: unknown,
+        sender: unknown,
+        sendResponse: (response?: unknown) => void
+      ) => void
+    ): void;
   };
 };
 

--- a/packages/platform-adapters/src/types/chrome-type.ts
+++ b/packages/platform-adapters/src/types/chrome-type.ts
@@ -8,6 +8,7 @@ export type ChromeStorageArea = {
 export type ChromeRuntime = {
   lastError?: { message?: string };
   sendMessage<TResponse = unknown>(message: unknown): Promise<TResponse>;
+  getManifest(): { version: string; [key: string]: unknown };
   onMessage?: {
     addListener(
       listener: (

--- a/packages/platform-adapters/src/types/chrome-type.ts
+++ b/packages/platform-adapters/src/types/chrome-type.ts
@@ -1,0 +1,37 @@
+export type ChromeStorageArea = {
+  get(keys?: string | string[] | Record<string, unknown> | null): Promise<Record<string, unknown>>;
+  set(items: Record<string, unknown>): Promise<void>;
+  remove(keys: string | string[]): Promise<void>;
+  clear(): Promise<void>;
+};
+
+export type ChromeRuntime = {
+  lastError?: { message?: string };
+  sendMessage<TResponse = unknown>(message: unknown): Promise<TResponse>;
+  onMessage?: {
+    addListener(listener: (message: unknown) => void): void;
+    removeListener(listener: (message: unknown) => void): void;
+  };
+};
+
+export type ChromeExtensionApi = {
+  storage?: {
+    local?: ChromeStorageArea;
+  };
+  runtime?: ChromeRuntime;
+};
+
+export type ChromeMessageResponse<TResponse> =
+  | {
+      ok: true;
+      data: TResponse;
+    }
+  | {
+      ok: false;
+      error: string;
+    };
+
+export interface ChromeRuntimeEvent<TPayload = unknown> {
+  type: string;
+  payload?: TPayload;
+}

--- a/packages/platform-adapters/src/types/platform-type.ts
+++ b/packages/platform-adapters/src/types/platform-type.ts
@@ -1,0 +1,44 @@
+import type { AppSettings, FileType, FolderSearchResult, RecentFile } from '@package/shared-types';
+import type { StorageAdapter } from './storage-type';
+
+export type PlatformKind = 'electron' | 'chrome';
+
+export interface PlatformMessage<TPayload = unknown> {
+  type: string;
+  payload?: TPayload;
+}
+
+export interface PlatformAdapter {
+  readonly kind: PlatformKind;
+  readonly storage: StorageAdapter;
+
+  readFile(path: string): Promise<string>;
+  watchFile(path: string): Promise<void>;
+  unWatchFile(path: string): Promise<void>;
+  openFileDialog(): Promise<string | null>;
+  openFolderDialog(): Promise<string | null>;
+  readFolder(path: string): Promise<FileType | null>;
+  getRecentFiles(): Promise<RecentFile[]>;
+  addRecentFile(path: string): Promise<void>;
+  clearRecentFiles(): Promise<void>;
+  getSettings(): Promise<AppSettings>;
+  saveSettings(settings: Partial<AppSettings>): Promise<AppSettings>;
+  getAppVersion(): Promise<string>;
+  searchFolder(path: string, query: string): Promise<FolderSearchResult[]>;
+  onFileChanged(callback: (path: string) => void): void;
+  removeFileChangedListener(): void;
+  onMenuEvent(event: string, callback: (payload?: unknown) => void): () => void;
+  removeMenuListeners(): void;
+  onOpenFilePath(callback: (path: string) => void): void;
+  removeOpenFilePathListener(): void;
+  showSaveDialog(options?: { defaultExt?: string; defaultPath?: string }): Promise<string | null>;
+  exportHTML(html: string, css: string, outputPath: string): Promise<void>;
+  exportPDF(html: string, css: string, outputPath: string): Promise<void>;
+  exportDOCX(html: string, css: string, outputPath: string): Promise<void>;
+  getPathForFile(file: File): string;
+  onUpdateAvailable(callback: (version: string) => void): () => void;
+  downloadUpdate(): void;
+  sendMessage<TResponse = unknown, TPayload = unknown>(
+    message: PlatformMessage<TPayload>
+  ): Promise<TResponse>;
+}

--- a/packages/platform-adapters/src/types/storage-type.ts
+++ b/packages/platform-adapters/src/types/storage-type.ts
@@ -1,0 +1,6 @@
+export interface StorageAdapter {
+  getItem<T>(key: string): Promise<T | null>;
+  setItem<T>(key: string, value: T): Promise<void>;
+  removeItem(key: string): Promise<void>;
+  clear(): Promise<void>;
+}

--- a/packages/platform-adapters/src/utils/constants/adapter-constants.ts
+++ b/packages/platform-adapters/src/utils/constants/adapter-constants.ts
@@ -1,3 +1,4 @@
+import { getChromeApi } from '../helpers/adapter-helper';
 export const PLATFORM_KIND = {
   ELECTRON: 'electron',
   CHROME: 'chrome',
@@ -24,4 +25,6 @@ export const CHROME_MESSAGE_TYPES = {
   DOWNLOAD_UPDATE: 'markdown-reader:download-update',
 } as const;
 
-export const DEFAULT_APP_VERSION = 'Chrome Extension';
+const chromeApi = getChromeApi();
+export const DEFAULT_APP_VERSION =
+  chromeApi?.runtime?.getManifest?.()?.version ?? '1.0.0-extension';

--- a/packages/platform-adapters/src/utils/constants/adapter-constants.ts
+++ b/packages/platform-adapters/src/utils/constants/adapter-constants.ts
@@ -1,0 +1,27 @@
+export const PLATFORM_KIND = {
+  ELECTRON: 'electron',
+  CHROME: 'chrome',
+} as const;
+
+export const STORAGE_KEYS = {
+  SETTINGS: 'markdown-reader:settings',
+  RECENT_FILES: 'markdown-reader:recent-files',
+  FILE_CONTENT_PREFIX: 'markdown-reader:file-content:',
+} as const;
+
+export const CHROME_MESSAGE_TYPES = {
+  READ_FILE: 'markdown-reader:read-file',
+  OPEN_FILE_DIALOG: 'markdown-reader:open-file-dialog',
+  OPEN_FOLDER_DIALOG: 'markdown-reader:open-folder-dialog',
+  READ_FOLDER: 'markdown-reader:read-folder',
+  SEARCH_FOLDER: 'markdown-reader:search-folder',
+  WATCH_FILE: 'markdown-reader:watch-file',
+  UNWATCH_FILE: 'markdown-reader:unwatch-file',
+  SHOW_SAVE_DIALOG: 'markdown-reader:show-save-dialog',
+  EXPORT_HTML: 'markdown-reader:export-html',
+  EXPORT_PDF: 'markdown-reader:export-pdf',
+  EXPORT_DOCX: 'markdown-reader:export-docx',
+  DOWNLOAD_UPDATE: 'markdown-reader:download-update',
+} as const;
+
+export const DEFAULT_APP_VERSION = 'Chrome Extension';

--- a/packages/platform-adapters/src/utils/helpers/adapter-helper.ts
+++ b/packages/platform-adapters/src/utils/helpers/adapter-helper.ts
@@ -1,0 +1,34 @@
+import type { MarkdownReaderAPI } from '@package/shared-types';
+import type { ChromeExtensionApi } from '../../types/chrome-type';
+
+export function getElectronApi(): MarkdownReaderAPI | null {
+  const candidate = globalThis as typeof globalThis & {
+    window?: { api?: MarkdownReaderAPI };
+  };
+
+  return candidate.window?.api ?? null;
+}
+
+export function getChromeApi(): ChromeExtensionApi | null {
+  const candidate = globalThis as typeof globalThis & {
+    chrome?: ChromeExtensionApi;
+  };
+
+  return candidate.chrome ?? null;
+}
+
+export function isElectronRuntime(): boolean {
+  return Boolean(getElectronApi());
+}
+
+export function isChromeExtensionRuntime(): boolean {
+  return Boolean(getChromeApi()?.runtime?.sendMessage && getChromeApi()?.storage?.local);
+}
+
+export function createUnsupportedPlatformMethod(methodName: string): never {
+  throw new Error(`${methodName} is not supported by this platform adapter.`);
+}
+
+export function toErrorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}

--- a/packages/platform-adapters/tsconfig.json
+++ b/packages/platform-adapters/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "rootDir": "./",
+    "outDir": "./dist",
+    "module": "esnext",
+    "moduleResolution": "Bundler"
+  },
+  "include": ["src"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/packages/platform-adapters/vitest.config.ts
+++ b/packages/platform-adapters/vitest.config.ts
@@ -1,0 +1,18 @@
+import { resolve } from 'path';
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'jsdom',
+    globals: true,
+    setupFiles: './setup.ts',
+    coverage: {
+      exclude: ['__tests__/**', 'dist/**', 'node_modules/**', 'setup.ts', 'vitest.config.ts'],
+    },
+  },
+  resolve: {
+    alias: {
+      '@platform-adapters': resolve(__dirname, './src'),
+    },
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,11 @@ overrides:
   serialize-javascript: '>=7.0.5'
   fast-uri: '>=3.1.2'
   tmp: '>=0.2.6'
+  shell-quote: '>=1.8.4'
+  esbuild: '>=0.28.1'
+  ws: '>=8.21.0'
+  form-data: '>=4.0.6'
+  vite: '>=7.3.5'
 
 importers:
 
@@ -37,10 +42,7 @@ importers:
         version: 0.5.19(tailwindcss@4.2.4)
       '@tailwindcss/vite':
         specifier: ^4.2.4
-        version: 4.2.4(vite@7.3.2(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.47.1)(yaml@2.8.3))
-      '@types/chrome':
-        specifier: ^0.1.43
-        version: 0.1.43
+        version: 4.2.4(vite@8.0.16(@types/node@25.6.0)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.47.1)(yaml@2.8.3))
       '@types/node':
         specifier: ^25.6.0
         version: 25.6.0
@@ -58,7 +60,7 @@ importers:
         version: 8.59.1(eslint@10.2.1(jiti@2.6.1))(typescript@6.0.3)
       '@vitejs/plugin-react':
         specifier: ^5.2.0
-        version: 5.2.0(vite@7.3.2(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.47.1)(yaml@2.8.3))
+        version: 5.2.0(vite@8.0.16(@types/node@25.6.0)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.47.1)(yaml@2.8.3))
       electron:
         specifier: ^41.2.2
         version: 41.3.0
@@ -67,7 +69,7 @@ importers:
         version: 26.8.1(electron-builder-squirrel-windows@26.8.1)
       electron-vite:
         specifier: ^5.0.0
-        version: 5.0.0(@swc/core@1.15.33)(vite@7.3.2(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.47.1)(yaml@2.8.3))
+        version: 5.0.0(@swc/core@1.15.33)(vite@8.0.16(@types/node@25.6.0)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.47.1)(yaml@2.8.3))
       eslint:
         specifier: ^10.2.0
         version: 10.2.1(jiti@2.6.1)
@@ -96,8 +98,8 @@ importers:
         specifier: ^8.58.2
         version: 8.59.1(eslint@10.2.1(jiti@2.6.1))(typescript@6.0.3)
       vite:
-        specifier: ^7.3.2
-        version: 7.3.2(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.47.1)(yaml@2.8.3)
+        specifier: '>=7.3.5'
+        version: 8.0.16(@types/node@25.6.0)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.47.1)(yaml@2.8.3)
 
   apps/extension:
     dependencies:
@@ -140,7 +142,7 @@ importers:
         version: 1.60.0
       vitest:
         specifier: ^4.1.5
-        version: 4.1.5(@types/node@25.6.0)(@vitest/coverage-v8@4.1.5)(jsdom@29.1.1)(vite@7.3.2(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.47.1)(yaml@2.8.3))
+        version: 4.1.5(@types/node@25.6.0)(@vitest/coverage-v8@4.1.5)(jsdom@29.1.1)(vite@8.0.16(@types/node@25.6.0)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.47.1)(yaml@2.8.3))
 
   apps/preload:
     dependencies:
@@ -198,19 +200,19 @@ importers:
         version: 29.1.1
       vitest:
         specifier: ^4.1.5
-        version: 4.1.5(@types/node@25.6.0)(@vitest/coverage-v8@4.1.5)(jsdom@29.1.1)(vite@7.3.2(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.47.1)(yaml@2.8.3))
+        version: 4.1.5(@types/node@25.6.0)(@vitest/coverage-v8@4.1.5)(jsdom@29.1.1)(vite@8.0.16(@types/node@25.6.0)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.47.1)(yaml@2.8.3))
 
   docs:
     dependencies:
       '@docusaurus/core':
         specifier: 3.10.1
-        version: 3.10.1(@docusaurus/faster@3.10.1(@docusaurus/types@3.10.1(@swc/core@1.15.33)(lightningcss@1.32.0)(postcss@8.5.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(postcss@8.5.14))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(@rspack/core@1.7.11)(@swc/core@1.15.33)(lightningcss@1.32.0)(postcss@8.5.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)
+        version: 3.10.1(@docusaurus/faster@3.10.1(@docusaurus/types@3.10.1(@swc/core@1.15.33)(esbuild@0.28.1)(postcss@8.5.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(esbuild@0.28.1)(postcss@8.5.14))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(@rspack/core@1.7.11)(@swc/core@1.15.33)(esbuild@0.28.1)(postcss@8.5.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)
       '@docusaurus/faster':
         specifier: 3.10.1
-        version: 3.10.1(@docusaurus/types@3.10.1(@swc/core@1.15.33)(lightningcss@1.32.0)(postcss@8.5.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(postcss@8.5.14)
+        version: 3.10.1(@docusaurus/types@3.10.1(@swc/core@1.15.33)(esbuild@0.28.1)(postcss@8.5.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(esbuild@0.28.1)(postcss@8.5.14)
       '@docusaurus/preset-classic':
         specifier: 3.10.1
-        version: 3.10.1(@algolia/client-search@5.52.1)(@docusaurus/faster@3.10.1(@docusaurus/types@3.10.1(@swc/core@1.15.33)(lightningcss@1.32.0)(postcss@8.5.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(postcss@8.5.14))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(@rspack/core@1.7.11)(@swc/core@1.15.33)(@types/react@19.2.14)(lightningcss@1.32.0)(postcss@8.5.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(search-insights@2.17.3)(typescript@6.0.3)
+        version: 3.10.1(@algolia/client-search@5.52.1)(@docusaurus/faster@3.10.1(@docusaurus/types@3.10.1(@swc/core@1.15.33)(esbuild@0.28.1)(postcss@8.5.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(esbuild@0.28.1)(postcss@8.5.14))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(@rspack/core@1.7.11)(@swc/core@1.15.33)(@types/react@19.2.14)(esbuild@0.28.1)(postcss@8.5.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(search-insights@2.17.3)(typescript@6.0.3)
       '@mdx-js/react':
         specifier: ^3.0.0
         version: 3.1.1(@types/react@19.2.14)(react@19.2.5)
@@ -235,13 +237,13 @@ importers:
     devDependencies:
       '@docusaurus/module-type-aliases':
         specifier: 3.10.1
-        version: 3.10.1(@swc/core@1.15.33)(lightningcss@1.32.0)(postcss@8.5.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+        version: 3.10.1(@swc/core@1.15.33)(esbuild@0.28.1)(postcss@8.5.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       '@docusaurus/tsconfig':
         specifier: 3.10.1
         version: 3.10.1
       '@docusaurus/types':
         specifier: 3.10.1
-        version: 3.10.1(@swc/core@1.15.33)(lightningcss@1.32.0)(postcss@8.5.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+        version: 3.10.1(@swc/core@1.15.33)(esbuild@0.28.1)(postcss@8.5.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       '@tailwindcss/postcss':
         specifier: ^4.3.0
         version: 4.3.0
@@ -281,7 +283,7 @@ importers:
         version: 29.1.1
       vitest:
         specifier: ^4.1.5
-        version: 4.1.5(@types/node@25.6.0)(@vitest/coverage-v8@4.1.5)(jsdom@29.1.1)(vite@7.3.2(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.47.1)(yaml@2.8.3))
+        version: 4.1.5(@types/node@25.6.0)(@vitest/coverage-v8@4.1.5)(jsdom@29.1.1)(vite@8.0.16(@types/node@25.6.0)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.47.1)(yaml@2.8.3))
 
   packages/shared-constants: {}
 
@@ -1777,314 +1779,158 @@ packages:
   '@emnapi/wasi-threads@1.2.1':
     resolution: {integrity: sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==}
 
-  '@esbuild/aix-ppc64@0.25.12':
-    resolution: {integrity: sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==}
+  '@esbuild/aix-ppc64@0.28.1':
+    resolution: {integrity: sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==}
     engines: {node: '>=18'}
     cpu: [ppc64]
     os: [aix]
 
-  '@esbuild/aix-ppc64@0.27.7':
-    resolution: {integrity: sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==}
-    engines: {node: '>=18'}
-    cpu: [ppc64]
-    os: [aix]
-
-  '@esbuild/android-arm64@0.25.12':
-    resolution: {integrity: sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==}
+  '@esbuild/android-arm64@0.28.1':
+    resolution: {integrity: sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [android]
 
-  '@esbuild/android-arm64@0.27.7':
-    resolution: {integrity: sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [android]
-
-  '@esbuild/android-arm@0.25.12':
-    resolution: {integrity: sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg==}
+  '@esbuild/android-arm@0.28.1':
+    resolution: {integrity: sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==}
     engines: {node: '>=18'}
     cpu: [arm]
     os: [android]
 
-  '@esbuild/android-arm@0.27.7':
-    resolution: {integrity: sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==}
-    engines: {node: '>=18'}
-    cpu: [arm]
-    os: [android]
-
-  '@esbuild/android-x64@0.25.12':
-    resolution: {integrity: sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==}
+  '@esbuild/android-x64@0.28.1':
+    resolution: {integrity: sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [android]
 
-  '@esbuild/android-x64@0.27.7':
-    resolution: {integrity: sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==}
-    engines: {node: '>=18'}
-    cpu: [x64]
-    os: [android]
-
-  '@esbuild/darwin-arm64@0.25.12':
-    resolution: {integrity: sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==}
+  '@esbuild/darwin-arm64@0.28.1':
+    resolution: {integrity: sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [darwin]
 
-  '@esbuild/darwin-arm64@0.27.7':
-    resolution: {integrity: sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [darwin]
-
-  '@esbuild/darwin-x64@0.25.12':
-    resolution: {integrity: sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==}
+  '@esbuild/darwin-x64@0.28.1':
+    resolution: {integrity: sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [darwin]
 
-  '@esbuild/darwin-x64@0.27.7':
-    resolution: {integrity: sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==}
-    engines: {node: '>=18'}
-    cpu: [x64]
-    os: [darwin]
-
-  '@esbuild/freebsd-arm64@0.25.12':
-    resolution: {integrity: sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==}
+  '@esbuild/freebsd-arm64@0.28.1':
+    resolution: {integrity: sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [freebsd]
 
-  '@esbuild/freebsd-arm64@0.27.7':
-    resolution: {integrity: sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [freebsd]
-
-  '@esbuild/freebsd-x64@0.25.12':
-    resolution: {integrity: sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==}
+  '@esbuild/freebsd-x64@0.28.1':
+    resolution: {integrity: sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [freebsd]
 
-  '@esbuild/freebsd-x64@0.27.7':
-    resolution: {integrity: sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==}
-    engines: {node: '>=18'}
-    cpu: [x64]
-    os: [freebsd]
-
-  '@esbuild/linux-arm64@0.25.12':
-    resolution: {integrity: sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==}
+  '@esbuild/linux-arm64@0.28.1':
+    resolution: {integrity: sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [linux]
 
-  '@esbuild/linux-arm64@0.27.7':
-    resolution: {integrity: sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [linux]
-
-  '@esbuild/linux-arm@0.25.12':
-    resolution: {integrity: sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==}
+  '@esbuild/linux-arm@0.28.1':
+    resolution: {integrity: sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==}
     engines: {node: '>=18'}
     cpu: [arm]
     os: [linux]
 
-  '@esbuild/linux-arm@0.27.7':
-    resolution: {integrity: sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==}
-    engines: {node: '>=18'}
-    cpu: [arm]
-    os: [linux]
-
-  '@esbuild/linux-ia32@0.25.12':
-    resolution: {integrity: sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==}
+  '@esbuild/linux-ia32@0.28.1':
+    resolution: {integrity: sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==}
     engines: {node: '>=18'}
     cpu: [ia32]
     os: [linux]
 
-  '@esbuild/linux-ia32@0.27.7':
-    resolution: {integrity: sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==}
-    engines: {node: '>=18'}
-    cpu: [ia32]
-    os: [linux]
-
-  '@esbuild/linux-loong64@0.25.12':
-    resolution: {integrity: sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==}
+  '@esbuild/linux-loong64@0.28.1':
+    resolution: {integrity: sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==}
     engines: {node: '>=18'}
     cpu: [loong64]
     os: [linux]
 
-  '@esbuild/linux-loong64@0.27.7':
-    resolution: {integrity: sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==}
-    engines: {node: '>=18'}
-    cpu: [loong64]
-    os: [linux]
-
-  '@esbuild/linux-mips64el@0.25.12':
-    resolution: {integrity: sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==}
+  '@esbuild/linux-mips64el@0.28.1':
+    resolution: {integrity: sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==}
     engines: {node: '>=18'}
     cpu: [mips64el]
     os: [linux]
 
-  '@esbuild/linux-mips64el@0.27.7':
-    resolution: {integrity: sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==}
-    engines: {node: '>=18'}
-    cpu: [mips64el]
-    os: [linux]
-
-  '@esbuild/linux-ppc64@0.25.12':
-    resolution: {integrity: sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==}
+  '@esbuild/linux-ppc64@0.28.1':
+    resolution: {integrity: sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==}
     engines: {node: '>=18'}
     cpu: [ppc64]
     os: [linux]
 
-  '@esbuild/linux-ppc64@0.27.7':
-    resolution: {integrity: sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==}
-    engines: {node: '>=18'}
-    cpu: [ppc64]
-    os: [linux]
-
-  '@esbuild/linux-riscv64@0.25.12':
-    resolution: {integrity: sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==}
+  '@esbuild/linux-riscv64@0.28.1':
+    resolution: {integrity: sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==}
     engines: {node: '>=18'}
     cpu: [riscv64]
     os: [linux]
 
-  '@esbuild/linux-riscv64@0.27.7':
-    resolution: {integrity: sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==}
-    engines: {node: '>=18'}
-    cpu: [riscv64]
-    os: [linux]
-
-  '@esbuild/linux-s390x@0.25.12':
-    resolution: {integrity: sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==}
+  '@esbuild/linux-s390x@0.28.1':
+    resolution: {integrity: sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==}
     engines: {node: '>=18'}
     cpu: [s390x]
     os: [linux]
 
-  '@esbuild/linux-s390x@0.27.7':
-    resolution: {integrity: sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==}
-    engines: {node: '>=18'}
-    cpu: [s390x]
-    os: [linux]
-
-  '@esbuild/linux-x64@0.25.12':
-    resolution: {integrity: sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw==}
+  '@esbuild/linux-x64@0.28.1':
+    resolution: {integrity: sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [linux]
 
-  '@esbuild/linux-x64@0.27.7':
-    resolution: {integrity: sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==}
-    engines: {node: '>=18'}
-    cpu: [x64]
-    os: [linux]
-
-  '@esbuild/netbsd-arm64@0.25.12':
-    resolution: {integrity: sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==}
+  '@esbuild/netbsd-arm64@0.28.1':
+    resolution: {integrity: sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [netbsd]
 
-  '@esbuild/netbsd-arm64@0.27.7':
-    resolution: {integrity: sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [netbsd]
-
-  '@esbuild/netbsd-x64@0.25.12':
-    resolution: {integrity: sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==}
+  '@esbuild/netbsd-x64@0.28.1':
+    resolution: {integrity: sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [netbsd]
 
-  '@esbuild/netbsd-x64@0.27.7':
-    resolution: {integrity: sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==}
-    engines: {node: '>=18'}
-    cpu: [x64]
-    os: [netbsd]
-
-  '@esbuild/openbsd-arm64@0.25.12':
-    resolution: {integrity: sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==}
+  '@esbuild/openbsd-arm64@0.28.1':
+    resolution: {integrity: sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [openbsd]
 
-  '@esbuild/openbsd-arm64@0.27.7':
-    resolution: {integrity: sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [openbsd]
-
-  '@esbuild/openbsd-x64@0.25.12':
-    resolution: {integrity: sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw==}
+  '@esbuild/openbsd-x64@0.28.1':
+    resolution: {integrity: sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [openbsd]
 
-  '@esbuild/openbsd-x64@0.27.7':
-    resolution: {integrity: sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==}
-    engines: {node: '>=18'}
-    cpu: [x64]
-    os: [openbsd]
-
-  '@esbuild/openharmony-arm64@0.25.12':
-    resolution: {integrity: sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==}
+  '@esbuild/openharmony-arm64@0.28.1':
+    resolution: {integrity: sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [openharmony]
 
-  '@esbuild/openharmony-arm64@0.27.7':
-    resolution: {integrity: sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [openharmony]
-
-  '@esbuild/sunos-x64@0.25.12':
-    resolution: {integrity: sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==}
+  '@esbuild/sunos-x64@0.28.1':
+    resolution: {integrity: sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [sunos]
 
-  '@esbuild/sunos-x64@0.27.7':
-    resolution: {integrity: sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==}
-    engines: {node: '>=18'}
-    cpu: [x64]
-    os: [sunos]
-
-  '@esbuild/win32-arm64@0.25.12':
-    resolution: {integrity: sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==}
+  '@esbuild/win32-arm64@0.28.1':
+    resolution: {integrity: sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [win32]
 
-  '@esbuild/win32-arm64@0.27.7':
-    resolution: {integrity: sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [win32]
-
-  '@esbuild/win32-ia32@0.25.12':
-    resolution: {integrity: sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==}
+  '@esbuild/win32-ia32@0.28.1':
+    resolution: {integrity: sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==}
     engines: {node: '>=18'}
     cpu: [ia32]
     os: [win32]
 
-  '@esbuild/win32-ia32@0.27.7':
-    resolution: {integrity: sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==}
-    engines: {node: '>=18'}
-    cpu: [ia32]
-    os: [win32]
-
-  '@esbuild/win32-x64@0.25.12':
-    resolution: {integrity: sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==}
-    engines: {node: '>=18'}
-    cpu: [x64]
-    os: [win32]
-
-  '@esbuild/win32-x64@0.27.7':
-    resolution: {integrity: sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==}
+  '@esbuild/win32-x64@0.28.1':
+    resolution: {integrity: sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [win32]
@@ -2379,6 +2225,12 @@ packages:
   '@napi-rs/wasm-runtime@1.0.7':
     resolution: {integrity: sha512-SeDnOO0Tk7Okiq6DbXmmBODgOAb9dp9gjlphokTUxmt8U3liIP1ZsozBahH69j/RJv+Rfs6IwUKHTgQYJ/HBAw==}
 
+  '@napi-rs/wasm-runtime@1.1.5':
+    resolution: {integrity: sha512-AWPoBRJ9tsnVhor4sjO7rkni+7p+2IAEFj6cx06UgP10jkQHqay/36uRV/bFkgrh18D9vb4cr8Q0Pthskgzy+Q==}
+    peerDependencies:
+      '@emnapi/core': ^1.7.1
+      '@emnapi/runtime': ^1.7.1
+
   '@noble/hashes@1.4.0':
     resolution: {integrity: sha512-V1JJ1WTRUqHHrOSh597hURcMqVKVGL/ea3kv0gSnEdsEZ0/+VyPghM1lMNGc00z7CIQorSvbKpuJkxvuHbvdbg==}
     engines: {node: '>= 16'}
@@ -2435,6 +2287,9 @@ packages:
     resolution: {integrity: sha512-6gH/bLQJSJEg7OEpkH4wGQdA8KXHRbzL1YkGyUO12YNAgV3jxKy4K9kvfXj4+9T0OLug5k58cnPCKSSIKzp7pg==}
     engines: {node: '>=8.0'}
 
+  '@oxc-project/types@0.133.0':
+    resolution: {integrity: sha512-KzkdCd6Uxqnf6l3HOw1xfatAlUURA0g14cvBYFyJ5SaNOQbOUvBr9PKArcPcrNIeRsBdgcUzOGrhKveVpvOIGA==}
+
   '@peculiar/asn1-cms@2.7.0':
     resolution: {integrity: sha512-hew63shtzzvBcSHbhm+cyAmKe6AIfinT9hzEqSPjDC6opTTMKmTkQ0gHuN2KsWlvqiKw1S/fS94fhag/FJkioQ==}
 
@@ -2487,146 +2342,106 @@ packages:
   '@polka/url@1.0.0-next.29':
     resolution: {integrity: sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww==}
 
-  '@rolldown/pluginutils@1.0.0-rc.3':
-    resolution: {integrity: sha512-eybk3TjzzzV97Dlj5c+XrBFW57eTNhzod66y9HrBlzJ6NsCrWCp/2kaPS3K9wJmurBC0Tdw4yPjXKZqlznim3Q==}
-
-  '@rollup/rollup-android-arm-eabi@4.60.2':
-    resolution: {integrity: sha512-dnlp69efPPg6Uaw2dVqzWRfAWRnYVb1XJ8CyyhIbZeaq4CA5/mLeZ1IEt9QqQxmbdvagjLIm2ZL8BxXv5lH4Yw==}
-    cpu: [arm]
-    os: [android]
-
-  '@rollup/rollup-android-arm64@4.60.2':
-    resolution: {integrity: sha512-OqZTwDRDchGRHHm/hwLOL7uVPB9aUvI0am/eQuWMNyFHf5PSEQmyEeYYheA0EPPKUO/l0uigCp+iaTjoLjVoHg==}
+  '@rolldown/binding-android-arm64@1.0.3':
+    resolution: {integrity: sha512-454rs7jHngixp/NMxd5srYD57OnzSlZ/eFTETjORQHLwJG1lRtmNOJcBerZlfu4GjKqeq8aCCIQrMdHyhI51Hw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [android]
 
-  '@rollup/rollup-darwin-arm64@4.60.2':
-    resolution: {integrity: sha512-UwRE7CGpvSVEQS8gUMBe1uADWjNnVgP3Iusyda1nSRwNDCsRjnGc7w6El6WLQsXmZTbLZx9cecegumcitNfpmA==}
+  '@rolldown/binding-darwin-arm64@1.0.3':
+    resolution: {integrity: sha512-PcAhP+ynjURNyy8SKGl5DQP94aGuB/7JrXJb/t7P+hanXvQVMWzUvRRhBAcg/lNRadBhoUPqSoP4xw5tR/KBEA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [darwin]
 
-  '@rollup/rollup-darwin-x64@4.60.2':
-    resolution: {integrity: sha512-gjEtURKLCC5VXm1I+2i1u9OhxFsKAQJKTVB8WvDAHF+oZlq0GTVFOlTlO1q3AlCTE/DF32c16ESvfgqR7343/g==}
+  '@rolldown/binding-darwin-x64@1.0.3':
+    resolution: {integrity: sha512-9YpfeUvSE2RS7wysJ81uOZkXJz7f7Q55H2Gvp3VEw/EsahqDtrphrZ0EwDLK5vvKOzaCrBsjF8JmnMLcUt78Gg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [darwin]
 
-  '@rollup/rollup-freebsd-arm64@4.60.2':
-    resolution: {integrity: sha512-Bcl6CYDeAgE70cqZaMojOi/eK63h5Me97ZqAQoh77VPjMysA/4ORQBRGo3rRy45x4MzVlU9uZxs8Uwy7ZaKnBw==}
-    cpu: [arm64]
-    os: [freebsd]
-
-  '@rollup/rollup-freebsd-x64@4.60.2':
-    resolution: {integrity: sha512-LU+TPda3mAE2QB0/Hp5VyeKJivpC6+tlOXd1VMoXV/YFMvk/MNk5iXeBfB4MQGRWyOYVJ01625vjkr0Az98OJQ==}
+  '@rolldown/binding-freebsd-x64@1.0.3':
+    resolution: {integrity: sha512-yB1IlAsSNHncV6SCTL27/MVGR5htvQsoGxIv5KMGXALp+Ll1wYsn+x98M9MW7qa+NdSbvrrY7ANI4wLJ0n1e6g==}
+    engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [freebsd]
 
-  '@rollup/rollup-linux-arm-gnueabihf@4.60.2':
-    resolution: {integrity: sha512-2QxQrM+KQ7DAW4o22j+XZ6RKdxjLD7BOWTP0Bv0tmjdyhXSsr2Ul1oJDQqh9Zf5qOwTuTc7Ek83mOFaKnodPjg==}
+  '@rolldown/binding-linux-arm-gnueabihf@1.0.3':
+    resolution: {integrity: sha512-Yi30IVAAfLUCy2MseFjbB1jAMDl1VMCAas5StnYp8da9+CKvMd2H2cbEjWcw5NPaPqzvYkVIaF1nNUG+b7u/sw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
-  '@rollup/rollup-linux-arm-musleabihf@4.60.2':
-    resolution: {integrity: sha512-TbziEu2DVsTEOPif2mKWkMeDMLoYjx95oESa9fkQQK7r/Orta0gnkcDpzwufEcAO2BLBsD7mZkXGFqEdMRRwfw==}
-    cpu: [arm]
-    os: [linux]
-    libc: [musl]
-
-  '@rollup/rollup-linux-arm64-gnu@4.60.2':
-    resolution: {integrity: sha512-bO/rVDiDUuM2YfuCUwZ1t1cP+/yqjqz+Xf2VtkdppefuOFS2OSeAfgafaHNkFn0t02hEyXngZkxtGqXcXwO8Rg==}
+  '@rolldown/binding-linux-arm64-gnu@1.0.3':
+    resolution: {integrity: sha512-jsO7R8To+AdlYgUmN5sHSCZbfhtMBkO0WUx8iORQnPcMMdgr7qM2DQmMwgabs3GhNztdmoKkMKQFHD6DTMCIQw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
 
-  '@rollup/rollup-linux-arm64-musl@4.60.2':
-    resolution: {integrity: sha512-hr26p7e93Rl0Za+JwW7EAnwAvKkehh12BU1Llm9Ykiibg4uIr2rbpxG9WCf56GuvidlTG9KiiQT/TXT1yAWxTA==}
+  '@rolldown/binding-linux-arm64-musl@1.0.3':
+    resolution: {integrity: sha512-VWkUHwWriDciit80wleYwKILoR/KMvxh/IdwS/paX+ZgpuRpCrKLUdadJbc0NpBEiyhpYawsJ73j9aCvOH+f7Q==}
+    engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
     libc: [musl]
 
-  '@rollup/rollup-linux-loong64-gnu@4.60.2':
-    resolution: {integrity: sha512-pOjB/uSIyDt+ow3k/RcLvUAOGpysT2phDn7TTUB3n75SlIgZzM6NKAqlErPhoFU+npgY3/n+2HYIQVbF70P9/A==}
-    cpu: [loong64]
-    os: [linux]
-    libc: [glibc]
-
-  '@rollup/rollup-linux-loong64-musl@4.60.2':
-    resolution: {integrity: sha512-2/w+q8jszv9Ww1c+6uJT3OwqhdmGP2/4T17cu8WuwyUuuaCDDJ2ojdyYwZzCxx0GcsZBhzi3HmH+J5pZNXnd+Q==}
-    cpu: [loong64]
-    os: [linux]
-    libc: [musl]
-
-  '@rollup/rollup-linux-ppc64-gnu@4.60.2':
-    resolution: {integrity: sha512-11+aL5vKheYgczxtPVVRhdptAM2H7fcDR5Gw4/bTcteuZBlH4oP9f5s9zYO9aGZvoGeBpqXI/9TZZihZ609wKw==}
+  '@rolldown/binding-linux-ppc64-gnu@1.0.3':
+    resolution: {integrity: sha512-5f1laC0SlIR0yDbFCd8acUhvJIag6N3zC5P7oUPN6wX0aOma+uKJ0wBDH5aq7I1PVI2ttTlhJwzwRIBnLiSGEg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
     libc: [glibc]
 
-  '@rollup/rollup-linux-ppc64-musl@4.60.2':
-    resolution: {integrity: sha512-i16fokAGK46IVZuV8LIIwMdtqhin9hfYkCh8pf8iC3QU3LpwL+1FSFGej+O7l3E/AoknL6Dclh2oTdnRMpTzFQ==}
-    cpu: [ppc64]
-    os: [linux]
-    libc: [musl]
-
-  '@rollup/rollup-linux-riscv64-gnu@4.60.2':
-    resolution: {integrity: sha512-49FkKS6RGQoriDSK/6E2GkAsAuU5kETFCh7pG4yD/ylj9rKhTmO3elsnmBvRD4PgJPds5W2PkhC82aVwmUcJ7A==}
-    cpu: [riscv64]
-    os: [linux]
-    libc: [glibc]
-
-  '@rollup/rollup-linux-riscv64-musl@4.60.2':
-    resolution: {integrity: sha512-mjYNkHPfGpUR00DuM1ZZIgs64Hpf4bWcz9Z41+4Q+pgDx73UwWdAYyf6EG/lRFldmdHHzgrYyge5akFUW0D3mQ==}
-    cpu: [riscv64]
-    os: [linux]
-    libc: [musl]
-
-  '@rollup/rollup-linux-s390x-gnu@4.60.2':
-    resolution: {integrity: sha512-ALyvJz965BQk8E9Al/JDKKDLH2kfKFLTGMlgkAbbYtZuJt9LU8DW3ZoDMCtQpXAltZxwBHevXz5u+gf0yA0YoA==}
+  '@rolldown/binding-linux-s390x-gnu@1.0.3':
+    resolution: {integrity: sha512-Iq4ko0r4XsgbrF/LunNgHtAGLRRVE2kXonAXQ/MV0mC6jQpMOhW1SvtZja2EhC/kd05++bP78dsqBeIQyYJ6Yg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
     libc: [glibc]
 
-  '@rollup/rollup-linux-x64-gnu@4.60.2':
-    resolution: {integrity: sha512-UQjrkIdWrKI626Du8lCQ6MJp/6V1LAo2bOK9OTu4mSn8GGXIkPXk/Vsp4bLHCd9Z9Iz2OTEaokUE90VweJgIYQ==}
+  '@rolldown/binding-linux-x64-gnu@1.0.3':
+    resolution: {integrity: sha512-B8m6tD5+/N5FeNQFbKlLA/2yVq9ycQP1SeedyEYYKWBNR3ZQbkvIUcNnDNM03lO1l5F2roiiFJGgvoLLyZXtSg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
 
-  '@rollup/rollup-linux-x64-musl@4.60.2':
-    resolution: {integrity: sha512-bTsRGj6VlSdn/XD4CGyzMnzaBs9bsRxy79eTqTCBsA8TMIEky7qg48aPkvJvFe1HyzQ5oMZdg7AnVlWQSKLTnw==}
+  '@rolldown/binding-linux-x64-musl@1.0.3':
+    resolution: {integrity: sha512-pSdpdUJHkuCxun9LE7jvgUB9qsRgaiyNNCX7m/AvHTcq67AiT/Yhoxvw5zPfhrM8k/BfP8ce/hMOpthKDpEUow==}
+    engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
     libc: [musl]
 
-  '@rollup/rollup-openbsd-x64@4.60.2':
-    resolution: {integrity: sha512-6d4Z3534xitaA1FcMWP7mQPq5zGwBmGbhphh2DwaA1aNIXUu3KTOfwrWpbwI4/Gr0uANo7NTtaykFyO2hPuFLg==}
-    cpu: [x64]
-    os: [openbsd]
-
-  '@rollup/rollup-openharmony-arm64@4.60.2':
-    resolution: {integrity: sha512-NetAg5iO2uN7eB8zE5qrZ3CSil+7IJt4WDFLcC75Ymywq1VZVD6qJ6EvNLjZ3rEm6gB7XW5JdT60c6MN35Z85Q==}
+  '@rolldown/binding-openharmony-arm64@1.0.3':
+    resolution: {integrity: sha512-OXXS3RKJgX2uLwM+gYyuH5omcH8fL1LJs96pZGgtetVCahON57+d4SJHzTgZiOjxgGkSnpXpOsWuPDGAKAigEg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [openharmony]
 
-  '@rollup/rollup-win32-arm64-msvc@4.60.2':
-    resolution: {integrity: sha512-NCYhOotpgWZ5kdxCZsv6Iudx0wX8980Q/oW4pNFNihpBKsDbEA1zpkfxJGC0yugsUuyDZ7gL37dbzwhR0VI7pQ==}
+  '@rolldown/binding-wasm32-wasi@1.0.3':
+    resolution: {integrity: sha512-JTtb8BWFynicNSoPrehsCzBtOKjZ6jhMiPFEmOiuXg1Fl8dn2KHQob+GuPSGR0dryQa1PQJbzjF3dqO/whhjLg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [wasm32]
+
+  '@rolldown/binding-win32-arm64-msvc@1.0.3':
+    resolution: {integrity: sha512-gEdFFEN70A/jxb2svrWsN3aDL7OUtmvlOy+6fa2jxG8K0wQ1ZbdeLGnidov6Yu5/733dI5ySfzFlQ/cb0bSz1g==}
+    engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [win32]
 
-  '@rollup/rollup-win32-ia32-msvc@4.60.2':
-    resolution: {integrity: sha512-RXsaOqXxfoUBQoOgvmmijVxJnW2IGB0eoMO7F8FAjaj0UTywUO/luSqimWBJn04WNgUkeNhh7fs7pESXajWmkg==}
-    cpu: [ia32]
-    os: [win32]
-
-  '@rollup/rollup-win32-x64-gnu@4.60.2':
-    resolution: {integrity: sha512-qdAzEULD+/hzObedtmV6iBpdL5TIbKVztGiK7O3/KYSf+HIzU257+MX1EXJcyIiDbMAqmbwaufcYPvyRryeZtA==}
+  '@rolldown/binding-win32-x64-msvc@1.0.3':
+    resolution: {integrity: sha512-eXB7CHuaQdqmJcc3koCNtNPmT/bj2gc999kUFgBxG8Ac0NdgXc4rkCHhqrgrhN3zddvvvrgzj1e90SuSfmyIXA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [win32]
 
-  '@rollup/rollup-win32-x64-msvc@4.60.2':
-    resolution: {integrity: sha512-Nd/SgG27WoA9e+/TdK74KnHz852TLa94ovOYySo/yMPuTmpckK/jIF2jSwS3g7ELSKXK13/cVdmg1Z/DaCWKxA==}
-    cpu: [x64]
-    os: [win32]
+  '@rolldown/pluginutils@1.0.0-rc.3':
+    resolution: {integrity: sha512-eybk3TjzzzV97Dlj5c+XrBFW57eTNhzod66y9HrBlzJ6NsCrWCp/2kaPS3K9wJmurBC0Tdw4yPjXKZqlznim3Q==}
+
+  '@rolldown/pluginutils@1.0.1':
+    resolution: {integrity: sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==}
 
   '@rspack/binding-darwin-arm64@1.7.11':
     resolution: {integrity: sha512-oduECiZVqbO5zlVw+q7Vy65sJFth99fWPTyucwvLJJtJkPL5n17Uiql2cYP6Ijn0pkqtf1SXgK8WjiKLG5bIig==}
@@ -3217,7 +3032,7 @@ packages:
   '@tailwindcss/vite@4.2.4':
     resolution: {integrity: sha512-pCvohwOCspk3ZFn6eJzrrX3g4n2JY73H6MmYC87XfGPyTty4YsCjYTMArRZm/zOI8dIt3+EcrLHAFPe5A4bgtw==}
     peerDependencies:
-      vite: ^5.2.0 || ^6 || ^7 || ^8
+      vite: '>=7.3.5'
 
   '@testing-library/dom@10.4.1':
     resolution: {integrity: sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==}
@@ -3277,9 +3092,6 @@ packages:
 
   '@types/chai@5.2.3':
     resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
-
-  '@types/chrome@0.1.43':
-    resolution: {integrity: sha512-ukH/HhmR6ht+UTX3PLUWJxgJ/RQcK2Foj4lBzsF24SIWsXgqhGuXqjd8FFuwioPP7d/JUKLM4g8GZxw3F4HTcA==}
 
   '@types/connect-history-api-fallback@1.5.4':
     resolution: {integrity: sha512-n6Cr2xS1h4uAulPRdlw6Jl6s1oG8KrVilPN2yUITEs+K48EzMJJ3W1xy8K5eWuFvjp3R74AOIGSmp2UfBJ8HFw==}
@@ -3407,12 +3219,6 @@ packages:
   '@types/express@4.17.25':
     resolution: {integrity: sha512-dVd04UKsfpINUnK0yBoYHDF3xu7xVH4BuDotC/xGuycx4CgbP48X/KF/586bcObxT0HENHXEU8Nqtu6NR+eKhw==}
 
-  '@types/filesystem@0.0.36':
-    resolution: {integrity: sha512-vPDXOZuannb9FZdxgHnqSwAG/jvdGM8Wq+6N4D/d80z+D4HWH+bItqsZaVRQykAn6WEVeEkLm2oQigyHtgb0RA==}
-
-  '@types/filewriter@0.0.33':
-    resolution: {integrity: sha512-xFU8ZXTw4gd358lb2jw25nxY9QAgqn2+bKKjKOYfNCzN4DKCFetK7sPtrlpg66Ywe3vWY9FNxprZawAh9wfJ3g==}
-
   '@types/fs-extra@9.0.13':
     resolution: {integrity: sha512-nEnwB++1u5lVDM2UI4c1+5R+FYaKfaAzS4OococimjVm3nQw3TuzH5UNsocrcTBbhnerblyHj4A49qXbIiZdpA==}
 
@@ -3421,9 +3227,6 @@ packages:
 
   '@types/gtag.js@0.0.20':
     resolution: {integrity: sha512-wwAbk3SA2QeU67unN7zPxjEHmPmlXwZXZvQEpbEUQuMCRGgKyE1m6XDuTUA9b6pCGb/GqJmdfMOY5LuDjJSbbg==}
-
-  '@types/har-format@1.2.16':
-    resolution: {integrity: sha512-fluxdy7ryD3MV6h8pTfTYpy/xQzCFC7m89nOH9y94cNqJ1mDIDPut7MnRHI3F6qRmh/cT2fUjG1MLdCNb4hE9A==}
 
   '@types/hast@3.0.4':
     resolution: {integrity: sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==}
@@ -3631,7 +3434,7 @@ packages:
     resolution: {integrity: sha512-YmKkfhOAi3wsB1PhJq5Scj3GXMn3WvtQ/JC0xoopuHoXSdmtdStOpFrYaT1kie2YgFBcIe64ROzMYRjCrYOdYw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     peerDependencies:
-      vite: ^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0
+      vite: '>=7.3.5'
 
   '@vitest/coverage-v8@4.1.5':
     resolution: {integrity: sha512-38C0/Ddb7HcRG0Z4/DUem8x57d2p9jYgp18mkaYswEOQBGsI1CG4f/hjm0ZCeaJfWhSZ4k7jgs29V1Zom7Ki9A==}
@@ -3649,7 +3452,7 @@ packages:
     resolution: {integrity: sha512-/x2EmFC4mT4NNzqvC3fmesuV97w5FC903KPmey4gsnJiMQ3Be1IlDKVaDaG8iqaLFHqJ2FVEkxZk5VmeLjIItw==}
     peerDependencies:
       msw: ^2.4.9
-      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+      vite: '>=7.3.5'
     peerDependenciesMeta:
       msw:
         optional: true
@@ -4973,7 +4776,7 @@ packages:
     hasBin: true
     peerDependencies:
       '@swc/core': ^1.0.0
-      vite: ^5.0.0 || ^6.0.0 || ^7.0.0
+      vite: '>=7.3.5'
     peerDependenciesMeta:
       '@swc/core':
         optional: true
@@ -5091,13 +4894,8 @@ packages:
   esast-util-from-js@2.0.1:
     resolution: {integrity: sha512-8Ja+rNJ0Lt56Pcf3TAmpBZjmx8ZcK5Ts4cAzIOjsjevg9oSXJnl6SUQ2EevU8tv3h6ZLWmoKL5H4fgWvdvfETw==}
 
-  esbuild@0.25.12:
-    resolution: {integrity: sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==}
-    engines: {node: '>=18'}
-    hasBin: true
-
-  esbuild@0.27.7:
-    resolution: {integrity: sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==}
+  esbuild@0.28.1:
+    resolution: {integrity: sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==}
     engines: {node: '>=18'}
     hasBin: true
 
@@ -5367,8 +5165,8 @@ packages:
     resolution: {integrity: sha512-yDYSgNMraqvnxiEXO4hi88+YZxaHC6QKzb5N84iRCTDeRO7ZALpir/lVmf/uXUhnwUr2O4HU8s/n6x+yNjQkHw==}
     engines: {node: '>= 14.17'}
 
-  form-data@4.0.5:
-    resolution: {integrity: sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==}
+  form-data@4.0.6:
+    resolution: {integrity: sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==}
     engines: {node: '>= 6'}
 
   format@0.2.2:
@@ -5584,6 +5382,10 @@ packages:
 
   hasown@2.0.3:
     resolution: {integrity: sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==}
+    engines: {node: '>= 0.4'}
+
+  hasown@2.0.4:
+    resolution: {integrity: sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==}
     engines: {node: '>= 0.4'}
 
   hast-util-from-parse5@8.0.3:
@@ -6752,6 +6554,11 @@ packages:
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
+  nanoid@3.3.12:
+    resolution: {integrity: sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==}
+    engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
+    hasBin: true
+
   natural-compare@1.4.0:
     resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
 
@@ -7505,6 +7312,10 @@ packages:
     resolution: {integrity: sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==}
     engines: {node: ^10 || ^12 || >=14}
 
+  postcss@8.5.15:
+    resolution: {integrity: sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==}
+    engines: {node: ^10 || ^12 || >=14}
+
   postject@1.0.0-alpha.6:
     resolution: {integrity: sha512-b9Eb8h2eVqNE8edvKdwqkrY6O7kAwmI8kcnBv1NScolYJbo59XUF0noFq+lxbC1yN20bmC0WBEbDC5H/7ASb0A==}
     engines: {node: '>=14.0.0'}
@@ -7884,9 +7695,9 @@ packages:
   robust-predicates@3.0.3:
     resolution: {integrity: sha512-NS3levdsRIUOmiJ8FZWCP7LG3QpJyrs/TE0Zpf1yvZu8cAJJ6QMW92H1c7kWpdIHo8RvmLxN/o2JXTKHp74lUA==}
 
-  rollup@4.60.2:
-    resolution: {integrity: sha512-J9qZyW++QK/09NyN/zeO0dG/1GdGfyp9lV8ajHnRVLfo/uFsbji5mHnDgn/qYdUHyCkM2N+8VyspgZclfAh0eQ==}
-    engines: {node: '>=18.0.0', npm: '>=8.0.0'}
+  rolldown@1.0.3:
+    resolution: {integrity: sha512-i00lAJ2ks1BYr7rjNjKC7BcqAS7nVfiT3QX1SI5aY+AFHblCmaUf9OE9dbdzDvW6dJxbi2ZCZiy9v3CcwOiX3g==}
+    engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
 
   roughjs@4.6.6:
@@ -8027,8 +7838,8 @@ packages:
     resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
     engines: {node: '>=8'}
 
-  shell-quote@1.8.3:
-    resolution: {integrity: sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw==}
+  shell-quote@1.8.4:
+    resolution: {integrity: sha512-VsC6n6vz1ihYYyZZwX7YZSF5l5x36ca17OC+a69h94YqB7X6XLwf+5MOgynYir2SLFUbl8gIYvBo8K8RoNQ6bQ==}
     engines: {node: '>= 0.4'}
 
   shiki@4.0.2:
@@ -8395,6 +8206,10 @@ packages:
     resolution: {integrity: sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==}
     engines: {node: '>=12.0.0'}
 
+  tinyglobby@0.2.17:
+    resolution: {integrity: sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==}
+    engines: {node: '>=12.0.0'}
+
   tinypool@1.1.1:
     resolution: {integrity: sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==}
     engines: {node: ^18.0.0 || >=20.0.0}
@@ -8656,15 +8471,16 @@ packages:
   virtual-dom@2.1.1:
     resolution: {integrity: sha512-wb6Qc9Lbqug0kRqo/iuApfBpJJAq14Sk1faAnSmtqXiwahg7PVTvWMs9L02Z8nNIMqbwsxzBAA90bbtRLbw0zg==}
 
-  vite@7.3.2:
-    resolution: {integrity: sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg==}
+  vite@8.0.16:
+    resolution: {integrity: sha512-h9bXPmJichP5fLmVQo3PyaGSDE2n3aPuomeAlVRm0JLmt4rY6zmPKd59HYI4LNW8oTK7tlTsuC7l/m7awx9Jcw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
     peerDependencies:
       '@types/node': ^20.19.0 || >=22.12.0
+      '@vitejs/devtools': ^0.1.18
+      esbuild: '>=0.28.1'
       jiti: '>=1.21.0'
       less: ^4.0.0
-      lightningcss: ^1.21.0
       sass: ^1.70.0
       sass-embedded: ^1.70.0
       stylus: '>=0.54.8'
@@ -8675,11 +8491,13 @@ packages:
     peerDependenciesMeta:
       '@types/node':
         optional: true
+      '@vitejs/devtools':
+        optional: true
+      esbuild:
+        optional: true
       jiti:
         optional: true
       less:
-        optional: true
-      lightningcss:
         optional: true
       sass:
         optional: true
@@ -8712,7 +8530,7 @@ packages:
       '@vitest/ui': 4.1.5
       happy-dom: '*'
       jsdom: '*'
-      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+      vite: '>=7.3.5'
     peerDependenciesMeta:
       '@edge-runtime/vm':
         optional: true
@@ -8907,20 +8725,8 @@ packages:
   write-file-atomic@3.0.3:
     resolution: {integrity: sha512-AvHcyZ5JnSfq3ioSyjrBkH9yW4m7Ayk8/9My/DD9onKeu/94fwrMocemO2QAJFAlnnDN+ZDS+ZjAR5ua1/PV/Q==}
 
-  ws@7.5.10:
-    resolution: {integrity: sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==}
-    engines: {node: '>=8.3.0'}
-    peerDependencies:
-      bufferutil: ^4.0.1
-      utf-8-validate: ^5.0.2
-    peerDependenciesMeta:
-      bufferutil:
-        optional: true
-      utf-8-validate:
-        optional: true
-
-  ws@8.20.0:
-    resolution: {integrity: sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==}
+  ws@8.21.0:
+    resolution: {integrity: sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==}
     engines: {node: '>=10.0.0'}
     peerDependencies:
       bufferutil: ^4.0.1
@@ -10601,7 +10407,7 @@ snapshots:
       - '@algolia/client-search'
       - algoliasearch
 
-  '@docusaurus/babel@3.10.1(@swc/core@1.15.33)(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.14))(html-minifier-terser@7.2.0)(lightningcss@1.32.0)(postcss@8.5.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
+  '@docusaurus/babel@3.10.1(@swc/core@1.15.33)(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.14))(esbuild@0.28.1)(html-minifier-terser@7.2.0)(postcss@8.5.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
     dependencies:
       '@babel/core': 7.29.0
       '@babel/generator': 7.29.1
@@ -10613,7 +10419,7 @@ snapshots:
       '@babel/runtime': 7.29.7
       '@babel/traverse': 7.29.0
       '@docusaurus/logger': 3.10.1
-      '@docusaurus/utils': 3.10.1(@swc/core@1.15.33)(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.14))(html-minifier-terser@7.2.0)(lightningcss@1.32.0)(postcss@8.5.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@docusaurus/utils': 3.10.1(@swc/core@1.15.33)(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.14))(esbuild@0.28.1)(html-minifier-terser@7.2.0)(postcss@8.5.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       babel-plugin-dynamic-import-node: 2.3.3
       fs-extra: 11.3.4
       tslib: 2.8.1
@@ -10635,7 +10441,7 @@ snapshots:
       - uglify-js
       - webpack-cli
 
-  '@docusaurus/babel@3.10.1(@swc/core@1.15.33)(lightningcss@1.32.0)(postcss@8.5.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
+  '@docusaurus/babel@3.10.1(@swc/core@1.15.33)(esbuild@0.28.1)(postcss@8.5.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
     dependencies:
       '@babel/core': 7.29.0
       '@babel/generator': 7.29.1
@@ -10647,7 +10453,7 @@ snapshots:
       '@babel/runtime': 7.29.7
       '@babel/traverse': 7.29.0
       '@docusaurus/logger': 3.10.1
-      '@docusaurus/utils': 3.10.1(@swc/core@1.15.33)(lightningcss@1.32.0)(postcss@8.5.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@docusaurus/utils': 3.10.1(@swc/core@1.15.33)(esbuild@0.28.1)(postcss@8.5.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       babel-plugin-dynamic-import-node: 2.3.3
       fs-extra: 11.3.4
       tslib: 2.8.1
@@ -10669,34 +10475,34 @@ snapshots:
       - uglify-js
       - webpack-cli
 
-  '@docusaurus/bundler@3.10.1(@docusaurus/faster@3.10.1(@docusaurus/types@3.10.1(@swc/core@1.15.33)(lightningcss@1.32.0)(postcss@8.5.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(postcss@8.5.14))(@rspack/core@1.7.11)(@swc/core@1.15.33)(lightningcss@1.32.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)':
+  '@docusaurus/bundler@3.10.1(@docusaurus/faster@3.10.1(@docusaurus/types@3.10.1(@swc/core@1.15.33)(esbuild@0.28.1)(postcss@8.5.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(esbuild@0.28.1)(postcss@8.5.14))(@rspack/core@1.7.11)(@swc/core@1.15.33)(esbuild@0.28.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)':
     dependencies:
       '@babel/core': 7.29.0
-      '@docusaurus/babel': 3.10.1(@swc/core@1.15.33)(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.14))(html-minifier-terser@7.2.0)(lightningcss@1.32.0)(postcss@8.5.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@docusaurus/babel': 3.10.1(@swc/core@1.15.33)(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.14))(esbuild@0.28.1)(html-minifier-terser@7.2.0)(postcss@8.5.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       '@docusaurus/cssnano-preset': 3.10.1
       '@docusaurus/logger': 3.10.1
-      '@docusaurus/types': 3.10.1(@swc/core@1.15.33)(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.14))(html-minifier-terser@7.2.0)(lightningcss@1.32.0)(postcss@8.5.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@docusaurus/utils': 3.10.1(@swc/core@1.15.33)(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.14))(html-minifier-terser@7.2.0)(lightningcss@1.32.0)(postcss@8.5.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      babel-loader: 9.2.1(@babel/core@7.29.0)(webpack@5.106.2(@swc/core@1.15.33)(lightningcss@1.32.0)(postcss@8.5.14))
+      '@docusaurus/types': 3.10.1(@swc/core@1.15.33)(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.14))(esbuild@0.28.1)(html-minifier-terser@7.2.0)(postcss@8.5.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@docusaurus/utils': 3.10.1(@swc/core@1.15.33)(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.14))(esbuild@0.28.1)(html-minifier-terser@7.2.0)(postcss@8.5.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      babel-loader: 9.2.1(@babel/core@7.29.0)(webpack@5.106.2(@swc/core@1.15.33)(esbuild@0.28.1)(postcss@8.5.14))
       clean-css: 5.3.3
-      copy-webpack-plugin: 11.0.0(webpack@5.106.2(@swc/core@1.15.33)(lightningcss@1.32.0)(postcss@8.5.14))
-      css-loader: 6.11.0(@rspack/core@1.7.11)(webpack@5.106.2(@swc/core@1.15.33)(lightningcss@1.32.0)(postcss@8.5.14))
-      css-minimizer-webpack-plugin: 5.0.1(clean-css@5.3.3)(lightningcss@1.32.0)(webpack@5.106.2(@swc/core@1.15.33)(lightningcss@1.32.0)(postcss@8.5.14))
+      copy-webpack-plugin: 11.0.0(webpack@5.106.2(@swc/core@1.15.33)(esbuild@0.28.1)(postcss@8.5.14))
+      css-loader: 6.11.0(@rspack/core@1.7.11)(webpack@5.106.2(@swc/core@1.15.33)(esbuild@0.28.1)(postcss@8.5.14))
+      css-minimizer-webpack-plugin: 5.0.1(clean-css@5.3.3)(esbuild@0.28.1)(webpack@5.106.2(@swc/core@1.15.33)(esbuild@0.28.1)(postcss@8.5.14))
       cssnano: 6.1.2(postcss@8.5.14)
-      file-loader: 6.2.0(webpack@5.106.2(@swc/core@1.15.33)(lightningcss@1.32.0)(postcss@8.5.14))
+      file-loader: 6.2.0(webpack@5.106.2(@swc/core@1.15.33)(esbuild@0.28.1)(postcss@8.5.14))
       html-minifier-terser: 7.2.0
-      mini-css-extract-plugin: 2.10.2(webpack@5.106.2(@swc/core@1.15.33)(lightningcss@1.32.0)(postcss@8.5.14))
-      null-loader: 4.0.1(webpack@5.106.2(@swc/core@1.15.33)(lightningcss@1.32.0)(postcss@8.5.14))
+      mini-css-extract-plugin: 2.10.2(webpack@5.106.2(@swc/core@1.15.33)(esbuild@0.28.1)(postcss@8.5.14))
+      null-loader: 4.0.1(webpack@5.106.2(@swc/core@1.15.33)(esbuild@0.28.1)(postcss@8.5.14))
       postcss: 8.5.14
-      postcss-loader: 7.3.4(postcss@8.5.14)(typescript@6.0.3)(webpack@5.106.2(@swc/core@1.15.33)(lightningcss@1.32.0)(postcss@8.5.14))
+      postcss-loader: 7.3.4(postcss@8.5.14)(typescript@6.0.3)(webpack@5.106.2(@swc/core@1.15.33)(esbuild@0.28.1)(postcss@8.5.14))
       postcss-preset-env: 10.6.1(postcss@8.5.14)
-      terser-webpack-plugin: 5.6.0(@swc/core@1.15.33)(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.14))(html-minifier-terser@7.2.0)(lightningcss@1.32.0)(postcss@8.5.14)(webpack@5.106.2(@swc/core@1.15.33)(lightningcss@1.32.0)(postcss@8.5.14))
+      terser-webpack-plugin: 5.6.0(@swc/core@1.15.33)(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.14))(esbuild@0.28.1)(html-minifier-terser@7.2.0)(postcss@8.5.14)(webpack@5.106.2(@swc/core@1.15.33)(esbuild@0.28.1)(postcss@8.5.14))
       tslib: 2.8.1
-      url-loader: 4.1.1(file-loader@6.2.0(webpack@5.106.2(@swc/core@1.15.33)(lightningcss@1.32.0)(postcss@8.5.14)))(webpack@5.106.2(@swc/core@1.15.33)(lightningcss@1.32.0)(postcss@8.5.14))
-      webpack: 5.106.2(@swc/core@1.15.33)(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.14))(html-minifier-terser@7.2.0)(lightningcss@1.32.0)(postcss@8.5.14)
-      webpackbar: 7.0.0(@rspack/core@1.7.11)(webpack@5.106.2(@swc/core@1.15.33)(lightningcss@1.32.0)(postcss@8.5.14))
+      url-loader: 4.1.1(file-loader@6.2.0(webpack@5.106.2(@swc/core@1.15.33)(esbuild@0.28.1)(postcss@8.5.14)))(webpack@5.106.2(@swc/core@1.15.33)(esbuild@0.28.1)(postcss@8.5.14))
+      webpack: 5.106.2(@swc/core@1.15.33)(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.14))(esbuild@0.28.1)(html-minifier-terser@7.2.0)(postcss@8.5.14)
+      webpackbar: 7.0.0(@rspack/core@1.7.11)(webpack@5.106.2(@swc/core@1.15.33)(esbuild@0.28.1)(postcss@8.5.14))
     optionalDependencies:
-      '@docusaurus/faster': 3.10.1(@docusaurus/types@3.10.1(@swc/core@1.15.33)(lightningcss@1.32.0)(postcss@8.5.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(postcss@8.5.14)
+      '@docusaurus/faster': 3.10.1(@docusaurus/types@3.10.1(@swc/core@1.15.33)(esbuild@0.28.1)(postcss@8.5.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(esbuild@0.28.1)(postcss@8.5.14)
     transitivePeerDependencies:
       - '@minify-html/node'
       - '@parcel/css'
@@ -10714,15 +10520,15 @@ snapshots:
       - uglify-js
       - webpack-cli
 
-  '@docusaurus/core@3.10.1(@docusaurus/faster@3.10.1(@docusaurus/types@3.10.1(@swc/core@1.15.33)(lightningcss@1.32.0)(postcss@8.5.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(postcss@8.5.14))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(@rspack/core@1.7.11)(@swc/core@1.15.33)(lightningcss@1.32.0)(postcss@8.5.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)':
+  '@docusaurus/core@3.10.1(@docusaurus/faster@3.10.1(@docusaurus/types@3.10.1(@swc/core@1.15.33)(esbuild@0.28.1)(postcss@8.5.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(esbuild@0.28.1)(postcss@8.5.14))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(@rspack/core@1.7.11)(@swc/core@1.15.33)(esbuild@0.28.1)(postcss@8.5.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)':
     dependencies:
-      '@docusaurus/babel': 3.10.1(@swc/core@1.15.33)(lightningcss@1.32.0)(postcss@8.5.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@docusaurus/bundler': 3.10.1(@docusaurus/faster@3.10.1(@docusaurus/types@3.10.1(@swc/core@1.15.33)(lightningcss@1.32.0)(postcss@8.5.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(postcss@8.5.14))(@rspack/core@1.7.11)(@swc/core@1.15.33)(lightningcss@1.32.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)
+      '@docusaurus/babel': 3.10.1(@swc/core@1.15.33)(esbuild@0.28.1)(postcss@8.5.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@docusaurus/bundler': 3.10.1(@docusaurus/faster@3.10.1(@docusaurus/types@3.10.1(@swc/core@1.15.33)(esbuild@0.28.1)(postcss@8.5.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(esbuild@0.28.1)(postcss@8.5.14))(@rspack/core@1.7.11)(@swc/core@1.15.33)(esbuild@0.28.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)
       '@docusaurus/logger': 3.10.1
-      '@docusaurus/mdx-loader': 3.10.1(@swc/core@1.15.33)(lightningcss@1.32.0)(postcss@8.5.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@docusaurus/utils': 3.10.1(@swc/core@1.15.33)(lightningcss@1.32.0)(postcss@8.5.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@docusaurus/utils-common': 3.10.1(@swc/core@1.15.33)(lightningcss@1.32.0)(postcss@8.5.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@docusaurus/utils-validation': 3.10.1(@swc/core@1.15.33)(lightningcss@1.32.0)(postcss@8.5.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@docusaurus/mdx-loader': 3.10.1(@swc/core@1.15.33)(esbuild@0.28.1)(postcss@8.5.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@docusaurus/utils': 3.10.1(@swc/core@1.15.33)(esbuild@0.28.1)(postcss@8.5.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@docusaurus/utils-common': 3.10.1(@swc/core@1.15.33)(esbuild@0.28.1)(postcss@8.5.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@docusaurus/utils-validation': 3.10.1(@swc/core@1.15.33)(esbuild@0.28.1)(postcss@8.5.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       '@mdx-js/react': 3.1.1(@types/react@19.2.14)(react@19.2.5)
       boxen: 6.2.1
       chalk: 4.1.2
@@ -10738,7 +10544,7 @@ snapshots:
       execa: 5.1.1
       fs-extra: 11.3.4
       html-tags: 3.3.1
-      html-webpack-plugin: 5.6.7(@rspack/core@1.7.11)(webpack@5.106.2(@swc/core@1.15.33)(lightningcss@1.32.0)(postcss@8.5.14))
+      html-webpack-plugin: 5.6.7(@rspack/core@1.7.11)(webpack@5.106.2(@swc/core@1.15.33)(esbuild@0.28.1)(postcss@8.5.14))
       leven: 3.1.0
       lodash: 4.18.1
       open: 8.4.2
@@ -10748,7 +10554,7 @@ snapshots:
       react-dom: 19.2.5(react@19.2.5)
       react-helmet-async: '@slorber/react-helmet-async@1.3.0(react-dom@19.2.5(react@19.2.5))(react@19.2.5)'
       react-loadable: '@docusaurus/react-loadable@6.0.0(react@19.2.5)'
-      react-loadable-ssr-addon-v5-slorber: 1.0.3(@docusaurus/react-loadable@6.0.0(react@19.2.5))(webpack@5.106.2(@swc/core@1.15.33)(lightningcss@1.32.0)(postcss@8.5.14))
+      react-loadable-ssr-addon-v5-slorber: 1.0.3(@docusaurus/react-loadable@6.0.0(react@19.2.5))(webpack@5.106.2(@swc/core@1.15.33)(esbuild@0.28.1)(postcss@8.5.14))
       react-router: 5.3.4(react@19.2.5)
       react-router-config: 5.1.1(react-router@5.3.4(react@19.2.5))(react@19.2.5)
       react-router-dom: 5.3.4(react@19.2.5)
@@ -10757,12 +10563,12 @@ snapshots:
       tinypool: 1.1.1
       tslib: 2.8.1
       update-notifier: 6.0.2
-      webpack: 5.106.2(@swc/core@1.15.33)(lightningcss@1.32.0)(postcss@8.5.14)
+      webpack: 5.106.2(@swc/core@1.15.33)(esbuild@0.28.1)(postcss@8.5.14)
       webpack-bundle-analyzer: 4.10.2
-      webpack-dev-server: 5.2.3(tslib@2.8.1)(webpack@5.106.2(@swc/core@1.15.33)(lightningcss@1.32.0)(postcss@8.5.14))
+      webpack-dev-server: 5.2.3(tslib@2.8.1)(webpack@5.106.2(@swc/core@1.15.33)(esbuild@0.28.1)(postcss@8.5.14))
       webpack-merge: 6.0.1
     optionalDependencies:
-      '@docusaurus/faster': 3.10.1(@docusaurus/types@3.10.1(@swc/core@1.15.33)(lightningcss@1.32.0)(postcss@8.5.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(postcss@8.5.14)
+      '@docusaurus/faster': 3.10.1(@docusaurus/types@3.10.1(@swc/core@1.15.33)(esbuild@0.28.1)(postcss@8.5.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(esbuild@0.28.1)(postcss@8.5.14)
     transitivePeerDependencies:
       - '@minify-html/node'
       - '@parcel/css'
@@ -10792,18 +10598,18 @@ snapshots:
       postcss-sort-media-queries: 5.2.0(postcss@8.5.14)
       tslib: 2.8.1
 
-  '@docusaurus/faster@3.10.1(@docusaurus/types@3.10.1(@swc/core@1.15.33)(lightningcss@1.32.0)(postcss@8.5.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(postcss@8.5.14)':
+  '@docusaurus/faster@3.10.1(@docusaurus/types@3.10.1(@swc/core@1.15.33)(esbuild@0.28.1)(postcss@8.5.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(esbuild@0.28.1)(postcss@8.5.14)':
     dependencies:
-      '@docusaurus/types': 3.10.1(@swc/core@1.15.33)(lightningcss@1.32.0)(postcss@8.5.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@docusaurus/types': 3.10.1(@swc/core@1.15.33)(esbuild@0.28.1)(postcss@8.5.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       '@rspack/core': 1.7.11
       '@swc/core': 1.15.33
       '@swc/html': 1.15.33
       browserslist: 4.28.2
       lightningcss: 1.32.0
       semver: 7.7.4
-      swc-loader: 0.2.7(@swc/core@1.15.33)(webpack@5.106.2(@swc/core@1.15.33)(lightningcss@1.32.0)(postcss@8.5.14))
+      swc-loader: 0.2.7(@swc/core@1.15.33)(webpack@5.106.2(@swc/core@1.15.33)(esbuild@0.28.1)(postcss@8.5.14))
       tslib: 2.8.1
-      webpack: 5.106.2(@swc/core@1.15.33)(@swc/html@1.15.33)(lightningcss@1.32.0)(postcss@8.5.14)
+      webpack: 5.106.2(@swc/core@1.15.33)(@swc/html@1.15.33)(esbuild@0.28.1)(lightningcss@1.32.0)(postcss@8.5.14)
     transitivePeerDependencies:
       - '@minify-html/node'
       - '@swc/css'
@@ -10822,16 +10628,16 @@ snapshots:
       chalk: 4.1.2
       tslib: 2.8.1
 
-  '@docusaurus/mdx-loader@3.10.1(@swc/core@1.15.33)(lightningcss@1.32.0)(postcss@8.5.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
+  '@docusaurus/mdx-loader@3.10.1(@swc/core@1.15.33)(esbuild@0.28.1)(postcss@8.5.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
     dependencies:
       '@docusaurus/logger': 3.10.1
-      '@docusaurus/utils': 3.10.1(@swc/core@1.15.33)(lightningcss@1.32.0)(postcss@8.5.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@docusaurus/utils-validation': 3.10.1(@swc/core@1.15.33)(lightningcss@1.32.0)(postcss@8.5.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@docusaurus/utils': 3.10.1(@swc/core@1.15.33)(esbuild@0.28.1)(postcss@8.5.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@docusaurus/utils-validation': 3.10.1(@swc/core@1.15.33)(esbuild@0.28.1)(postcss@8.5.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       '@mdx-js/mdx': 3.1.1
       '@slorber/remark-comment': 1.0.0
       escape-html: 1.0.3
       estree-util-value-to-estree: 3.5.0
-      file-loader: 6.2.0(webpack@5.106.2(@swc/core@1.15.33)(lightningcss@1.32.0)(postcss@8.5.14))
+      file-loader: 6.2.0(webpack@5.106.2(@swc/core@1.15.33)(esbuild@0.28.1)(postcss@8.5.14))
       fs-extra: 11.3.4
       image-size: 2.0.2
       mdast-util-mdx: 3.0.0
@@ -10847,9 +10653,9 @@ snapshots:
       tslib: 2.8.1
       unified: 11.0.5
       unist-util-visit: 5.1.0
-      url-loader: 4.1.1(file-loader@6.2.0(webpack@5.106.2(@swc/core@1.15.33)(lightningcss@1.32.0)(postcss@8.5.14)))(webpack@5.106.2(@swc/core@1.15.33)(lightningcss@1.32.0)(postcss@8.5.14))
+      url-loader: 4.1.1(file-loader@6.2.0(webpack@5.106.2(@swc/core@1.15.33)(esbuild@0.28.1)(postcss@8.5.14)))(webpack@5.106.2(@swc/core@1.15.33)(esbuild@0.28.1)(postcss@8.5.14))
       vfile: 6.0.3
-      webpack: 5.106.2(@swc/core@1.15.33)(lightningcss@1.32.0)(postcss@8.5.14)
+      webpack: 5.106.2(@swc/core@1.15.33)(esbuild@0.28.1)(postcss@8.5.14)
     transitivePeerDependencies:
       - '@minify-html/node'
       - '@swc/core'
@@ -10866,9 +10672,9 @@ snapshots:
       - uglify-js
       - webpack-cli
 
-  '@docusaurus/module-type-aliases@3.10.1(@swc/core@1.15.33)(lightningcss@1.32.0)(postcss@8.5.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
+  '@docusaurus/module-type-aliases@3.10.1(@swc/core@1.15.33)(esbuild@0.28.1)(postcss@8.5.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
     dependencies:
-      '@docusaurus/types': 3.10.1(@swc/core@1.15.33)(lightningcss@1.32.0)(postcss@8.5.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@docusaurus/types': 3.10.1(@swc/core@1.15.33)(esbuild@0.28.1)(postcss@8.5.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       '@types/history': 4.7.11
       '@types/react': 19.2.14
       '@types/react-router-config': 5.0.11
@@ -10893,17 +10699,17 @@ snapshots:
       - uglify-js
       - webpack-cli
 
-  '@docusaurus/plugin-content-blog@3.10.1(@docusaurus/faster@3.10.1(@docusaurus/types@3.10.1(@swc/core@1.15.33)(lightningcss@1.32.0)(postcss@8.5.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(postcss@8.5.14))(@docusaurus/plugin-content-docs@3.10.1(@docusaurus/faster@3.10.1(@docusaurus/types@3.10.1(@swc/core@1.15.33)(lightningcss@1.32.0)(postcss@8.5.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(postcss@8.5.14))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(@rspack/core@1.7.11)(@swc/core@1.15.33)(lightningcss@1.32.0)(postcss@8.5.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(@rspack/core@1.7.11)(@swc/core@1.15.33)(lightningcss@1.32.0)(postcss@8.5.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)':
+  '@docusaurus/plugin-content-blog@3.10.1(@docusaurus/faster@3.10.1(@docusaurus/types@3.10.1(@swc/core@1.15.33)(esbuild@0.28.1)(postcss@8.5.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(esbuild@0.28.1)(postcss@8.5.14))(@docusaurus/plugin-content-docs@3.10.1(@docusaurus/faster@3.10.1(@docusaurus/types@3.10.1(@swc/core@1.15.33)(esbuild@0.28.1)(postcss@8.5.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(esbuild@0.28.1)(postcss@8.5.14))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(@rspack/core@1.7.11)(@swc/core@1.15.33)(esbuild@0.28.1)(postcss@8.5.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(@rspack/core@1.7.11)(@swc/core@1.15.33)(esbuild@0.28.1)(postcss@8.5.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)':
     dependencies:
-      '@docusaurus/core': 3.10.1(@docusaurus/faster@3.10.1(@docusaurus/types@3.10.1(@swc/core@1.15.33)(lightningcss@1.32.0)(postcss@8.5.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(postcss@8.5.14))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(@rspack/core@1.7.11)(@swc/core@1.15.33)(lightningcss@1.32.0)(postcss@8.5.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)
+      '@docusaurus/core': 3.10.1(@docusaurus/faster@3.10.1(@docusaurus/types@3.10.1(@swc/core@1.15.33)(esbuild@0.28.1)(postcss@8.5.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(esbuild@0.28.1)(postcss@8.5.14))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(@rspack/core@1.7.11)(@swc/core@1.15.33)(esbuild@0.28.1)(postcss@8.5.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)
       '@docusaurus/logger': 3.10.1
-      '@docusaurus/mdx-loader': 3.10.1(@swc/core@1.15.33)(lightningcss@1.32.0)(postcss@8.5.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@docusaurus/plugin-content-docs': 3.10.1(@docusaurus/faster@3.10.1(@docusaurus/types@3.10.1(@swc/core@1.15.33)(lightningcss@1.32.0)(postcss@8.5.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(postcss@8.5.14))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(@rspack/core@1.7.11)(@swc/core@1.15.33)(lightningcss@1.32.0)(postcss@8.5.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)
-      '@docusaurus/theme-common': 3.10.1(@docusaurus/plugin-content-docs@3.10.1(@docusaurus/faster@3.10.1(@docusaurus/types@3.10.1(@swc/core@1.15.33)(lightningcss@1.32.0)(postcss@8.5.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(postcss@8.5.14))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(@rspack/core@1.7.11)(@swc/core@1.15.33)(lightningcss@1.32.0)(postcss@8.5.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3))(@swc/core@1.15.33)(lightningcss@1.32.0)(postcss@8.5.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@docusaurus/types': 3.10.1(@swc/core@1.15.33)(lightningcss@1.32.0)(postcss@8.5.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@docusaurus/utils': 3.10.1(@swc/core@1.15.33)(lightningcss@1.32.0)(postcss@8.5.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@docusaurus/utils-common': 3.10.1(@swc/core@1.15.33)(lightningcss@1.32.0)(postcss@8.5.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@docusaurus/utils-validation': 3.10.1(@swc/core@1.15.33)(lightningcss@1.32.0)(postcss@8.5.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@docusaurus/mdx-loader': 3.10.1(@swc/core@1.15.33)(esbuild@0.28.1)(postcss@8.5.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@docusaurus/plugin-content-docs': 3.10.1(@docusaurus/faster@3.10.1(@docusaurus/types@3.10.1(@swc/core@1.15.33)(esbuild@0.28.1)(postcss@8.5.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(esbuild@0.28.1)(postcss@8.5.14))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(@rspack/core@1.7.11)(@swc/core@1.15.33)(esbuild@0.28.1)(postcss@8.5.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)
+      '@docusaurus/theme-common': 3.10.1(@docusaurus/plugin-content-docs@3.10.1(@docusaurus/faster@3.10.1(@docusaurus/types@3.10.1(@swc/core@1.15.33)(esbuild@0.28.1)(postcss@8.5.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(esbuild@0.28.1)(postcss@8.5.14))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(@rspack/core@1.7.11)(@swc/core@1.15.33)(esbuild@0.28.1)(postcss@8.5.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3))(@swc/core@1.15.33)(esbuild@0.28.1)(postcss@8.5.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@docusaurus/types': 3.10.1(@swc/core@1.15.33)(esbuild@0.28.1)(postcss@8.5.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@docusaurus/utils': 3.10.1(@swc/core@1.15.33)(esbuild@0.28.1)(postcss@8.5.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@docusaurus/utils-common': 3.10.1(@swc/core@1.15.33)(esbuild@0.28.1)(postcss@8.5.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@docusaurus/utils-validation': 3.10.1(@swc/core@1.15.33)(esbuild@0.28.1)(postcss@8.5.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       cheerio: 1.0.0-rc.12
       combine-promises: 1.2.0
       feed: 4.2.2
@@ -10916,7 +10722,7 @@ snapshots:
       tslib: 2.8.1
       unist-util-visit: 5.1.0
       utility-types: 3.11.0
-      webpack: 5.106.2(@swc/core@1.15.33)(lightningcss@1.32.0)(postcss@8.5.14)
+      webpack: 5.106.2(@swc/core@1.15.33)(esbuild@0.28.1)(postcss@8.5.14)
     transitivePeerDependencies:
       - '@docusaurus/faster'
       - '@mdx-js/react'
@@ -10941,17 +10747,17 @@ snapshots:
       - utf-8-validate
       - webpack-cli
 
-  '@docusaurus/plugin-content-docs@3.10.1(@docusaurus/faster@3.10.1(@docusaurus/types@3.10.1(@swc/core@1.15.33)(lightningcss@1.32.0)(postcss@8.5.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(postcss@8.5.14))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(@rspack/core@1.7.11)(@swc/core@1.15.33)(lightningcss@1.32.0)(postcss@8.5.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)':
+  '@docusaurus/plugin-content-docs@3.10.1(@docusaurus/faster@3.10.1(@docusaurus/types@3.10.1(@swc/core@1.15.33)(esbuild@0.28.1)(postcss@8.5.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(esbuild@0.28.1)(postcss@8.5.14))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(@rspack/core@1.7.11)(@swc/core@1.15.33)(esbuild@0.28.1)(postcss@8.5.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)':
     dependencies:
-      '@docusaurus/core': 3.10.1(@docusaurus/faster@3.10.1(@docusaurus/types@3.10.1(@swc/core@1.15.33)(lightningcss@1.32.0)(postcss@8.5.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(postcss@8.5.14))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(@rspack/core@1.7.11)(@swc/core@1.15.33)(lightningcss@1.32.0)(postcss@8.5.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)
+      '@docusaurus/core': 3.10.1(@docusaurus/faster@3.10.1(@docusaurus/types@3.10.1(@swc/core@1.15.33)(esbuild@0.28.1)(postcss@8.5.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(esbuild@0.28.1)(postcss@8.5.14))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(@rspack/core@1.7.11)(@swc/core@1.15.33)(esbuild@0.28.1)(postcss@8.5.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)
       '@docusaurus/logger': 3.10.1
-      '@docusaurus/mdx-loader': 3.10.1(@swc/core@1.15.33)(lightningcss@1.32.0)(postcss@8.5.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@docusaurus/module-type-aliases': 3.10.1(@swc/core@1.15.33)(lightningcss@1.32.0)(postcss@8.5.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@docusaurus/theme-common': 3.10.1(@docusaurus/plugin-content-docs@3.10.1(@docusaurus/faster@3.10.1(@docusaurus/types@3.10.1(@swc/core@1.15.33)(lightningcss@1.32.0)(postcss@8.5.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(postcss@8.5.14))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(@rspack/core@1.7.11)(@swc/core@1.15.33)(lightningcss@1.32.0)(postcss@8.5.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3))(@swc/core@1.15.33)(lightningcss@1.32.0)(postcss@8.5.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@docusaurus/types': 3.10.1(@swc/core@1.15.33)(lightningcss@1.32.0)(postcss@8.5.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@docusaurus/utils': 3.10.1(@swc/core@1.15.33)(lightningcss@1.32.0)(postcss@8.5.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@docusaurus/utils-common': 3.10.1(@swc/core@1.15.33)(lightningcss@1.32.0)(postcss@8.5.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@docusaurus/utils-validation': 3.10.1(@swc/core@1.15.33)(lightningcss@1.32.0)(postcss@8.5.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@docusaurus/mdx-loader': 3.10.1(@swc/core@1.15.33)(esbuild@0.28.1)(postcss@8.5.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@docusaurus/module-type-aliases': 3.10.1(@swc/core@1.15.33)(esbuild@0.28.1)(postcss@8.5.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@docusaurus/theme-common': 3.10.1(@docusaurus/plugin-content-docs@3.10.1(@docusaurus/faster@3.10.1(@docusaurus/types@3.10.1(@swc/core@1.15.33)(esbuild@0.28.1)(postcss@8.5.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(esbuild@0.28.1)(postcss@8.5.14))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(@rspack/core@1.7.11)(@swc/core@1.15.33)(esbuild@0.28.1)(postcss@8.5.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3))(@swc/core@1.15.33)(esbuild@0.28.1)(postcss@8.5.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@docusaurus/types': 3.10.1(@swc/core@1.15.33)(esbuild@0.28.1)(postcss@8.5.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@docusaurus/utils': 3.10.1(@swc/core@1.15.33)(esbuild@0.28.1)(postcss@8.5.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@docusaurus/utils-common': 3.10.1(@swc/core@1.15.33)(esbuild@0.28.1)(postcss@8.5.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@docusaurus/utils-validation': 3.10.1(@swc/core@1.15.33)(esbuild@0.28.1)(postcss@8.5.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       '@types/react-router-config': 5.0.11
       combine-promises: 1.2.0
       fs-extra: 11.3.4
@@ -10962,7 +10768,7 @@ snapshots:
       schema-dts: 1.1.5
       tslib: 2.8.1
       utility-types: 3.11.0
-      webpack: 5.106.2(@swc/core@1.15.33)(lightningcss@1.32.0)(postcss@8.5.14)
+      webpack: 5.106.2(@swc/core@1.15.33)(esbuild@0.28.1)(postcss@8.5.14)
     transitivePeerDependencies:
       - '@docusaurus/faster'
       - '@mdx-js/react'
@@ -10987,18 +10793,18 @@ snapshots:
       - utf-8-validate
       - webpack-cli
 
-  '@docusaurus/plugin-content-pages@3.10.1(@docusaurus/faster@3.10.1(@docusaurus/types@3.10.1(@swc/core@1.15.33)(lightningcss@1.32.0)(postcss@8.5.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(postcss@8.5.14))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(@rspack/core@1.7.11)(@swc/core@1.15.33)(lightningcss@1.32.0)(postcss@8.5.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)':
+  '@docusaurus/plugin-content-pages@3.10.1(@docusaurus/faster@3.10.1(@docusaurus/types@3.10.1(@swc/core@1.15.33)(esbuild@0.28.1)(postcss@8.5.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(esbuild@0.28.1)(postcss@8.5.14))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(@rspack/core@1.7.11)(@swc/core@1.15.33)(esbuild@0.28.1)(postcss@8.5.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)':
     dependencies:
-      '@docusaurus/core': 3.10.1(@docusaurus/faster@3.10.1(@docusaurus/types@3.10.1(@swc/core@1.15.33)(lightningcss@1.32.0)(postcss@8.5.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(postcss@8.5.14))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(@rspack/core@1.7.11)(@swc/core@1.15.33)(lightningcss@1.32.0)(postcss@8.5.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)
-      '@docusaurus/mdx-loader': 3.10.1(@swc/core@1.15.33)(lightningcss@1.32.0)(postcss@8.5.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@docusaurus/types': 3.10.1(@swc/core@1.15.33)(lightningcss@1.32.0)(postcss@8.5.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@docusaurus/utils': 3.10.1(@swc/core@1.15.33)(lightningcss@1.32.0)(postcss@8.5.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@docusaurus/utils-validation': 3.10.1(@swc/core@1.15.33)(lightningcss@1.32.0)(postcss@8.5.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@docusaurus/core': 3.10.1(@docusaurus/faster@3.10.1(@docusaurus/types@3.10.1(@swc/core@1.15.33)(esbuild@0.28.1)(postcss@8.5.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(esbuild@0.28.1)(postcss@8.5.14))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(@rspack/core@1.7.11)(@swc/core@1.15.33)(esbuild@0.28.1)(postcss@8.5.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)
+      '@docusaurus/mdx-loader': 3.10.1(@swc/core@1.15.33)(esbuild@0.28.1)(postcss@8.5.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@docusaurus/types': 3.10.1(@swc/core@1.15.33)(esbuild@0.28.1)(postcss@8.5.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@docusaurus/utils': 3.10.1(@swc/core@1.15.33)(esbuild@0.28.1)(postcss@8.5.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@docusaurus/utils-validation': 3.10.1(@swc/core@1.15.33)(esbuild@0.28.1)(postcss@8.5.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       fs-extra: 11.3.4
       react: 19.2.5
       react-dom: 19.2.5(react@19.2.5)
       tslib: 2.8.1
-      webpack: 5.106.2(@swc/core@1.15.33)(lightningcss@1.32.0)(postcss@8.5.14)
+      webpack: 5.106.2(@swc/core@1.15.33)(esbuild@0.28.1)(postcss@8.5.14)
     transitivePeerDependencies:
       - '@docusaurus/faster'
       - '@mdx-js/react'
@@ -11023,12 +10829,12 @@ snapshots:
       - utf-8-validate
       - webpack-cli
 
-  '@docusaurus/plugin-css-cascade-layers@3.10.1(@docusaurus/faster@3.10.1(@docusaurus/types@3.10.1(@swc/core@1.15.33)(lightningcss@1.32.0)(postcss@8.5.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(postcss@8.5.14))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(@rspack/core@1.7.11)(@swc/core@1.15.33)(lightningcss@1.32.0)(postcss@8.5.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)':
+  '@docusaurus/plugin-css-cascade-layers@3.10.1(@docusaurus/faster@3.10.1(@docusaurus/types@3.10.1(@swc/core@1.15.33)(esbuild@0.28.1)(postcss@8.5.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(esbuild@0.28.1)(postcss@8.5.14))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(@rspack/core@1.7.11)(@swc/core@1.15.33)(esbuild@0.28.1)(postcss@8.5.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)':
     dependencies:
-      '@docusaurus/core': 3.10.1(@docusaurus/faster@3.10.1(@docusaurus/types@3.10.1(@swc/core@1.15.33)(lightningcss@1.32.0)(postcss@8.5.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(postcss@8.5.14))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(@rspack/core@1.7.11)(@swc/core@1.15.33)(lightningcss@1.32.0)(postcss@8.5.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)
-      '@docusaurus/types': 3.10.1(@swc/core@1.15.33)(lightningcss@1.32.0)(postcss@8.5.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@docusaurus/utils': 3.10.1(@swc/core@1.15.33)(lightningcss@1.32.0)(postcss@8.5.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@docusaurus/utils-validation': 3.10.1(@swc/core@1.15.33)(lightningcss@1.32.0)(postcss@8.5.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@docusaurus/core': 3.10.1(@docusaurus/faster@3.10.1(@docusaurus/types@3.10.1(@swc/core@1.15.33)(esbuild@0.28.1)(postcss@8.5.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(esbuild@0.28.1)(postcss@8.5.14))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(@rspack/core@1.7.11)(@swc/core@1.15.33)(esbuild@0.28.1)(postcss@8.5.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)
+      '@docusaurus/types': 3.10.1(@swc/core@1.15.33)(esbuild@0.28.1)(postcss@8.5.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@docusaurus/utils': 3.10.1(@swc/core@1.15.33)(esbuild@0.28.1)(postcss@8.5.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@docusaurus/utils-validation': 3.10.1(@swc/core@1.15.33)(esbuild@0.28.1)(postcss@8.5.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       tslib: 2.8.1
     transitivePeerDependencies:
       - '@docusaurus/faster'
@@ -11056,11 +10862,11 @@ snapshots:
       - utf-8-validate
       - webpack-cli
 
-  '@docusaurus/plugin-debug@3.10.1(@docusaurus/faster@3.10.1(@docusaurus/types@3.10.1(@swc/core@1.15.33)(lightningcss@1.32.0)(postcss@8.5.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(postcss@8.5.14))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(@rspack/core@1.7.11)(@swc/core@1.15.33)(lightningcss@1.32.0)(postcss@8.5.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)':
+  '@docusaurus/plugin-debug@3.10.1(@docusaurus/faster@3.10.1(@docusaurus/types@3.10.1(@swc/core@1.15.33)(esbuild@0.28.1)(postcss@8.5.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(esbuild@0.28.1)(postcss@8.5.14))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(@rspack/core@1.7.11)(@swc/core@1.15.33)(esbuild@0.28.1)(postcss@8.5.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)':
     dependencies:
-      '@docusaurus/core': 3.10.1(@docusaurus/faster@3.10.1(@docusaurus/types@3.10.1(@swc/core@1.15.33)(lightningcss@1.32.0)(postcss@8.5.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(postcss@8.5.14))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(@rspack/core@1.7.11)(@swc/core@1.15.33)(lightningcss@1.32.0)(postcss@8.5.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)
-      '@docusaurus/types': 3.10.1(@swc/core@1.15.33)(lightningcss@1.32.0)(postcss@8.5.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@docusaurus/utils': 3.10.1(@swc/core@1.15.33)(lightningcss@1.32.0)(postcss@8.5.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@docusaurus/core': 3.10.1(@docusaurus/faster@3.10.1(@docusaurus/types@3.10.1(@swc/core@1.15.33)(esbuild@0.28.1)(postcss@8.5.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(esbuild@0.28.1)(postcss@8.5.14))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(@rspack/core@1.7.11)(@swc/core@1.15.33)(esbuild@0.28.1)(postcss@8.5.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)
+      '@docusaurus/types': 3.10.1(@swc/core@1.15.33)(esbuild@0.28.1)(postcss@8.5.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@docusaurus/utils': 3.10.1(@swc/core@1.15.33)(esbuild@0.28.1)(postcss@8.5.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       fs-extra: 11.3.4
       react: 19.2.5
       react-dom: 19.2.5(react@19.2.5)
@@ -11090,11 +10896,11 @@ snapshots:
       - utf-8-validate
       - webpack-cli
 
-  '@docusaurus/plugin-google-analytics@3.10.1(@docusaurus/faster@3.10.1(@docusaurus/types@3.10.1(@swc/core@1.15.33)(lightningcss@1.32.0)(postcss@8.5.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(postcss@8.5.14))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(@rspack/core@1.7.11)(@swc/core@1.15.33)(lightningcss@1.32.0)(postcss@8.5.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)':
+  '@docusaurus/plugin-google-analytics@3.10.1(@docusaurus/faster@3.10.1(@docusaurus/types@3.10.1(@swc/core@1.15.33)(esbuild@0.28.1)(postcss@8.5.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(esbuild@0.28.1)(postcss@8.5.14))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(@rspack/core@1.7.11)(@swc/core@1.15.33)(esbuild@0.28.1)(postcss@8.5.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)':
     dependencies:
-      '@docusaurus/core': 3.10.1(@docusaurus/faster@3.10.1(@docusaurus/types@3.10.1(@swc/core@1.15.33)(lightningcss@1.32.0)(postcss@8.5.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(postcss@8.5.14))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(@rspack/core@1.7.11)(@swc/core@1.15.33)(lightningcss@1.32.0)(postcss@8.5.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)
-      '@docusaurus/types': 3.10.1(@swc/core@1.15.33)(lightningcss@1.32.0)(postcss@8.5.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@docusaurus/utils-validation': 3.10.1(@swc/core@1.15.33)(lightningcss@1.32.0)(postcss@8.5.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@docusaurus/core': 3.10.1(@docusaurus/faster@3.10.1(@docusaurus/types@3.10.1(@swc/core@1.15.33)(esbuild@0.28.1)(postcss@8.5.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(esbuild@0.28.1)(postcss@8.5.14))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(@rspack/core@1.7.11)(@swc/core@1.15.33)(esbuild@0.28.1)(postcss@8.5.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)
+      '@docusaurus/types': 3.10.1(@swc/core@1.15.33)(esbuild@0.28.1)(postcss@8.5.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@docusaurus/utils-validation': 3.10.1(@swc/core@1.15.33)(esbuild@0.28.1)(postcss@8.5.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       react: 19.2.5
       react-dom: 19.2.5(react@19.2.5)
       tslib: 2.8.1
@@ -11122,11 +10928,11 @@ snapshots:
       - utf-8-validate
       - webpack-cli
 
-  '@docusaurus/plugin-google-gtag@3.10.1(@docusaurus/faster@3.10.1(@docusaurus/types@3.10.1(@swc/core@1.15.33)(lightningcss@1.32.0)(postcss@8.5.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(postcss@8.5.14))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(@rspack/core@1.7.11)(@swc/core@1.15.33)(lightningcss@1.32.0)(postcss@8.5.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)':
+  '@docusaurus/plugin-google-gtag@3.10.1(@docusaurus/faster@3.10.1(@docusaurus/types@3.10.1(@swc/core@1.15.33)(esbuild@0.28.1)(postcss@8.5.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(esbuild@0.28.1)(postcss@8.5.14))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(@rspack/core@1.7.11)(@swc/core@1.15.33)(esbuild@0.28.1)(postcss@8.5.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)':
     dependencies:
-      '@docusaurus/core': 3.10.1(@docusaurus/faster@3.10.1(@docusaurus/types@3.10.1(@swc/core@1.15.33)(lightningcss@1.32.0)(postcss@8.5.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(postcss@8.5.14))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(@rspack/core@1.7.11)(@swc/core@1.15.33)(lightningcss@1.32.0)(postcss@8.5.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)
-      '@docusaurus/types': 3.10.1(@swc/core@1.15.33)(lightningcss@1.32.0)(postcss@8.5.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@docusaurus/utils-validation': 3.10.1(@swc/core@1.15.33)(lightningcss@1.32.0)(postcss@8.5.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@docusaurus/core': 3.10.1(@docusaurus/faster@3.10.1(@docusaurus/types@3.10.1(@swc/core@1.15.33)(esbuild@0.28.1)(postcss@8.5.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(esbuild@0.28.1)(postcss@8.5.14))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(@rspack/core@1.7.11)(@swc/core@1.15.33)(esbuild@0.28.1)(postcss@8.5.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)
+      '@docusaurus/types': 3.10.1(@swc/core@1.15.33)(esbuild@0.28.1)(postcss@8.5.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@docusaurus/utils-validation': 3.10.1(@swc/core@1.15.33)(esbuild@0.28.1)(postcss@8.5.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       '@types/gtag.js': 0.0.20
       react: 19.2.5
       react-dom: 19.2.5(react@19.2.5)
@@ -11155,11 +10961,11 @@ snapshots:
       - utf-8-validate
       - webpack-cli
 
-  '@docusaurus/plugin-google-tag-manager@3.10.1(@docusaurus/faster@3.10.1(@docusaurus/types@3.10.1(@swc/core@1.15.33)(lightningcss@1.32.0)(postcss@8.5.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(postcss@8.5.14))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(@rspack/core@1.7.11)(@swc/core@1.15.33)(lightningcss@1.32.0)(postcss@8.5.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)':
+  '@docusaurus/plugin-google-tag-manager@3.10.1(@docusaurus/faster@3.10.1(@docusaurus/types@3.10.1(@swc/core@1.15.33)(esbuild@0.28.1)(postcss@8.5.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(esbuild@0.28.1)(postcss@8.5.14))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(@rspack/core@1.7.11)(@swc/core@1.15.33)(esbuild@0.28.1)(postcss@8.5.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)':
     dependencies:
-      '@docusaurus/core': 3.10.1(@docusaurus/faster@3.10.1(@docusaurus/types@3.10.1(@swc/core@1.15.33)(lightningcss@1.32.0)(postcss@8.5.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(postcss@8.5.14))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(@rspack/core@1.7.11)(@swc/core@1.15.33)(lightningcss@1.32.0)(postcss@8.5.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)
-      '@docusaurus/types': 3.10.1(@swc/core@1.15.33)(lightningcss@1.32.0)(postcss@8.5.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@docusaurus/utils-validation': 3.10.1(@swc/core@1.15.33)(lightningcss@1.32.0)(postcss@8.5.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@docusaurus/core': 3.10.1(@docusaurus/faster@3.10.1(@docusaurus/types@3.10.1(@swc/core@1.15.33)(esbuild@0.28.1)(postcss@8.5.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(esbuild@0.28.1)(postcss@8.5.14))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(@rspack/core@1.7.11)(@swc/core@1.15.33)(esbuild@0.28.1)(postcss@8.5.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)
+      '@docusaurus/types': 3.10.1(@swc/core@1.15.33)(esbuild@0.28.1)(postcss@8.5.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@docusaurus/utils-validation': 3.10.1(@swc/core@1.15.33)(esbuild@0.28.1)(postcss@8.5.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       react: 19.2.5
       react-dom: 19.2.5(react@19.2.5)
       tslib: 2.8.1
@@ -11187,14 +10993,14 @@ snapshots:
       - utf-8-validate
       - webpack-cli
 
-  '@docusaurus/plugin-sitemap@3.10.1(@docusaurus/faster@3.10.1(@docusaurus/types@3.10.1(@swc/core@1.15.33)(lightningcss@1.32.0)(postcss@8.5.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(postcss@8.5.14))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(@rspack/core@1.7.11)(@swc/core@1.15.33)(lightningcss@1.32.0)(postcss@8.5.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)':
+  '@docusaurus/plugin-sitemap@3.10.1(@docusaurus/faster@3.10.1(@docusaurus/types@3.10.1(@swc/core@1.15.33)(esbuild@0.28.1)(postcss@8.5.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(esbuild@0.28.1)(postcss@8.5.14))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(@rspack/core@1.7.11)(@swc/core@1.15.33)(esbuild@0.28.1)(postcss@8.5.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)':
     dependencies:
-      '@docusaurus/core': 3.10.1(@docusaurus/faster@3.10.1(@docusaurus/types@3.10.1(@swc/core@1.15.33)(lightningcss@1.32.0)(postcss@8.5.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(postcss@8.5.14))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(@rspack/core@1.7.11)(@swc/core@1.15.33)(lightningcss@1.32.0)(postcss@8.5.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)
+      '@docusaurus/core': 3.10.1(@docusaurus/faster@3.10.1(@docusaurus/types@3.10.1(@swc/core@1.15.33)(esbuild@0.28.1)(postcss@8.5.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(esbuild@0.28.1)(postcss@8.5.14))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(@rspack/core@1.7.11)(@swc/core@1.15.33)(esbuild@0.28.1)(postcss@8.5.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)
       '@docusaurus/logger': 3.10.1
-      '@docusaurus/types': 3.10.1(@swc/core@1.15.33)(lightningcss@1.32.0)(postcss@8.5.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@docusaurus/utils': 3.10.1(@swc/core@1.15.33)(lightningcss@1.32.0)(postcss@8.5.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@docusaurus/utils-common': 3.10.1(@swc/core@1.15.33)(lightningcss@1.32.0)(postcss@8.5.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@docusaurus/utils-validation': 3.10.1(@swc/core@1.15.33)(lightningcss@1.32.0)(postcss@8.5.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@docusaurus/types': 3.10.1(@swc/core@1.15.33)(esbuild@0.28.1)(postcss@8.5.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@docusaurus/utils': 3.10.1(@swc/core@1.15.33)(esbuild@0.28.1)(postcss@8.5.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@docusaurus/utils-common': 3.10.1(@swc/core@1.15.33)(esbuild@0.28.1)(postcss@8.5.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@docusaurus/utils-validation': 3.10.1(@swc/core@1.15.33)(esbuild@0.28.1)(postcss@8.5.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       fs-extra: 11.3.4
       react: 19.2.5
       react-dom: 19.2.5(react@19.2.5)
@@ -11224,18 +11030,18 @@ snapshots:
       - utf-8-validate
       - webpack-cli
 
-  '@docusaurus/plugin-svgr@3.10.1(@docusaurus/faster@3.10.1(@docusaurus/types@3.10.1(@swc/core@1.15.33)(lightningcss@1.32.0)(postcss@8.5.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(postcss@8.5.14))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(@rspack/core@1.7.11)(@swc/core@1.15.33)(lightningcss@1.32.0)(postcss@8.5.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)':
+  '@docusaurus/plugin-svgr@3.10.1(@docusaurus/faster@3.10.1(@docusaurus/types@3.10.1(@swc/core@1.15.33)(esbuild@0.28.1)(postcss@8.5.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(esbuild@0.28.1)(postcss@8.5.14))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(@rspack/core@1.7.11)(@swc/core@1.15.33)(esbuild@0.28.1)(postcss@8.5.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)':
     dependencies:
-      '@docusaurus/core': 3.10.1(@docusaurus/faster@3.10.1(@docusaurus/types@3.10.1(@swc/core@1.15.33)(lightningcss@1.32.0)(postcss@8.5.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(postcss@8.5.14))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(@rspack/core@1.7.11)(@swc/core@1.15.33)(lightningcss@1.32.0)(postcss@8.5.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)
-      '@docusaurus/types': 3.10.1(@swc/core@1.15.33)(lightningcss@1.32.0)(postcss@8.5.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@docusaurus/utils': 3.10.1(@swc/core@1.15.33)(lightningcss@1.32.0)(postcss@8.5.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@docusaurus/utils-validation': 3.10.1(@swc/core@1.15.33)(lightningcss@1.32.0)(postcss@8.5.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@docusaurus/core': 3.10.1(@docusaurus/faster@3.10.1(@docusaurus/types@3.10.1(@swc/core@1.15.33)(esbuild@0.28.1)(postcss@8.5.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(esbuild@0.28.1)(postcss@8.5.14))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(@rspack/core@1.7.11)(@swc/core@1.15.33)(esbuild@0.28.1)(postcss@8.5.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)
+      '@docusaurus/types': 3.10.1(@swc/core@1.15.33)(esbuild@0.28.1)(postcss@8.5.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@docusaurus/utils': 3.10.1(@swc/core@1.15.33)(esbuild@0.28.1)(postcss@8.5.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@docusaurus/utils-validation': 3.10.1(@swc/core@1.15.33)(esbuild@0.28.1)(postcss@8.5.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       '@svgr/core': 8.1.0(typescript@6.0.3)
       '@svgr/webpack': 8.1.0(typescript@6.0.3)
       react: 19.2.5
       react-dom: 19.2.5(react@19.2.5)
       tslib: 2.8.1
-      webpack: 5.106.2(@swc/core@1.15.33)(lightningcss@1.32.0)(postcss@8.5.14)
+      webpack: 5.106.2(@swc/core@1.15.33)(esbuild@0.28.1)(postcss@8.5.14)
     transitivePeerDependencies:
       - '@docusaurus/faster'
       - '@mdx-js/react'
@@ -11260,23 +11066,23 @@ snapshots:
       - utf-8-validate
       - webpack-cli
 
-  '@docusaurus/preset-classic@3.10.1(@algolia/client-search@5.52.1)(@docusaurus/faster@3.10.1(@docusaurus/types@3.10.1(@swc/core@1.15.33)(lightningcss@1.32.0)(postcss@8.5.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(postcss@8.5.14))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(@rspack/core@1.7.11)(@swc/core@1.15.33)(@types/react@19.2.14)(lightningcss@1.32.0)(postcss@8.5.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(search-insights@2.17.3)(typescript@6.0.3)':
+  '@docusaurus/preset-classic@3.10.1(@algolia/client-search@5.52.1)(@docusaurus/faster@3.10.1(@docusaurus/types@3.10.1(@swc/core@1.15.33)(esbuild@0.28.1)(postcss@8.5.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(esbuild@0.28.1)(postcss@8.5.14))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(@rspack/core@1.7.11)(@swc/core@1.15.33)(@types/react@19.2.14)(esbuild@0.28.1)(postcss@8.5.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(search-insights@2.17.3)(typescript@6.0.3)':
     dependencies:
-      '@docusaurus/core': 3.10.1(@docusaurus/faster@3.10.1(@docusaurus/types@3.10.1(@swc/core@1.15.33)(lightningcss@1.32.0)(postcss@8.5.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(postcss@8.5.14))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(@rspack/core@1.7.11)(@swc/core@1.15.33)(lightningcss@1.32.0)(postcss@8.5.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)
-      '@docusaurus/plugin-content-blog': 3.10.1(@docusaurus/faster@3.10.1(@docusaurus/types@3.10.1(@swc/core@1.15.33)(lightningcss@1.32.0)(postcss@8.5.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(postcss@8.5.14))(@docusaurus/plugin-content-docs@3.10.1(@docusaurus/faster@3.10.1(@docusaurus/types@3.10.1(@swc/core@1.15.33)(lightningcss@1.32.0)(postcss@8.5.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(postcss@8.5.14))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(@rspack/core@1.7.11)(@swc/core@1.15.33)(lightningcss@1.32.0)(postcss@8.5.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(@rspack/core@1.7.11)(@swc/core@1.15.33)(lightningcss@1.32.0)(postcss@8.5.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)
-      '@docusaurus/plugin-content-docs': 3.10.1(@docusaurus/faster@3.10.1(@docusaurus/types@3.10.1(@swc/core@1.15.33)(lightningcss@1.32.0)(postcss@8.5.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(postcss@8.5.14))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(@rspack/core@1.7.11)(@swc/core@1.15.33)(lightningcss@1.32.0)(postcss@8.5.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)
-      '@docusaurus/plugin-content-pages': 3.10.1(@docusaurus/faster@3.10.1(@docusaurus/types@3.10.1(@swc/core@1.15.33)(lightningcss@1.32.0)(postcss@8.5.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(postcss@8.5.14))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(@rspack/core@1.7.11)(@swc/core@1.15.33)(lightningcss@1.32.0)(postcss@8.5.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)
-      '@docusaurus/plugin-css-cascade-layers': 3.10.1(@docusaurus/faster@3.10.1(@docusaurus/types@3.10.1(@swc/core@1.15.33)(lightningcss@1.32.0)(postcss@8.5.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(postcss@8.5.14))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(@rspack/core@1.7.11)(@swc/core@1.15.33)(lightningcss@1.32.0)(postcss@8.5.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)
-      '@docusaurus/plugin-debug': 3.10.1(@docusaurus/faster@3.10.1(@docusaurus/types@3.10.1(@swc/core@1.15.33)(lightningcss@1.32.0)(postcss@8.5.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(postcss@8.5.14))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(@rspack/core@1.7.11)(@swc/core@1.15.33)(lightningcss@1.32.0)(postcss@8.5.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)
-      '@docusaurus/plugin-google-analytics': 3.10.1(@docusaurus/faster@3.10.1(@docusaurus/types@3.10.1(@swc/core@1.15.33)(lightningcss@1.32.0)(postcss@8.5.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(postcss@8.5.14))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(@rspack/core@1.7.11)(@swc/core@1.15.33)(lightningcss@1.32.0)(postcss@8.5.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)
-      '@docusaurus/plugin-google-gtag': 3.10.1(@docusaurus/faster@3.10.1(@docusaurus/types@3.10.1(@swc/core@1.15.33)(lightningcss@1.32.0)(postcss@8.5.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(postcss@8.5.14))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(@rspack/core@1.7.11)(@swc/core@1.15.33)(lightningcss@1.32.0)(postcss@8.5.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)
-      '@docusaurus/plugin-google-tag-manager': 3.10.1(@docusaurus/faster@3.10.1(@docusaurus/types@3.10.1(@swc/core@1.15.33)(lightningcss@1.32.0)(postcss@8.5.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(postcss@8.5.14))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(@rspack/core@1.7.11)(@swc/core@1.15.33)(lightningcss@1.32.0)(postcss@8.5.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)
-      '@docusaurus/plugin-sitemap': 3.10.1(@docusaurus/faster@3.10.1(@docusaurus/types@3.10.1(@swc/core@1.15.33)(lightningcss@1.32.0)(postcss@8.5.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(postcss@8.5.14))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(@rspack/core@1.7.11)(@swc/core@1.15.33)(lightningcss@1.32.0)(postcss@8.5.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)
-      '@docusaurus/plugin-svgr': 3.10.1(@docusaurus/faster@3.10.1(@docusaurus/types@3.10.1(@swc/core@1.15.33)(lightningcss@1.32.0)(postcss@8.5.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(postcss@8.5.14))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(@rspack/core@1.7.11)(@swc/core@1.15.33)(lightningcss@1.32.0)(postcss@8.5.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)
-      '@docusaurus/theme-classic': 3.10.1(@docusaurus/faster@3.10.1(@docusaurus/types@3.10.1(@swc/core@1.15.33)(lightningcss@1.32.0)(postcss@8.5.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(postcss@8.5.14))(@rspack/core@1.7.11)(@swc/core@1.15.33)(@types/react@19.2.14)(lightningcss@1.32.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)
-      '@docusaurus/theme-common': 3.10.1(@docusaurus/plugin-content-docs@3.10.1(@docusaurus/faster@3.10.1(@docusaurus/types@3.10.1(@swc/core@1.15.33)(lightningcss@1.32.0)(postcss@8.5.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(postcss@8.5.14))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(@rspack/core@1.7.11)(@swc/core@1.15.33)(lightningcss@1.32.0)(postcss@8.5.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3))(@swc/core@1.15.33)(lightningcss@1.32.0)(postcss@8.5.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@docusaurus/theme-search-algolia': 3.10.1(@algolia/client-search@5.52.1)(@docusaurus/faster@3.10.1(@docusaurus/types@3.10.1(@swc/core@1.15.33)(lightningcss@1.32.0)(postcss@8.5.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(postcss@8.5.14))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(@rspack/core@1.7.11)(@swc/core@1.15.33)(@types/react@19.2.14)(lightningcss@1.32.0)(postcss@8.5.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(search-insights@2.17.3)(typescript@6.0.3)
-      '@docusaurus/types': 3.10.1(@swc/core@1.15.33)(lightningcss@1.32.0)(postcss@8.5.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@docusaurus/core': 3.10.1(@docusaurus/faster@3.10.1(@docusaurus/types@3.10.1(@swc/core@1.15.33)(esbuild@0.28.1)(postcss@8.5.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(esbuild@0.28.1)(postcss@8.5.14))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(@rspack/core@1.7.11)(@swc/core@1.15.33)(esbuild@0.28.1)(postcss@8.5.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)
+      '@docusaurus/plugin-content-blog': 3.10.1(@docusaurus/faster@3.10.1(@docusaurus/types@3.10.1(@swc/core@1.15.33)(esbuild@0.28.1)(postcss@8.5.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(esbuild@0.28.1)(postcss@8.5.14))(@docusaurus/plugin-content-docs@3.10.1(@docusaurus/faster@3.10.1(@docusaurus/types@3.10.1(@swc/core@1.15.33)(esbuild@0.28.1)(postcss@8.5.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(esbuild@0.28.1)(postcss@8.5.14))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(@rspack/core@1.7.11)(@swc/core@1.15.33)(esbuild@0.28.1)(postcss@8.5.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(@rspack/core@1.7.11)(@swc/core@1.15.33)(esbuild@0.28.1)(postcss@8.5.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)
+      '@docusaurus/plugin-content-docs': 3.10.1(@docusaurus/faster@3.10.1(@docusaurus/types@3.10.1(@swc/core@1.15.33)(esbuild@0.28.1)(postcss@8.5.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(esbuild@0.28.1)(postcss@8.5.14))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(@rspack/core@1.7.11)(@swc/core@1.15.33)(esbuild@0.28.1)(postcss@8.5.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)
+      '@docusaurus/plugin-content-pages': 3.10.1(@docusaurus/faster@3.10.1(@docusaurus/types@3.10.1(@swc/core@1.15.33)(esbuild@0.28.1)(postcss@8.5.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(esbuild@0.28.1)(postcss@8.5.14))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(@rspack/core@1.7.11)(@swc/core@1.15.33)(esbuild@0.28.1)(postcss@8.5.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)
+      '@docusaurus/plugin-css-cascade-layers': 3.10.1(@docusaurus/faster@3.10.1(@docusaurus/types@3.10.1(@swc/core@1.15.33)(esbuild@0.28.1)(postcss@8.5.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(esbuild@0.28.1)(postcss@8.5.14))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(@rspack/core@1.7.11)(@swc/core@1.15.33)(esbuild@0.28.1)(postcss@8.5.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)
+      '@docusaurus/plugin-debug': 3.10.1(@docusaurus/faster@3.10.1(@docusaurus/types@3.10.1(@swc/core@1.15.33)(esbuild@0.28.1)(postcss@8.5.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(esbuild@0.28.1)(postcss@8.5.14))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(@rspack/core@1.7.11)(@swc/core@1.15.33)(esbuild@0.28.1)(postcss@8.5.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)
+      '@docusaurus/plugin-google-analytics': 3.10.1(@docusaurus/faster@3.10.1(@docusaurus/types@3.10.1(@swc/core@1.15.33)(esbuild@0.28.1)(postcss@8.5.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(esbuild@0.28.1)(postcss@8.5.14))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(@rspack/core@1.7.11)(@swc/core@1.15.33)(esbuild@0.28.1)(postcss@8.5.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)
+      '@docusaurus/plugin-google-gtag': 3.10.1(@docusaurus/faster@3.10.1(@docusaurus/types@3.10.1(@swc/core@1.15.33)(esbuild@0.28.1)(postcss@8.5.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(esbuild@0.28.1)(postcss@8.5.14))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(@rspack/core@1.7.11)(@swc/core@1.15.33)(esbuild@0.28.1)(postcss@8.5.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)
+      '@docusaurus/plugin-google-tag-manager': 3.10.1(@docusaurus/faster@3.10.1(@docusaurus/types@3.10.1(@swc/core@1.15.33)(esbuild@0.28.1)(postcss@8.5.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(esbuild@0.28.1)(postcss@8.5.14))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(@rspack/core@1.7.11)(@swc/core@1.15.33)(esbuild@0.28.1)(postcss@8.5.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)
+      '@docusaurus/plugin-sitemap': 3.10.1(@docusaurus/faster@3.10.1(@docusaurus/types@3.10.1(@swc/core@1.15.33)(esbuild@0.28.1)(postcss@8.5.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(esbuild@0.28.1)(postcss@8.5.14))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(@rspack/core@1.7.11)(@swc/core@1.15.33)(esbuild@0.28.1)(postcss@8.5.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)
+      '@docusaurus/plugin-svgr': 3.10.1(@docusaurus/faster@3.10.1(@docusaurus/types@3.10.1(@swc/core@1.15.33)(esbuild@0.28.1)(postcss@8.5.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(esbuild@0.28.1)(postcss@8.5.14))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(@rspack/core@1.7.11)(@swc/core@1.15.33)(esbuild@0.28.1)(postcss@8.5.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)
+      '@docusaurus/theme-classic': 3.10.1(@docusaurus/faster@3.10.1(@docusaurus/types@3.10.1(@swc/core@1.15.33)(esbuild@0.28.1)(postcss@8.5.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(esbuild@0.28.1)(postcss@8.5.14))(@rspack/core@1.7.11)(@swc/core@1.15.33)(@types/react@19.2.14)(esbuild@0.28.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)
+      '@docusaurus/theme-common': 3.10.1(@docusaurus/plugin-content-docs@3.10.1(@docusaurus/faster@3.10.1(@docusaurus/types@3.10.1(@swc/core@1.15.33)(esbuild@0.28.1)(postcss@8.5.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(esbuild@0.28.1)(postcss@8.5.14))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(@rspack/core@1.7.11)(@swc/core@1.15.33)(esbuild@0.28.1)(postcss@8.5.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3))(@swc/core@1.15.33)(esbuild@0.28.1)(postcss@8.5.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@docusaurus/theme-search-algolia': 3.10.1(@algolia/client-search@5.52.1)(@docusaurus/faster@3.10.1(@docusaurus/types@3.10.1(@swc/core@1.15.33)(esbuild@0.28.1)(postcss@8.5.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(esbuild@0.28.1)(postcss@8.5.14))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(@rspack/core@1.7.11)(@swc/core@1.15.33)(@types/react@19.2.14)(esbuild@0.28.1)(postcss@8.5.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(search-insights@2.17.3)(typescript@6.0.3)
+      '@docusaurus/types': 3.10.1(@swc/core@1.15.33)(esbuild@0.28.1)(postcss@8.5.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       react: 19.2.5
       react-dom: 19.2.5(react@19.2.5)
     transitivePeerDependencies:
@@ -11311,21 +11117,21 @@ snapshots:
       '@types/react': 19.2.14
       react: 19.2.5
 
-  '@docusaurus/theme-classic@3.10.1(@docusaurus/faster@3.10.1(@docusaurus/types@3.10.1(@swc/core@1.15.33)(lightningcss@1.32.0)(postcss@8.5.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(postcss@8.5.14))(@rspack/core@1.7.11)(@swc/core@1.15.33)(@types/react@19.2.14)(lightningcss@1.32.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)':
+  '@docusaurus/theme-classic@3.10.1(@docusaurus/faster@3.10.1(@docusaurus/types@3.10.1(@swc/core@1.15.33)(esbuild@0.28.1)(postcss@8.5.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(esbuild@0.28.1)(postcss@8.5.14))(@rspack/core@1.7.11)(@swc/core@1.15.33)(@types/react@19.2.14)(esbuild@0.28.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)':
     dependencies:
-      '@docusaurus/core': 3.10.1(@docusaurus/faster@3.10.1(@docusaurus/types@3.10.1(@swc/core@1.15.33)(lightningcss@1.32.0)(postcss@8.5.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(postcss@8.5.14))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(@rspack/core@1.7.11)(@swc/core@1.15.33)(lightningcss@1.32.0)(postcss@8.5.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)
+      '@docusaurus/core': 3.10.1(@docusaurus/faster@3.10.1(@docusaurus/types@3.10.1(@swc/core@1.15.33)(esbuild@0.28.1)(postcss@8.5.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(esbuild@0.28.1)(postcss@8.5.14))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(@rspack/core@1.7.11)(@swc/core@1.15.33)(esbuild@0.28.1)(postcss@8.5.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)
       '@docusaurus/logger': 3.10.1
-      '@docusaurus/mdx-loader': 3.10.1(@swc/core@1.15.33)(lightningcss@1.32.0)(postcss@8.5.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@docusaurus/module-type-aliases': 3.10.1(@swc/core@1.15.33)(lightningcss@1.32.0)(postcss@8.5.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@docusaurus/plugin-content-blog': 3.10.1(@docusaurus/faster@3.10.1(@docusaurus/types@3.10.1(@swc/core@1.15.33)(lightningcss@1.32.0)(postcss@8.5.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(postcss@8.5.14))(@docusaurus/plugin-content-docs@3.10.1(@docusaurus/faster@3.10.1(@docusaurus/types@3.10.1(@swc/core@1.15.33)(lightningcss@1.32.0)(postcss@8.5.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(postcss@8.5.14))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(@rspack/core@1.7.11)(@swc/core@1.15.33)(lightningcss@1.32.0)(postcss@8.5.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(@rspack/core@1.7.11)(@swc/core@1.15.33)(lightningcss@1.32.0)(postcss@8.5.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)
-      '@docusaurus/plugin-content-docs': 3.10.1(@docusaurus/faster@3.10.1(@docusaurus/types@3.10.1(@swc/core@1.15.33)(lightningcss@1.32.0)(postcss@8.5.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(postcss@8.5.14))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(@rspack/core@1.7.11)(@swc/core@1.15.33)(lightningcss@1.32.0)(postcss@8.5.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)
-      '@docusaurus/plugin-content-pages': 3.10.1(@docusaurus/faster@3.10.1(@docusaurus/types@3.10.1(@swc/core@1.15.33)(lightningcss@1.32.0)(postcss@8.5.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(postcss@8.5.14))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(@rspack/core@1.7.11)(@swc/core@1.15.33)(lightningcss@1.32.0)(postcss@8.5.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)
-      '@docusaurus/theme-common': 3.10.1(@docusaurus/plugin-content-docs@3.10.1(@docusaurus/faster@3.10.1(@docusaurus/types@3.10.1(@swc/core@1.15.33)(lightningcss@1.32.0)(postcss@8.5.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(postcss@8.5.14))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(@rspack/core@1.7.11)(@swc/core@1.15.33)(lightningcss@1.32.0)(postcss@8.5.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3))(@swc/core@1.15.33)(lightningcss@1.32.0)(postcss@8.5.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@docusaurus/mdx-loader': 3.10.1(@swc/core@1.15.33)(esbuild@0.28.1)(postcss@8.5.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@docusaurus/module-type-aliases': 3.10.1(@swc/core@1.15.33)(esbuild@0.28.1)(postcss@8.5.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@docusaurus/plugin-content-blog': 3.10.1(@docusaurus/faster@3.10.1(@docusaurus/types@3.10.1(@swc/core@1.15.33)(esbuild@0.28.1)(postcss@8.5.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(esbuild@0.28.1)(postcss@8.5.14))(@docusaurus/plugin-content-docs@3.10.1(@docusaurus/faster@3.10.1(@docusaurus/types@3.10.1(@swc/core@1.15.33)(esbuild@0.28.1)(postcss@8.5.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(esbuild@0.28.1)(postcss@8.5.14))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(@rspack/core@1.7.11)(@swc/core@1.15.33)(esbuild@0.28.1)(postcss@8.5.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(@rspack/core@1.7.11)(@swc/core@1.15.33)(esbuild@0.28.1)(postcss@8.5.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)
+      '@docusaurus/plugin-content-docs': 3.10.1(@docusaurus/faster@3.10.1(@docusaurus/types@3.10.1(@swc/core@1.15.33)(esbuild@0.28.1)(postcss@8.5.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(esbuild@0.28.1)(postcss@8.5.14))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(@rspack/core@1.7.11)(@swc/core@1.15.33)(esbuild@0.28.1)(postcss@8.5.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)
+      '@docusaurus/plugin-content-pages': 3.10.1(@docusaurus/faster@3.10.1(@docusaurus/types@3.10.1(@swc/core@1.15.33)(esbuild@0.28.1)(postcss@8.5.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(esbuild@0.28.1)(postcss@8.5.14))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(@rspack/core@1.7.11)(@swc/core@1.15.33)(esbuild@0.28.1)(postcss@8.5.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)
+      '@docusaurus/theme-common': 3.10.1(@docusaurus/plugin-content-docs@3.10.1(@docusaurus/faster@3.10.1(@docusaurus/types@3.10.1(@swc/core@1.15.33)(esbuild@0.28.1)(postcss@8.5.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(esbuild@0.28.1)(postcss@8.5.14))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(@rspack/core@1.7.11)(@swc/core@1.15.33)(esbuild@0.28.1)(postcss@8.5.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3))(@swc/core@1.15.33)(esbuild@0.28.1)(postcss@8.5.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       '@docusaurus/theme-translations': 3.10.1
-      '@docusaurus/types': 3.10.1(@swc/core@1.15.33)(lightningcss@1.32.0)(postcss@8.5.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@docusaurus/utils': 3.10.1(@swc/core@1.15.33)(lightningcss@1.32.0)(postcss@8.5.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@docusaurus/utils-common': 3.10.1(@swc/core@1.15.33)(lightningcss@1.32.0)(postcss@8.5.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@docusaurus/utils-validation': 3.10.1(@swc/core@1.15.33)(lightningcss@1.32.0)(postcss@8.5.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@docusaurus/types': 3.10.1(@swc/core@1.15.33)(esbuild@0.28.1)(postcss@8.5.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@docusaurus/utils': 3.10.1(@swc/core@1.15.33)(esbuild@0.28.1)(postcss@8.5.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@docusaurus/utils-common': 3.10.1(@swc/core@1.15.33)(esbuild@0.28.1)(postcss@8.5.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@docusaurus/utils-validation': 3.10.1(@swc/core@1.15.33)(esbuild@0.28.1)(postcss@8.5.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       '@mdx-js/react': 3.1.1(@types/react@19.2.14)(react@19.2.5)
       clsx: 2.1.1
       copy-text-to-clipboard: 3.2.2
@@ -11364,13 +11170,13 @@ snapshots:
       - utf-8-validate
       - webpack-cli
 
-  '@docusaurus/theme-common@3.10.1(@docusaurus/plugin-content-docs@3.10.1(@docusaurus/faster@3.10.1(@docusaurus/types@3.10.1(@swc/core@1.15.33)(lightningcss@1.32.0)(postcss@8.5.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(postcss@8.5.14))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(@rspack/core@1.7.11)(@swc/core@1.15.33)(lightningcss@1.32.0)(postcss@8.5.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3))(@swc/core@1.15.33)(lightningcss@1.32.0)(postcss@8.5.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
+  '@docusaurus/theme-common@3.10.1(@docusaurus/plugin-content-docs@3.10.1(@docusaurus/faster@3.10.1(@docusaurus/types@3.10.1(@swc/core@1.15.33)(esbuild@0.28.1)(postcss@8.5.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(esbuild@0.28.1)(postcss@8.5.14))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(@rspack/core@1.7.11)(@swc/core@1.15.33)(esbuild@0.28.1)(postcss@8.5.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3))(@swc/core@1.15.33)(esbuild@0.28.1)(postcss@8.5.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
     dependencies:
-      '@docusaurus/mdx-loader': 3.10.1(@swc/core@1.15.33)(lightningcss@1.32.0)(postcss@8.5.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@docusaurus/module-type-aliases': 3.10.1(@swc/core@1.15.33)(lightningcss@1.32.0)(postcss@8.5.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@docusaurus/plugin-content-docs': 3.10.1(@docusaurus/faster@3.10.1(@docusaurus/types@3.10.1(@swc/core@1.15.33)(lightningcss@1.32.0)(postcss@8.5.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(postcss@8.5.14))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(@rspack/core@1.7.11)(@swc/core@1.15.33)(lightningcss@1.32.0)(postcss@8.5.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)
-      '@docusaurus/utils': 3.10.1(@swc/core@1.15.33)(lightningcss@1.32.0)(postcss@8.5.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@docusaurus/utils-common': 3.10.1(@swc/core@1.15.33)(lightningcss@1.32.0)(postcss@8.5.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@docusaurus/mdx-loader': 3.10.1(@swc/core@1.15.33)(esbuild@0.28.1)(postcss@8.5.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@docusaurus/module-type-aliases': 3.10.1(@swc/core@1.15.33)(esbuild@0.28.1)(postcss@8.5.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@docusaurus/plugin-content-docs': 3.10.1(@docusaurus/faster@3.10.1(@docusaurus/types@3.10.1(@swc/core@1.15.33)(esbuild@0.28.1)(postcss@8.5.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(esbuild@0.28.1)(postcss@8.5.14))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(@rspack/core@1.7.11)(@swc/core@1.15.33)(esbuild@0.28.1)(postcss@8.5.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)
+      '@docusaurus/utils': 3.10.1(@swc/core@1.15.33)(esbuild@0.28.1)(postcss@8.5.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@docusaurus/utils-common': 3.10.1(@swc/core@1.15.33)(esbuild@0.28.1)(postcss@8.5.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       '@types/history': 4.7.11
       '@types/react': 19.2.14
       '@types/react-router-config': 5.0.11
@@ -11397,17 +11203,17 @@ snapshots:
       - uglify-js
       - webpack-cli
 
-  '@docusaurus/theme-search-algolia@3.10.1(@algolia/client-search@5.52.1)(@docusaurus/faster@3.10.1(@docusaurus/types@3.10.1(@swc/core@1.15.33)(lightningcss@1.32.0)(postcss@8.5.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(postcss@8.5.14))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(@rspack/core@1.7.11)(@swc/core@1.15.33)(@types/react@19.2.14)(lightningcss@1.32.0)(postcss@8.5.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(search-insights@2.17.3)(typescript@6.0.3)':
+  '@docusaurus/theme-search-algolia@3.10.1(@algolia/client-search@5.52.1)(@docusaurus/faster@3.10.1(@docusaurus/types@3.10.1(@swc/core@1.15.33)(esbuild@0.28.1)(postcss@8.5.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(esbuild@0.28.1)(postcss@8.5.14))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(@rspack/core@1.7.11)(@swc/core@1.15.33)(@types/react@19.2.14)(esbuild@0.28.1)(postcss@8.5.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(search-insights@2.17.3)(typescript@6.0.3)':
     dependencies:
       '@algolia/autocomplete-core': 1.19.8(@algolia/client-search@5.52.1)(algoliasearch@5.52.1)(search-insights@2.17.3)
       '@docsearch/react': 4.6.3(@algolia/client-search@5.52.1)(@types/react@19.2.14)(algoliasearch@5.52.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(search-insights@2.17.3)
-      '@docusaurus/core': 3.10.1(@docusaurus/faster@3.10.1(@docusaurus/types@3.10.1(@swc/core@1.15.33)(lightningcss@1.32.0)(postcss@8.5.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(postcss@8.5.14))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(@rspack/core@1.7.11)(@swc/core@1.15.33)(lightningcss@1.32.0)(postcss@8.5.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)
+      '@docusaurus/core': 3.10.1(@docusaurus/faster@3.10.1(@docusaurus/types@3.10.1(@swc/core@1.15.33)(esbuild@0.28.1)(postcss@8.5.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(esbuild@0.28.1)(postcss@8.5.14))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(@rspack/core@1.7.11)(@swc/core@1.15.33)(esbuild@0.28.1)(postcss@8.5.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)
       '@docusaurus/logger': 3.10.1
-      '@docusaurus/plugin-content-docs': 3.10.1(@docusaurus/faster@3.10.1(@docusaurus/types@3.10.1(@swc/core@1.15.33)(lightningcss@1.32.0)(postcss@8.5.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(postcss@8.5.14))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(@rspack/core@1.7.11)(@swc/core@1.15.33)(lightningcss@1.32.0)(postcss@8.5.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)
-      '@docusaurus/theme-common': 3.10.1(@docusaurus/plugin-content-docs@3.10.1(@docusaurus/faster@3.10.1(@docusaurus/types@3.10.1(@swc/core@1.15.33)(lightningcss@1.32.0)(postcss@8.5.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(postcss@8.5.14))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(@rspack/core@1.7.11)(@swc/core@1.15.33)(lightningcss@1.32.0)(postcss@8.5.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3))(@swc/core@1.15.33)(lightningcss@1.32.0)(postcss@8.5.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@docusaurus/plugin-content-docs': 3.10.1(@docusaurus/faster@3.10.1(@docusaurus/types@3.10.1(@swc/core@1.15.33)(esbuild@0.28.1)(postcss@8.5.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(esbuild@0.28.1)(postcss@8.5.14))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(@rspack/core@1.7.11)(@swc/core@1.15.33)(esbuild@0.28.1)(postcss@8.5.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)
+      '@docusaurus/theme-common': 3.10.1(@docusaurus/plugin-content-docs@3.10.1(@docusaurus/faster@3.10.1(@docusaurus/types@3.10.1(@swc/core@1.15.33)(esbuild@0.28.1)(postcss@8.5.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(esbuild@0.28.1)(postcss@8.5.14))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(@rspack/core@1.7.11)(@swc/core@1.15.33)(esbuild@0.28.1)(postcss@8.5.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3))(@swc/core@1.15.33)(esbuild@0.28.1)(postcss@8.5.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       '@docusaurus/theme-translations': 3.10.1
-      '@docusaurus/utils': 3.10.1(@swc/core@1.15.33)(lightningcss@1.32.0)(postcss@8.5.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@docusaurus/utils-validation': 3.10.1(@swc/core@1.15.33)(lightningcss@1.32.0)(postcss@8.5.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@docusaurus/utils': 3.10.1(@swc/core@1.15.33)(esbuild@0.28.1)(postcss@8.5.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@docusaurus/utils-validation': 3.10.1(@swc/core@1.15.33)(esbuild@0.28.1)(postcss@8.5.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       algoliasearch: 5.52.1
       algoliasearch-helper: 3.29.1(algoliasearch@5.52.1)
       clsx: 2.1.1
@@ -11452,7 +11258,7 @@ snapshots:
 
   '@docusaurus/tsconfig@3.10.1': {}
 
-  '@docusaurus/types@3.10.1(@swc/core@1.15.33)(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.14))(html-minifier-terser@7.2.0)(lightningcss@1.32.0)(postcss@8.5.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
+  '@docusaurus/types@3.10.1(@swc/core@1.15.33)(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.14))(esbuild@0.28.1)(html-minifier-terser@7.2.0)(postcss@8.5.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
     dependencies:
       '@mdx-js/mdx': 3.1.1
       '@types/history': 4.7.11
@@ -11464,7 +11270,7 @@ snapshots:
       react-dom: 19.2.5(react@19.2.5)
       react-helmet-async: '@slorber/react-helmet-async@1.3.0(react-dom@19.2.5(react@19.2.5))(react@19.2.5)'
       utility-types: 3.11.0
-      webpack: 5.106.2(@swc/core@1.15.33)(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.14))(html-minifier-terser@7.2.0)(lightningcss@1.32.0)(postcss@8.5.14)
+      webpack: 5.106.2(@swc/core@1.15.33)(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.14))(esbuild@0.28.1)(html-minifier-terser@7.2.0)(postcss@8.5.14)
       webpack-merge: 5.10.0
     transitivePeerDependencies:
       - '@minify-html/node'
@@ -11482,7 +11288,7 @@ snapshots:
       - uglify-js
       - webpack-cli
 
-  '@docusaurus/types@3.10.1(@swc/core@1.15.33)(lightningcss@1.32.0)(postcss@8.5.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
+  '@docusaurus/types@3.10.1(@swc/core@1.15.33)(esbuild@0.28.1)(postcss@8.5.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
     dependencies:
       '@mdx-js/mdx': 3.1.1
       '@types/history': 4.7.11
@@ -11494,7 +11300,7 @@ snapshots:
       react-dom: 19.2.5(react@19.2.5)
       react-helmet-async: '@slorber/react-helmet-async@1.3.0(react-dom@19.2.5(react@19.2.5))(react@19.2.5)'
       utility-types: 3.11.0
-      webpack: 5.106.2(@swc/core@1.15.33)(lightningcss@1.32.0)(postcss@8.5.14)
+      webpack: 5.106.2(@swc/core@1.15.33)(esbuild@0.28.1)(postcss@8.5.14)
       webpack-merge: 5.10.0
     transitivePeerDependencies:
       - '@minify-html/node'
@@ -11512,9 +11318,9 @@ snapshots:
       - uglify-js
       - webpack-cli
 
-  '@docusaurus/utils-common@3.10.1(@swc/core@1.15.33)(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.14))(html-minifier-terser@7.2.0)(lightningcss@1.32.0)(postcss@8.5.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
+  '@docusaurus/utils-common@3.10.1(@swc/core@1.15.33)(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.14))(esbuild@0.28.1)(html-minifier-terser@7.2.0)(postcss@8.5.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
     dependencies:
-      '@docusaurus/types': 3.10.1(@swc/core@1.15.33)(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.14))(html-minifier-terser@7.2.0)(lightningcss@1.32.0)(postcss@8.5.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@docusaurus/types': 3.10.1(@swc/core@1.15.33)(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.14))(esbuild@0.28.1)(html-minifier-terser@7.2.0)(postcss@8.5.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       tslib: 2.8.1
     transitivePeerDependencies:
       - '@minify-html/node'
@@ -11534,9 +11340,9 @@ snapshots:
       - uglify-js
       - webpack-cli
 
-  '@docusaurus/utils-common@3.10.1(@swc/core@1.15.33)(lightningcss@1.32.0)(postcss@8.5.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
+  '@docusaurus/utils-common@3.10.1(@swc/core@1.15.33)(esbuild@0.28.1)(postcss@8.5.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
     dependencies:
-      '@docusaurus/types': 3.10.1(@swc/core@1.15.33)(lightningcss@1.32.0)(postcss@8.5.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@docusaurus/types': 3.10.1(@swc/core@1.15.33)(esbuild@0.28.1)(postcss@8.5.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       tslib: 2.8.1
     transitivePeerDependencies:
       - '@minify-html/node'
@@ -11556,11 +11362,11 @@ snapshots:
       - uglify-js
       - webpack-cli
 
-  '@docusaurus/utils-validation@3.10.1(@swc/core@1.15.33)(lightningcss@1.32.0)(postcss@8.5.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
+  '@docusaurus/utils-validation@3.10.1(@swc/core@1.15.33)(esbuild@0.28.1)(postcss@8.5.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
     dependencies:
       '@docusaurus/logger': 3.10.1
-      '@docusaurus/utils': 3.10.1(@swc/core@1.15.33)(lightningcss@1.32.0)(postcss@8.5.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@docusaurus/utils-common': 3.10.1(@swc/core@1.15.33)(lightningcss@1.32.0)(postcss@8.5.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@docusaurus/utils': 3.10.1(@swc/core@1.15.33)(esbuild@0.28.1)(postcss@8.5.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@docusaurus/utils-common': 3.10.1(@swc/core@1.15.33)(esbuild@0.28.1)(postcss@8.5.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       fs-extra: 11.3.4
       joi: 17.13.3
       js-yaml: 4.1.1
@@ -11584,14 +11390,14 @@ snapshots:
       - uglify-js
       - webpack-cli
 
-  '@docusaurus/utils@3.10.1(@swc/core@1.15.33)(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.14))(html-minifier-terser@7.2.0)(lightningcss@1.32.0)(postcss@8.5.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
+  '@docusaurus/utils@3.10.1(@swc/core@1.15.33)(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.14))(esbuild@0.28.1)(html-minifier-terser@7.2.0)(postcss@8.5.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
     dependencies:
       '@docusaurus/logger': 3.10.1
-      '@docusaurus/types': 3.10.1(@swc/core@1.15.33)(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.14))(html-minifier-terser@7.2.0)(lightningcss@1.32.0)(postcss@8.5.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@docusaurus/utils-common': 3.10.1(@swc/core@1.15.33)(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.14))(html-minifier-terser@7.2.0)(lightningcss@1.32.0)(postcss@8.5.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@docusaurus/types': 3.10.1(@swc/core@1.15.33)(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.14))(esbuild@0.28.1)(html-minifier-terser@7.2.0)(postcss@8.5.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@docusaurus/utils-common': 3.10.1(@swc/core@1.15.33)(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.14))(esbuild@0.28.1)(html-minifier-terser@7.2.0)(postcss@8.5.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       escape-string-regexp: 4.0.0
       execa: 5.1.1
-      file-loader: 6.2.0(webpack@5.106.2(@swc/core@1.15.33)(lightningcss@1.32.0)(postcss@8.5.14))
+      file-loader: 6.2.0(webpack@5.106.2(@swc/core@1.15.33)(esbuild@0.28.1)(postcss@8.5.14))
       fs-extra: 11.3.4
       github-slugger: 1.5.0
       globby: 11.1.0
@@ -11604,9 +11410,9 @@ snapshots:
       prompts: 2.4.2
       resolve-pathname: 3.0.0
       tslib: 2.8.1
-      url-loader: 4.1.1(file-loader@6.2.0(webpack@5.106.2(@swc/core@1.15.33)(lightningcss@1.32.0)(postcss@8.5.14)))(webpack@5.106.2(@swc/core@1.15.33)(lightningcss@1.32.0)(postcss@8.5.14))
+      url-loader: 4.1.1(file-loader@6.2.0(webpack@5.106.2(@swc/core@1.15.33)(esbuild@0.28.1)(postcss@8.5.14)))(webpack@5.106.2(@swc/core@1.15.33)(esbuild@0.28.1)(postcss@8.5.14))
       utility-types: 3.11.0
-      webpack: 5.106.2(@swc/core@1.15.33)(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.14))(html-minifier-terser@7.2.0)(lightningcss@1.32.0)(postcss@8.5.14)
+      webpack: 5.106.2(@swc/core@1.15.33)(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.14))(esbuild@0.28.1)(html-minifier-terser@7.2.0)(postcss@8.5.14)
     transitivePeerDependencies:
       - '@minify-html/node'
       - '@swc/core'
@@ -11625,14 +11431,14 @@ snapshots:
       - uglify-js
       - webpack-cli
 
-  '@docusaurus/utils@3.10.1(@swc/core@1.15.33)(lightningcss@1.32.0)(postcss@8.5.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
+  '@docusaurus/utils@3.10.1(@swc/core@1.15.33)(esbuild@0.28.1)(postcss@8.5.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
     dependencies:
       '@docusaurus/logger': 3.10.1
-      '@docusaurus/types': 3.10.1(@swc/core@1.15.33)(lightningcss@1.32.0)(postcss@8.5.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@docusaurus/utils-common': 3.10.1(@swc/core@1.15.33)(lightningcss@1.32.0)(postcss@8.5.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@docusaurus/types': 3.10.1(@swc/core@1.15.33)(esbuild@0.28.1)(postcss@8.5.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@docusaurus/utils-common': 3.10.1(@swc/core@1.15.33)(esbuild@0.28.1)(postcss@8.5.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       escape-string-regexp: 4.0.0
       execa: 5.1.1
-      file-loader: 6.2.0(webpack@5.106.2(@swc/core@1.15.33)(lightningcss@1.32.0)(postcss@8.5.14))
+      file-loader: 6.2.0(webpack@5.106.2(@swc/core@1.15.33)(esbuild@0.28.1)(postcss@8.5.14))
       fs-extra: 11.3.4
       github-slugger: 1.5.0
       globby: 11.1.0
@@ -11645,9 +11451,9 @@ snapshots:
       prompts: 2.4.2
       resolve-pathname: 3.0.0
       tslib: 2.8.1
-      url-loader: 4.1.1(file-loader@6.2.0(webpack@5.106.2(@swc/core@1.15.33)(lightningcss@1.32.0)(postcss@8.5.14)))(webpack@5.106.2(@swc/core@1.15.33)(lightningcss@1.32.0)(postcss@8.5.14))
+      url-loader: 4.1.1(file-loader@6.2.0(webpack@5.106.2(@swc/core@1.15.33)(esbuild@0.28.1)(postcss@8.5.14)))(webpack@5.106.2(@swc/core@1.15.33)(esbuild@0.28.1)(postcss@8.5.14))
       utility-types: 3.11.0
-      webpack: 5.106.2(@swc/core@1.15.33)(lightningcss@1.32.0)(postcss@8.5.14)
+      webpack: 5.106.2(@swc/core@1.15.33)(esbuild@0.28.1)(postcss@8.5.14)
     transitivePeerDependencies:
       - '@minify-html/node'
       - '@swc/core'
@@ -11775,160 +11581,82 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
-  '@esbuild/aix-ppc64@0.25.12':
+  '@esbuild/aix-ppc64@0.28.1':
     optional: true
 
-  '@esbuild/aix-ppc64@0.27.7':
+  '@esbuild/android-arm64@0.28.1':
     optional: true
 
-  '@esbuild/android-arm64@0.25.12':
+  '@esbuild/android-arm@0.28.1':
     optional: true
 
-  '@esbuild/android-arm64@0.27.7':
+  '@esbuild/android-x64@0.28.1':
     optional: true
 
-  '@esbuild/android-arm@0.25.12':
+  '@esbuild/darwin-arm64@0.28.1':
     optional: true
 
-  '@esbuild/android-arm@0.27.7':
+  '@esbuild/darwin-x64@0.28.1':
     optional: true
 
-  '@esbuild/android-x64@0.25.12':
+  '@esbuild/freebsd-arm64@0.28.1':
     optional: true
 
-  '@esbuild/android-x64@0.27.7':
+  '@esbuild/freebsd-x64@0.28.1':
     optional: true
 
-  '@esbuild/darwin-arm64@0.25.12':
+  '@esbuild/linux-arm64@0.28.1':
     optional: true
 
-  '@esbuild/darwin-arm64@0.27.7':
+  '@esbuild/linux-arm@0.28.1':
     optional: true
 
-  '@esbuild/darwin-x64@0.25.12':
+  '@esbuild/linux-ia32@0.28.1':
     optional: true
 
-  '@esbuild/darwin-x64@0.27.7':
+  '@esbuild/linux-loong64@0.28.1':
     optional: true
 
-  '@esbuild/freebsd-arm64@0.25.12':
+  '@esbuild/linux-mips64el@0.28.1':
     optional: true
 
-  '@esbuild/freebsd-arm64@0.27.7':
+  '@esbuild/linux-ppc64@0.28.1':
     optional: true
 
-  '@esbuild/freebsd-x64@0.25.12':
+  '@esbuild/linux-riscv64@0.28.1':
     optional: true
 
-  '@esbuild/freebsd-x64@0.27.7':
+  '@esbuild/linux-s390x@0.28.1':
     optional: true
 
-  '@esbuild/linux-arm64@0.25.12':
+  '@esbuild/linux-x64@0.28.1':
     optional: true
 
-  '@esbuild/linux-arm64@0.27.7':
+  '@esbuild/netbsd-arm64@0.28.1':
     optional: true
 
-  '@esbuild/linux-arm@0.25.12':
+  '@esbuild/netbsd-x64@0.28.1':
     optional: true
 
-  '@esbuild/linux-arm@0.27.7':
+  '@esbuild/openbsd-arm64@0.28.1':
     optional: true
 
-  '@esbuild/linux-ia32@0.25.12':
+  '@esbuild/openbsd-x64@0.28.1':
     optional: true
 
-  '@esbuild/linux-ia32@0.27.7':
+  '@esbuild/openharmony-arm64@0.28.1':
     optional: true
 
-  '@esbuild/linux-loong64@0.25.12':
+  '@esbuild/sunos-x64@0.28.1':
     optional: true
 
-  '@esbuild/linux-loong64@0.27.7':
+  '@esbuild/win32-arm64@0.28.1':
     optional: true
 
-  '@esbuild/linux-mips64el@0.25.12':
+  '@esbuild/win32-ia32@0.28.1':
     optional: true
 
-  '@esbuild/linux-mips64el@0.27.7':
-    optional: true
-
-  '@esbuild/linux-ppc64@0.25.12':
-    optional: true
-
-  '@esbuild/linux-ppc64@0.27.7':
-    optional: true
-
-  '@esbuild/linux-riscv64@0.25.12':
-    optional: true
-
-  '@esbuild/linux-riscv64@0.27.7':
-    optional: true
-
-  '@esbuild/linux-s390x@0.25.12':
-    optional: true
-
-  '@esbuild/linux-s390x@0.27.7':
-    optional: true
-
-  '@esbuild/linux-x64@0.25.12':
-    optional: true
-
-  '@esbuild/linux-x64@0.27.7':
-    optional: true
-
-  '@esbuild/netbsd-arm64@0.25.12':
-    optional: true
-
-  '@esbuild/netbsd-arm64@0.27.7':
-    optional: true
-
-  '@esbuild/netbsd-x64@0.25.12':
-    optional: true
-
-  '@esbuild/netbsd-x64@0.27.7':
-    optional: true
-
-  '@esbuild/openbsd-arm64@0.25.12':
-    optional: true
-
-  '@esbuild/openbsd-arm64@0.27.7':
-    optional: true
-
-  '@esbuild/openbsd-x64@0.25.12':
-    optional: true
-
-  '@esbuild/openbsd-x64@0.27.7':
-    optional: true
-
-  '@esbuild/openharmony-arm64@0.25.12':
-    optional: true
-
-  '@esbuild/openharmony-arm64@0.27.7':
-    optional: true
-
-  '@esbuild/sunos-x64@0.25.12':
-    optional: true
-
-  '@esbuild/sunos-x64@0.27.7':
-    optional: true
-
-  '@esbuild/win32-arm64@0.25.12':
-    optional: true
-
-  '@esbuild/win32-arm64@0.27.7':
-    optional: true
-
-  '@esbuild/win32-ia32@0.25.12':
-    optional: true
-
-  '@esbuild/win32-ia32@0.27.7':
-    optional: true
-
-  '@esbuild/win32-x64@0.25.12':
-    optional: true
-
-  '@esbuild/win32-x64@0.27.7':
+  '@esbuild/win32-x64@0.28.1':
     optional: true
 
   '@eslint-community/eslint-utils@4.9.1(eslint@10.2.1(jiti@2.6.1))':
@@ -12275,6 +12003,13 @@ snapshots:
       '@tybys/wasm-util': 0.10.2
     optional: true
 
+  '@napi-rs/wasm-runtime@1.1.5(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)':
+    dependencies:
+      '@emnapi/core': 1.10.0
+      '@emnapi/runtime': 1.10.0
+      '@tybys/wasm-util': 0.10.2
+    optional: true
+
   '@noble/hashes@1.4.0': {}
 
   '@nodelib/fs.scandir@2.1.5':
@@ -12323,6 +12058,8 @@ snapshots:
   '@oozcitak/util@8.3.3': {}
 
   '@oozcitak/util@8.3.4': {}
+
+  '@oxc-project/types@0.133.0': {}
 
   '@peculiar/asn1-cms@2.7.0':
     dependencies:
@@ -12432,82 +12169,58 @@ snapshots:
 
   '@polka/url@1.0.0-next.29': {}
 
+  '@rolldown/binding-android-arm64@1.0.3':
+    optional: true
+
+  '@rolldown/binding-darwin-arm64@1.0.3':
+    optional: true
+
+  '@rolldown/binding-darwin-x64@1.0.3':
+    optional: true
+
+  '@rolldown/binding-freebsd-x64@1.0.3':
+    optional: true
+
+  '@rolldown/binding-linux-arm-gnueabihf@1.0.3':
+    optional: true
+
+  '@rolldown/binding-linux-arm64-gnu@1.0.3':
+    optional: true
+
+  '@rolldown/binding-linux-arm64-musl@1.0.3':
+    optional: true
+
+  '@rolldown/binding-linux-ppc64-gnu@1.0.3':
+    optional: true
+
+  '@rolldown/binding-linux-s390x-gnu@1.0.3':
+    optional: true
+
+  '@rolldown/binding-linux-x64-gnu@1.0.3':
+    optional: true
+
+  '@rolldown/binding-linux-x64-musl@1.0.3':
+    optional: true
+
+  '@rolldown/binding-openharmony-arm64@1.0.3':
+    optional: true
+
+  '@rolldown/binding-wasm32-wasi@1.0.3':
+    dependencies:
+      '@emnapi/core': 1.10.0
+      '@emnapi/runtime': 1.10.0
+      '@napi-rs/wasm-runtime': 1.1.5(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
+    optional: true
+
+  '@rolldown/binding-win32-arm64-msvc@1.0.3':
+    optional: true
+
+  '@rolldown/binding-win32-x64-msvc@1.0.3':
+    optional: true
+
   '@rolldown/pluginutils@1.0.0-rc.3': {}
 
-  '@rollup/rollup-android-arm-eabi@4.60.2':
-    optional: true
-
-  '@rollup/rollup-android-arm64@4.60.2':
-    optional: true
-
-  '@rollup/rollup-darwin-arm64@4.60.2':
-    optional: true
-
-  '@rollup/rollup-darwin-x64@4.60.2':
-    optional: true
-
-  '@rollup/rollup-freebsd-arm64@4.60.2':
-    optional: true
-
-  '@rollup/rollup-freebsd-x64@4.60.2':
-    optional: true
-
-  '@rollup/rollup-linux-arm-gnueabihf@4.60.2':
-    optional: true
-
-  '@rollup/rollup-linux-arm-musleabihf@4.60.2':
-    optional: true
-
-  '@rollup/rollup-linux-arm64-gnu@4.60.2':
-    optional: true
-
-  '@rollup/rollup-linux-arm64-musl@4.60.2':
-    optional: true
-
-  '@rollup/rollup-linux-loong64-gnu@4.60.2':
-    optional: true
-
-  '@rollup/rollup-linux-loong64-musl@4.60.2':
-    optional: true
-
-  '@rollup/rollup-linux-ppc64-gnu@4.60.2':
-    optional: true
-
-  '@rollup/rollup-linux-ppc64-musl@4.60.2':
-    optional: true
-
-  '@rollup/rollup-linux-riscv64-gnu@4.60.2':
-    optional: true
-
-  '@rollup/rollup-linux-riscv64-musl@4.60.2':
-    optional: true
-
-  '@rollup/rollup-linux-s390x-gnu@4.60.2':
-    optional: true
-
-  '@rollup/rollup-linux-x64-gnu@4.60.2':
-    optional: true
-
-  '@rollup/rollup-linux-x64-musl@4.60.2':
-    optional: true
-
-  '@rollup/rollup-openbsd-x64@4.60.2':
-    optional: true
-
-  '@rollup/rollup-openharmony-arm64@4.60.2':
-    optional: true
-
-  '@rollup/rollup-win32-arm64-msvc@4.60.2':
-    optional: true
-
-  '@rollup/rollup-win32-ia32-msvc@4.60.2':
-    optional: true
-
-  '@rollup/rollup-win32-x64-gnu@4.60.2':
-    optional: true
-
-  '@rollup/rollup-win32-x64-msvc@4.60.2':
-    optional: true
+  '@rolldown/pluginutils@1.0.1': {}
 
   '@rspack/binding-darwin-arm64@1.7.11':
     optional: true
@@ -12989,12 +12702,12 @@ snapshots:
       postcss-selector-parser: 6.0.10
       tailwindcss: 4.2.4
 
-  '@tailwindcss/vite@4.2.4(vite@7.3.2(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.47.1)(yaml@2.8.3))':
+  '@tailwindcss/vite@4.2.4(vite@8.0.16(@types/node@25.6.0)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.47.1)(yaml@2.8.3))':
     dependencies:
       '@tailwindcss/node': 4.2.4
       '@tailwindcss/oxide': 4.2.4
       tailwindcss: 4.2.4
-      vite: 7.3.2(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.47.1)(yaml@2.8.3)
+      vite: 8.0.16(@types/node@25.6.0)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.47.1)(yaml@2.8.3)
 
   '@testing-library/dom@10.4.1':
     dependencies:
@@ -13078,11 +12791,6 @@ snapshots:
     dependencies:
       '@types/deep-eql': 4.0.2
       assertion-error: 2.0.1
-
-  '@types/chrome@0.1.43':
-    dependencies:
-      '@types/filesystem': 0.0.36
-      '@types/har-format': 1.2.16
 
   '@types/connect-history-api-fallback@1.5.4':
     dependencies:
@@ -13248,12 +12956,6 @@ snapshots:
       '@types/qs': 6.15.1
       '@types/serve-static': 1.15.10
 
-  '@types/filesystem@0.0.36':
-    dependencies:
-      '@types/filewriter': 0.0.33
-
-  '@types/filewriter@0.0.33': {}
-
   '@types/fs-extra@9.0.13':
     dependencies:
       '@types/node': 25.6.0
@@ -13261,8 +12963,6 @@ snapshots:
   '@types/geojson@7946.0.16': {}
 
   '@types/gtag.js@0.0.20': {}
-
-  '@types/har-format@1.2.16': {}
 
   '@types/hast@3.0.4':
     dependencies:
@@ -13515,7 +13215,7 @@ snapshots:
       d3-selection: 3.0.0
       d3-transition: 3.0.1(d3-selection@3.0.0)
 
-  '@vitejs/plugin-react@5.2.0(vite@7.3.2(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.47.1)(yaml@2.8.3))':
+  '@vitejs/plugin-react@5.2.0(vite@8.0.16(@types/node@25.6.0)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.47.1)(yaml@2.8.3))':
     dependencies:
       '@babel/core': 7.29.0
       '@babel/plugin-transform-react-jsx-self': 7.27.1(@babel/core@7.29.0)
@@ -13523,7 +13223,7 @@ snapshots:
       '@rolldown/pluginutils': 1.0.0-rc.3
       '@types/babel__core': 7.20.5
       react-refresh: 0.18.0
-      vite: 7.3.2(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.47.1)(yaml@2.8.3)
+      vite: 8.0.16(@types/node@25.6.0)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.47.1)(yaml@2.8.3)
     transitivePeerDependencies:
       - supports-color
 
@@ -13539,7 +13239,7 @@ snapshots:
       obug: 2.1.1
       std-env: 4.1.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.5(@types/node@25.6.0)(@vitest/coverage-v8@4.1.5)(jsdom@29.1.1)(vite@7.3.2(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.47.1)(yaml@2.8.3))
+      vitest: 4.1.5(@types/node@25.6.0)(@vitest/coverage-v8@4.1.5)(jsdom@29.1.1)(vite@8.0.16(@types/node@25.6.0)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.47.1)(yaml@2.8.3))
 
   '@vitest/expect@4.1.5':
     dependencies:
@@ -13550,13 +13250,13 @@ snapshots:
       chai: 6.2.2
       tinyrainbow: 3.1.0
 
-  '@vitest/mocker@4.1.5(vite@7.3.2(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.47.1)(yaml@2.8.3))':
+  '@vitest/mocker@4.1.5(vite@8.0.16(@types/node@25.6.0)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.47.1)(yaml@2.8.3))':
     dependencies:
       '@vitest/spy': 4.1.5
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 7.3.2(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.47.1)(yaml@2.8.3)
+      vite: 8.0.16(@types/node@25.6.0)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.47.1)(yaml@2.8.3)
 
   '@vitest/pretty-format@4.1.5':
     dependencies:
@@ -13881,12 +13581,12 @@ snapshots:
       postcss: 8.5.14
       postcss-value-parser: 4.2.0
 
-  babel-loader@9.2.1(@babel/core@7.29.0)(webpack@5.106.2(@swc/core@1.15.33)(lightningcss@1.32.0)(postcss@8.5.14)):
+  babel-loader@9.2.1(@babel/core@7.29.0)(webpack@5.106.2(@swc/core@1.15.33)(esbuild@0.28.1)(postcss@8.5.14)):
     dependencies:
       '@babel/core': 7.29.0
       find-cache-dir: 4.0.0
       schema-utils: 4.3.3
-      webpack: 5.106.2(@swc/core@1.15.33)(lightningcss@1.32.0)(postcss@8.5.14)
+      webpack: 5.106.2(@swc/core@1.15.33)(esbuild@0.28.1)(postcss@8.5.14)
 
   babel-plugin-dynamic-import-node@2.3.3:
     dependencies:
@@ -14377,7 +14077,7 @@ snapshots:
 
   copy-text-to-clipboard@3.2.2: {}
 
-  copy-webpack-plugin@11.0.0(webpack@5.106.2(@swc/core@1.15.33)(lightningcss@1.32.0)(postcss@8.5.14)):
+  copy-webpack-plugin@11.0.0(webpack@5.106.2(@swc/core@1.15.33)(esbuild@0.28.1)(postcss@8.5.14)):
     dependencies:
       fast-glob: 3.3.3
       glob-parent: 6.0.2
@@ -14385,7 +14085,7 @@ snapshots:
       normalize-path: 3.0.0
       schema-utils: 4.3.3
       serialize-javascript: 7.0.5
-      webpack: 5.106.2(@swc/core@1.15.33)(lightningcss@1.32.0)(postcss@8.5.14)
+      webpack: 5.106.2(@swc/core@1.15.33)(esbuild@0.28.1)(postcss@8.5.14)
 
   core-js-compat@3.49.0:
     dependencies:
@@ -14465,7 +14165,7 @@ snapshots:
       postcss-selector-parser: 7.1.1
       postcss-value-parser: 4.2.0
 
-  css-loader@6.11.0(@rspack/core@1.7.11)(webpack@5.106.2(@swc/core@1.15.33)(lightningcss@1.32.0)(postcss@8.5.14)):
+  css-loader@6.11.0(@rspack/core@1.7.11)(webpack@5.106.2(@swc/core@1.15.33)(esbuild@0.28.1)(postcss@8.5.14)):
     dependencies:
       icss-utils: 5.1.0(postcss@8.5.14)
       postcss: 8.5.14
@@ -14477,9 +14177,9 @@ snapshots:
       semver: 7.7.4
     optionalDependencies:
       '@rspack/core': 1.7.11
-      webpack: 5.106.2(@swc/core@1.15.33)(lightningcss@1.32.0)(postcss@8.5.14)
+      webpack: 5.106.2(@swc/core@1.15.33)(esbuild@0.28.1)(postcss@8.5.14)
 
-  css-minimizer-webpack-plugin@5.0.1(clean-css@5.3.3)(lightningcss@1.32.0)(webpack@5.106.2(@swc/core@1.15.33)(lightningcss@1.32.0)(postcss@8.5.14)):
+  css-minimizer-webpack-plugin@5.0.1(clean-css@5.3.3)(esbuild@0.28.1)(webpack@5.106.2(@swc/core@1.15.33)(esbuild@0.28.1)(postcss@8.5.14)):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.31
       cssnano: 6.1.2(postcss@8.5.14)
@@ -14487,10 +14187,10 @@ snapshots:
       postcss: 8.5.14
       schema-utils: 4.3.3
       serialize-javascript: 7.0.5
-      webpack: 5.106.2(@swc/core@1.15.33)(lightningcss@1.32.0)(postcss@8.5.14)
+      webpack: 5.106.2(@swc/core@1.15.33)(esbuild@0.28.1)(postcss@8.5.14)
     optionalDependencies:
       clean-css: 5.3.3
-      lightningcss: 1.32.0
+      esbuild: 0.28.1
 
   css-prefers-color-scheme@10.0.0(postcss@8.5.14):
     dependencies:
@@ -15039,7 +14739,7 @@ snapshots:
       builder-util: 26.8.1
       builder-util-runtime: 9.5.1
       chalk: 4.1.2
-      form-data: 4.0.5
+      form-data: 4.0.6
       fs-extra: 10.1.0
       lazy-val: 1.0.5
       mime: 2.6.0
@@ -15061,15 +14761,15 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  electron-vite@5.0.0(@swc/core@1.15.33)(vite@7.3.2(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.47.1)(yaml@2.8.3)):
+  electron-vite@5.0.0(@swc/core@1.15.33)(vite@8.0.16(@types/node@25.6.0)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.47.1)(yaml@2.8.3)):
     dependencies:
       '@babel/core': 7.29.0
       '@babel/plugin-transform-arrow-functions': 7.27.1(@babel/core@7.29.0)
       cac: 6.7.14
-      esbuild: 0.25.12
+      esbuild: 0.28.1
       magic-string: 0.30.21
       picocolors: 1.1.1
-      vite: 7.3.2(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.47.1)(yaml@2.8.3)
+      vite: 8.0.16(@types/node@25.6.0)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.47.1)(yaml@2.8.3)
     optionalDependencies:
       '@swc/core': 1.15.33
     transitivePeerDependencies:
@@ -15171,7 +14871,7 @@ snapshots:
       es-errors: 1.3.0
       get-intrinsic: 1.3.0
       has-tostringtag: 1.0.2
-      hasown: 2.0.3
+      hasown: 2.0.4
 
   es-toolkit@1.46.1: {}
 
@@ -15192,63 +14892,34 @@ snapshots:
       esast-util-from-estree: 2.0.0
       vfile-message: 4.0.3
 
-  esbuild@0.25.12:
+  esbuild@0.28.1:
     optionalDependencies:
-      '@esbuild/aix-ppc64': 0.25.12
-      '@esbuild/android-arm': 0.25.12
-      '@esbuild/android-arm64': 0.25.12
-      '@esbuild/android-x64': 0.25.12
-      '@esbuild/darwin-arm64': 0.25.12
-      '@esbuild/darwin-x64': 0.25.12
-      '@esbuild/freebsd-arm64': 0.25.12
-      '@esbuild/freebsd-x64': 0.25.12
-      '@esbuild/linux-arm': 0.25.12
-      '@esbuild/linux-arm64': 0.25.12
-      '@esbuild/linux-ia32': 0.25.12
-      '@esbuild/linux-loong64': 0.25.12
-      '@esbuild/linux-mips64el': 0.25.12
-      '@esbuild/linux-ppc64': 0.25.12
-      '@esbuild/linux-riscv64': 0.25.12
-      '@esbuild/linux-s390x': 0.25.12
-      '@esbuild/linux-x64': 0.25.12
-      '@esbuild/netbsd-arm64': 0.25.12
-      '@esbuild/netbsd-x64': 0.25.12
-      '@esbuild/openbsd-arm64': 0.25.12
-      '@esbuild/openbsd-x64': 0.25.12
-      '@esbuild/openharmony-arm64': 0.25.12
-      '@esbuild/sunos-x64': 0.25.12
-      '@esbuild/win32-arm64': 0.25.12
-      '@esbuild/win32-ia32': 0.25.12
-      '@esbuild/win32-x64': 0.25.12
-
-  esbuild@0.27.7:
-    optionalDependencies:
-      '@esbuild/aix-ppc64': 0.27.7
-      '@esbuild/android-arm': 0.27.7
-      '@esbuild/android-arm64': 0.27.7
-      '@esbuild/android-x64': 0.27.7
-      '@esbuild/darwin-arm64': 0.27.7
-      '@esbuild/darwin-x64': 0.27.7
-      '@esbuild/freebsd-arm64': 0.27.7
-      '@esbuild/freebsd-x64': 0.27.7
-      '@esbuild/linux-arm': 0.27.7
-      '@esbuild/linux-arm64': 0.27.7
-      '@esbuild/linux-ia32': 0.27.7
-      '@esbuild/linux-loong64': 0.27.7
-      '@esbuild/linux-mips64el': 0.27.7
-      '@esbuild/linux-ppc64': 0.27.7
-      '@esbuild/linux-riscv64': 0.27.7
-      '@esbuild/linux-s390x': 0.27.7
-      '@esbuild/linux-x64': 0.27.7
-      '@esbuild/netbsd-arm64': 0.27.7
-      '@esbuild/netbsd-x64': 0.27.7
-      '@esbuild/openbsd-arm64': 0.27.7
-      '@esbuild/openbsd-x64': 0.27.7
-      '@esbuild/openharmony-arm64': 0.27.7
-      '@esbuild/sunos-x64': 0.27.7
-      '@esbuild/win32-arm64': 0.27.7
-      '@esbuild/win32-ia32': 0.27.7
-      '@esbuild/win32-x64': 0.27.7
+      '@esbuild/aix-ppc64': 0.28.1
+      '@esbuild/android-arm': 0.28.1
+      '@esbuild/android-arm64': 0.28.1
+      '@esbuild/android-x64': 0.28.1
+      '@esbuild/darwin-arm64': 0.28.1
+      '@esbuild/darwin-x64': 0.28.1
+      '@esbuild/freebsd-arm64': 0.28.1
+      '@esbuild/freebsd-x64': 0.28.1
+      '@esbuild/linux-arm': 0.28.1
+      '@esbuild/linux-arm64': 0.28.1
+      '@esbuild/linux-ia32': 0.28.1
+      '@esbuild/linux-loong64': 0.28.1
+      '@esbuild/linux-mips64el': 0.28.1
+      '@esbuild/linux-ppc64': 0.28.1
+      '@esbuild/linux-riscv64': 0.28.1
+      '@esbuild/linux-s390x': 0.28.1
+      '@esbuild/linux-x64': 0.28.1
+      '@esbuild/netbsd-arm64': 0.28.1
+      '@esbuild/netbsd-x64': 0.28.1
+      '@esbuild/openbsd-arm64': 0.28.1
+      '@esbuild/openbsd-x64': 0.28.1
+      '@esbuild/openharmony-arm64': 0.28.1
+      '@esbuild/sunos-x64': 0.28.1
+      '@esbuild/win32-arm64': 0.28.1
+      '@esbuild/win32-ia32': 0.28.1
+      '@esbuild/win32-x64': 0.28.1
 
   escalade@3.2.0: {}
 
@@ -15512,11 +15183,11 @@ snapshots:
     dependencies:
       flat-cache: 4.0.1
 
-  file-loader@6.2.0(webpack@5.106.2(@swc/core@1.15.33)(lightningcss@1.32.0)(postcss@8.5.14)):
+  file-loader@6.2.0(webpack@5.106.2(@swc/core@1.15.33)(esbuild@0.28.1)(postcss@8.5.14)):
     dependencies:
       loader-utils: 2.0.4
       schema-utils: 3.3.0
-      webpack: 5.106.2(@swc/core@1.15.33)(lightningcss@1.32.0)(postcss@8.5.14)
+      webpack: 5.106.2(@swc/core@1.15.33)(esbuild@0.28.1)(postcss@8.5.14)
 
   filelist@1.0.6:
     dependencies:
@@ -15571,12 +15242,12 @@ snapshots:
 
   form-data-encoder@2.1.4: {}
 
-  form-data@4.0.5:
+  form-data@4.0.6:
     dependencies:
       asynckit: 0.4.0
       combined-stream: 1.0.8
       es-set-tostringtag: 2.1.0
-      hasown: 2.0.3
+      hasown: 2.0.4
       mime-types: 2.1.35
 
   format@0.2.2: {}
@@ -15660,7 +15331,7 @@ snapshots:
       get-proto: 1.0.1
       gopd: 1.2.0
       has-symbols: 1.1.0
-      hasown: 2.0.3
+      hasown: 2.0.4
       math-intrinsics: 1.1.0
 
   get-own-enumerable-property-symbols@3.0.2: {}
@@ -15821,6 +15492,10 @@ snapshots:
   has-yarn@3.0.0: {}
 
   hasown@2.0.3:
+    dependencies:
+      function-bind: 1.1.2
+
+  hasown@2.0.4:
     dependencies:
       function-bind: 1.1.2
 
@@ -16015,7 +15690,7 @@ snapshots:
 
   html-void-elements@3.0.0: {}
 
-  html-webpack-plugin@5.6.7(@rspack/core@1.7.11)(webpack@5.106.2(@swc/core@1.15.33)(lightningcss@1.32.0)(postcss@8.5.14)):
+  html-webpack-plugin@5.6.7(@rspack/core@1.7.11)(webpack@5.106.2(@swc/core@1.15.33)(esbuild@0.28.1)(postcss@8.5.14)):
     dependencies:
       '@types/html-minifier-terser': 6.1.0
       html-minifier-terser: 6.1.0
@@ -16024,7 +15699,7 @@ snapshots:
       tapable: 2.3.3
     optionalDependencies:
       '@rspack/core': 1.7.11
-      webpack: 5.106.2(@swc/core@1.15.33)(lightningcss@1.32.0)(postcss@8.5.14)
+      webpack: 5.106.2(@swc/core@1.15.33)(esbuild@0.28.1)(postcss@8.5.14)
 
   htmlparser2@3.10.1:
     dependencies:
@@ -16487,7 +16162,7 @@ snapshots:
   launch-editor@2.13.2:
     dependencies:
       picocolors: 1.1.1
-      shell-quote: 1.8.3
+      shell-quote: 1.8.4
 
   layout-base@1.0.2: {}
 
@@ -17269,11 +16944,11 @@ snapshots:
 
   min-indent@1.0.1: {}
 
-  mini-css-extract-plugin@2.10.2(webpack@5.106.2(@swc/core@1.15.33)(lightningcss@1.32.0)(postcss@8.5.14)):
+  mini-css-extract-plugin@2.10.2(webpack@5.106.2(@swc/core@1.15.33)(esbuild@0.28.1)(postcss@8.5.14)):
     dependencies:
       schema-utils: 4.3.3
       tapable: 2.3.3
-      webpack: 5.106.2(@swc/core@1.15.33)(lightningcss@1.32.0)(postcss@8.5.14)
+      webpack: 5.106.2(@swc/core@1.15.33)(esbuild@0.28.1)(postcss@8.5.14)
 
   minimalistic-assert@1.0.1: {}
 
@@ -17332,6 +17007,8 @@ snapshots:
       thunky: 1.1.0
 
   nanoid@3.3.11: {}
+
+  nanoid@3.3.12: {}
 
   natural-compare@1.4.0: {}
 
@@ -17405,11 +17082,11 @@ snapshots:
     dependencies:
       boolbase: 1.0.0
 
-  null-loader@4.0.1(webpack@5.106.2(@swc/core@1.15.33)(lightningcss@1.32.0)(postcss@8.5.14)):
+  null-loader@4.0.1(webpack@5.106.2(@swc/core@1.15.33)(esbuild@0.28.1)(postcss@8.5.14)):
     dependencies:
       loader-utils: 2.0.4
       schema-utils: 3.3.0
-      webpack: 5.106.2(@swc/core@1.15.33)(lightningcss@1.32.0)(postcss@8.5.14)
+      webpack: 5.106.2(@swc/core@1.15.33)(esbuild@0.28.1)(postcss@8.5.14)
 
   object-assign@4.1.1: {}
 
@@ -17829,13 +17506,13 @@ snapshots:
       '@csstools/utilities': 2.0.0(postcss@8.5.14)
       postcss: 8.5.14
 
-  postcss-loader@7.3.4(postcss@8.5.14)(typescript@6.0.3)(webpack@5.106.2(@swc/core@1.15.33)(lightningcss@1.32.0)(postcss@8.5.14)):
+  postcss-loader@7.3.4(postcss@8.5.14)(typescript@6.0.3)(webpack@5.106.2(@swc/core@1.15.33)(esbuild@0.28.1)(postcss@8.5.14)):
     dependencies:
       cosmiconfig: 8.3.6(typescript@6.0.3)
       jiti: 1.21.7
       postcss: 8.5.14
       semver: 7.7.4
-      webpack: 5.106.2(@swc/core@1.15.33)(lightningcss@1.32.0)(postcss@8.5.14)
+      webpack: 5.106.2(@swc/core@1.15.33)(esbuild@0.28.1)(postcss@8.5.14)
     transitivePeerDependencies:
       - typescript
 
@@ -18133,6 +17810,12 @@ snapshots:
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
+  postcss@8.5.15:
+    dependencies:
+      nanoid: 3.3.12
+      picocolors: 1.1.1
+      source-map-js: 1.2.1
+
   postject@1.0.0-alpha.6:
     dependencies:
       commander: 9.5.0
@@ -18274,11 +17957,11 @@ snapshots:
     dependencies:
       react: 19.2.5
 
-  react-loadable-ssr-addon-v5-slorber@1.0.3(@docusaurus/react-loadable@6.0.0(react@19.2.5))(webpack@5.106.2(@swc/core@1.15.33)(lightningcss@1.32.0)(postcss@8.5.14)):
+  react-loadable-ssr-addon-v5-slorber@1.0.3(@docusaurus/react-loadable@6.0.0(react@19.2.5))(webpack@5.106.2(@swc/core@1.15.33)(esbuild@0.28.1)(postcss@8.5.14)):
     dependencies:
       '@babel/runtime': 7.29.7
       react-loadable: '@docusaurus/react-loadable@6.0.0(react@19.2.5)'
-      webpack: 5.106.2(@swc/core@1.15.33)(lightningcss@1.32.0)(postcss@8.5.14)
+      webpack: 5.106.2(@swc/core@1.15.33)(esbuild@0.28.1)(postcss@8.5.14)
 
   react-refresh@0.18.0: {}
 
@@ -18579,36 +18262,26 @@ snapshots:
 
   robust-predicates@3.0.3: {}
 
-  rollup@4.60.2:
+  rolldown@1.0.3:
     dependencies:
-      '@types/estree': 1.0.8
+      '@oxc-project/types': 0.133.0
+      '@rolldown/pluginutils': 1.0.1
     optionalDependencies:
-      '@rollup/rollup-android-arm-eabi': 4.60.2
-      '@rollup/rollup-android-arm64': 4.60.2
-      '@rollup/rollup-darwin-arm64': 4.60.2
-      '@rollup/rollup-darwin-x64': 4.60.2
-      '@rollup/rollup-freebsd-arm64': 4.60.2
-      '@rollup/rollup-freebsd-x64': 4.60.2
-      '@rollup/rollup-linux-arm-gnueabihf': 4.60.2
-      '@rollup/rollup-linux-arm-musleabihf': 4.60.2
-      '@rollup/rollup-linux-arm64-gnu': 4.60.2
-      '@rollup/rollup-linux-arm64-musl': 4.60.2
-      '@rollup/rollup-linux-loong64-gnu': 4.60.2
-      '@rollup/rollup-linux-loong64-musl': 4.60.2
-      '@rollup/rollup-linux-ppc64-gnu': 4.60.2
-      '@rollup/rollup-linux-ppc64-musl': 4.60.2
-      '@rollup/rollup-linux-riscv64-gnu': 4.60.2
-      '@rollup/rollup-linux-riscv64-musl': 4.60.2
-      '@rollup/rollup-linux-s390x-gnu': 4.60.2
-      '@rollup/rollup-linux-x64-gnu': 4.60.2
-      '@rollup/rollup-linux-x64-musl': 4.60.2
-      '@rollup/rollup-openbsd-x64': 4.60.2
-      '@rollup/rollup-openharmony-arm64': 4.60.2
-      '@rollup/rollup-win32-arm64-msvc': 4.60.2
-      '@rollup/rollup-win32-ia32-msvc': 4.60.2
-      '@rollup/rollup-win32-x64-gnu': 4.60.2
-      '@rollup/rollup-win32-x64-msvc': 4.60.2
-      fsevents: 2.3.3
+      '@rolldown/binding-android-arm64': 1.0.3
+      '@rolldown/binding-darwin-arm64': 1.0.3
+      '@rolldown/binding-darwin-x64': 1.0.3
+      '@rolldown/binding-freebsd-x64': 1.0.3
+      '@rolldown/binding-linux-arm-gnueabihf': 1.0.3
+      '@rolldown/binding-linux-arm64-gnu': 1.0.3
+      '@rolldown/binding-linux-arm64-musl': 1.0.3
+      '@rolldown/binding-linux-ppc64-gnu': 1.0.3
+      '@rolldown/binding-linux-s390x-gnu': 1.0.3
+      '@rolldown/binding-linux-x64-gnu': 1.0.3
+      '@rolldown/binding-linux-x64-musl': 1.0.3
+      '@rolldown/binding-openharmony-arm64': 1.0.3
+      '@rolldown/binding-wasm32-wasi': 1.0.3
+      '@rolldown/binding-win32-arm64-msvc': 1.0.3
+      '@rolldown/binding-win32-x64-msvc': 1.0.3
 
   roughjs@4.6.6:
     dependencies:
@@ -18779,7 +18452,7 @@ snapshots:
 
   shebang-regex@3.0.0: {}
 
-  shell-quote@1.8.3: {}
+  shell-quote@1.8.4: {}
 
   shiki@4.0.2:
     dependencies:
@@ -19056,11 +18729,11 @@ snapshots:
       picocolors: 1.1.1
       sax: 1.6.0
 
-  swc-loader@0.2.7(@swc/core@1.15.33)(webpack@5.106.2(@swc/core@1.15.33)(lightningcss@1.32.0)(postcss@8.5.14)):
+  swc-loader@0.2.7(@swc/core@1.15.33)(webpack@5.106.2(@swc/core@1.15.33)(esbuild@0.28.1)(postcss@8.5.14)):
     dependencies:
       '@swc/core': 1.15.33
       '@swc/counter': 0.1.3
-      webpack: 5.106.2(@swc/core@1.15.33)(lightningcss@1.32.0)(postcss@8.5.14)
+      webpack: 5.106.2(@swc/core@1.15.33)(esbuild@0.28.1)(postcss@8.5.14)
 
   symbol-tree@3.2.4: {}
 
@@ -19090,44 +18763,45 @@ snapshots:
 
   term-size@2.2.1: {}
 
-  terser-webpack-plugin@5.6.0(@swc/core@1.15.33)(@swc/html@1.15.33)(lightningcss@1.32.0)(postcss@8.5.14)(webpack@5.106.2(@swc/core@1.15.33)(lightningcss@1.32.0)(postcss@8.5.14)):
+  terser-webpack-plugin@5.6.0(@swc/core@1.15.33)(@swc/html@1.15.33)(esbuild@0.28.1)(lightningcss@1.32.0)(postcss@8.5.14)(webpack@5.106.2(@swc/core@1.15.33)(esbuild@0.28.1)(postcss@8.5.14)):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.31
       jest-worker: 27.5.1
       schema-utils: 4.3.3
       terser: 5.47.1
-      webpack: 5.106.2(@swc/core@1.15.33)(lightningcss@1.32.0)(postcss@8.5.14)
+      webpack: 5.106.2(@swc/core@1.15.33)(esbuild@0.28.1)(postcss@8.5.14)
     optionalDependencies:
       '@swc/core': 1.15.33
       '@swc/html': 1.15.33
+      esbuild: 0.28.1
       lightningcss: 1.32.0
       postcss: 8.5.14
 
-  terser-webpack-plugin@5.6.0(@swc/core@1.15.33)(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.14))(html-minifier-terser@7.2.0)(lightningcss@1.32.0)(postcss@8.5.14)(webpack@5.106.2(@swc/core@1.15.33)(lightningcss@1.32.0)(postcss@8.5.14)):
+  terser-webpack-plugin@5.6.0(@swc/core@1.15.33)(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.14))(esbuild@0.28.1)(html-minifier-terser@7.2.0)(postcss@8.5.14)(webpack@5.106.2(@swc/core@1.15.33)(esbuild@0.28.1)(postcss@8.5.14)):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.31
       jest-worker: 27.5.1
       schema-utils: 4.3.3
       terser: 5.47.1
-      webpack: 5.106.2(@swc/core@1.15.33)(lightningcss@1.32.0)(postcss@8.5.14)
+      webpack: 5.106.2(@swc/core@1.15.33)(esbuild@0.28.1)(postcss@8.5.14)
     optionalDependencies:
       '@swc/core': 1.15.33
       clean-css: 5.3.3
       cssnano: 6.1.2(postcss@8.5.14)
+      esbuild: 0.28.1
       html-minifier-terser: 7.2.0
-      lightningcss: 1.32.0
       postcss: 8.5.14
 
-  terser-webpack-plugin@5.6.0(@swc/core@1.15.33)(lightningcss@1.32.0)(postcss@8.5.14)(webpack@5.106.2(@swc/core@1.15.33)(lightningcss@1.32.0)(postcss@8.5.14)):
+  terser-webpack-plugin@5.6.0(@swc/core@1.15.33)(esbuild@0.28.1)(postcss@8.5.14)(webpack@5.106.2(@swc/core@1.15.33)(esbuild@0.28.1)(postcss@8.5.14)):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.31
       jest-worker: 27.5.1
       schema-utils: 4.3.3
       terser: 5.47.1
-      webpack: 5.106.2(@swc/core@1.15.33)(lightningcss@1.32.0)(postcss@8.5.14)
+      webpack: 5.106.2(@swc/core@1.15.33)(esbuild@0.28.1)(postcss@8.5.14)
     optionalDependencies:
       '@swc/core': 1.15.33
-      lightningcss: 1.32.0
+      esbuild: 0.28.1
       postcss: 8.5.14
 
   terser@5.47.1:
@@ -19158,6 +18832,11 @@ snapshots:
   tinyexec@1.1.2: {}
 
   tinyglobby@0.2.16:
+    dependencies:
+      fdir: 6.5.0(picomatch@4.0.4)
+      picomatch: 4.0.4
+
+  tinyglobby@0.2.17:
     dependencies:
       fdir: 6.5.0(picomatch@4.0.4)
       picomatch: 4.0.4
@@ -19352,14 +19031,14 @@ snapshots:
     dependencies:
       punycode: 2.3.1
 
-  url-loader@4.1.1(file-loader@6.2.0(webpack@5.106.2(@swc/core@1.15.33)(lightningcss@1.32.0)(postcss@8.5.14)))(webpack@5.106.2(@swc/core@1.15.33)(lightningcss@1.32.0)(postcss@8.5.14)):
+  url-loader@4.1.1(file-loader@6.2.0(webpack@5.106.2(@swc/core@1.15.33)(esbuild@0.28.1)(postcss@8.5.14)))(webpack@5.106.2(@swc/core@1.15.33)(esbuild@0.28.1)(postcss@8.5.14)):
     dependencies:
       loader-utils: 2.0.4
       mime-types: 2.1.35
       schema-utils: 3.3.0
-      webpack: 5.106.2(@swc/core@1.15.33)(lightningcss@1.32.0)(postcss@8.5.14)
+      webpack: 5.106.2(@swc/core@1.15.33)(esbuild@0.28.1)(postcss@8.5.14)
     optionalDependencies:
-      file-loader: 6.2.0(webpack@5.106.2(@swc/core@1.15.33)(lightningcss@1.32.0)(postcss@8.5.14))
+      file-loader: 6.2.0(webpack@5.106.2(@swc/core@1.15.33)(esbuild@0.28.1)(postcss@8.5.14))
 
   utf8-byte-length@1.0.5: {}
 
@@ -19412,26 +19091,25 @@ snapshots:
       x-is-array: 0.1.0
       x-is-string: 0.1.0
 
-  vite@7.3.2(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.47.1)(yaml@2.8.3):
+  vite@8.0.16(@types/node@25.6.0)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.47.1)(yaml@2.8.3):
     dependencies:
-      esbuild: 0.27.7
-      fdir: 6.5.0(picomatch@4.0.4)
+      lightningcss: 1.32.0
       picomatch: 4.0.4
-      postcss: 8.5.14
-      rollup: 4.60.2
-      tinyglobby: 0.2.16
+      postcss: 8.5.15
+      rolldown: 1.0.3
+      tinyglobby: 0.2.17
     optionalDependencies:
       '@types/node': 25.6.0
+      esbuild: 0.28.1
       fsevents: 2.3.3
       jiti: 2.6.1
-      lightningcss: 1.32.0
       terser: 5.47.1
       yaml: 2.8.3
 
-  vitest@4.1.5(@types/node@25.6.0)(@vitest/coverage-v8@4.1.5)(jsdom@29.1.1)(vite@7.3.2(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.47.1)(yaml@2.8.3)):
+  vitest@4.1.5(@types/node@25.6.0)(@vitest/coverage-v8@4.1.5)(jsdom@29.1.1)(vite@8.0.16(@types/node@25.6.0)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.47.1)(yaml@2.8.3)):
     dependencies:
       '@vitest/expect': 4.1.5
-      '@vitest/mocker': 4.1.5(vite@7.3.2(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.47.1)(yaml@2.8.3))
+      '@vitest/mocker': 4.1.5(vite@8.0.16(@types/node@25.6.0)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.47.1)(yaml@2.8.3))
       '@vitest/pretty-format': 4.1.5
       '@vitest/runner': 4.1.5
       '@vitest/snapshot': 4.1.5
@@ -19448,7 +19126,7 @@ snapshots:
       tinyexec: 1.1.2
       tinyglobby: 0.2.16
       tinyrainbow: 3.1.0
-      vite: 7.3.2(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.47.1)(yaml@2.8.3)
+      vite: 8.0.16(@types/node@25.6.0)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.47.1)(yaml@2.8.3)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 25.6.0
@@ -19506,12 +19184,12 @@ snapshots:
       opener: 1.5.2
       picocolors: 1.1.1
       sirv: 2.0.4
-      ws: 7.5.10
+      ws: 8.21.0
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
 
-  webpack-dev-middleware@7.4.5(tslib@2.8.1)(webpack@5.106.2(@swc/core@1.15.33)(lightningcss@1.32.0)(postcss@8.5.14)):
+  webpack-dev-middleware@7.4.5(tslib@2.8.1)(webpack@5.106.2(@swc/core@1.15.33)(esbuild@0.28.1)(postcss@8.5.14)):
     dependencies:
       colorette: 2.0.20
       memfs: 4.57.2(tslib@2.8.1)
@@ -19520,11 +19198,11 @@ snapshots:
       range-parser: 1.2.1
       schema-utils: 4.3.3
     optionalDependencies:
-      webpack: 5.106.2(@swc/core@1.15.33)(lightningcss@1.32.0)(postcss@8.5.14)
+      webpack: 5.106.2(@swc/core@1.15.33)(esbuild@0.28.1)(postcss@8.5.14)
     transitivePeerDependencies:
       - tslib
 
-  webpack-dev-server@5.2.3(tslib@2.8.1)(webpack@5.106.2(@swc/core@1.15.33)(lightningcss@1.32.0)(postcss@8.5.14)):
+  webpack-dev-server@5.2.3(tslib@2.8.1)(webpack@5.106.2(@swc/core@1.15.33)(esbuild@0.28.1)(postcss@8.5.14)):
     dependencies:
       '@types/bonjour': 3.5.13
       '@types/connect-history-api-fallback': 1.5.4
@@ -19552,10 +19230,10 @@ snapshots:
       serve-index: 1.9.2
       sockjs: 0.3.24
       spdy: 4.0.2
-      webpack-dev-middleware: 7.4.5(tslib@2.8.1)(webpack@5.106.2(@swc/core@1.15.33)(lightningcss@1.32.0)(postcss@8.5.14))
-      ws: 8.20.0
+      webpack-dev-middleware: 7.4.5(tslib@2.8.1)(webpack@5.106.2(@swc/core@1.15.33)(esbuild@0.28.1)(postcss@8.5.14))
+      ws: 8.21.0
     optionalDependencies:
-      webpack: 5.106.2(@swc/core@1.15.33)(lightningcss@1.32.0)(postcss@8.5.14)
+      webpack: 5.106.2(@swc/core@1.15.33)(esbuild@0.28.1)(postcss@8.5.14)
     transitivePeerDependencies:
       - bufferutil
       - debug
@@ -19577,7 +19255,7 @@ snapshots:
 
   webpack-sources@3.4.1: {}
 
-  webpack@5.106.2(@swc/core@1.15.33)(@swc/html@1.15.33)(lightningcss@1.32.0)(postcss@8.5.14):
+  webpack@5.106.2(@swc/core@1.15.33)(@swc/html@1.15.33)(esbuild@0.28.1)(lightningcss@1.32.0)(postcss@8.5.14):
     dependencies:
       '@types/eslint-scope': 3.7.7
       '@types/estree': 1.0.8
@@ -19600,7 +19278,7 @@ snapshots:
       neo-async: 2.6.2
       schema-utils: 4.3.3
       tapable: 2.3.3
-      terser-webpack-plugin: 5.6.0(@swc/core@1.15.33)(@swc/html@1.15.33)(lightningcss@1.32.0)(postcss@8.5.14)(webpack@5.106.2(@swc/core@1.15.33)(lightningcss@1.32.0)(postcss@8.5.14))
+      terser-webpack-plugin: 5.6.0(@swc/core@1.15.33)(@swc/html@1.15.33)(esbuild@0.28.1)(lightningcss@1.32.0)(postcss@8.5.14)(webpack@5.106.2(@swc/core@1.15.33)(esbuild@0.28.1)(postcss@8.5.14))
       watchpack: 2.5.1
       webpack-sources: 3.4.1
     transitivePeerDependencies:
@@ -19617,7 +19295,7 @@ snapshots:
       - postcss
       - uglify-js
 
-  webpack@5.106.2(@swc/core@1.15.33)(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.14))(html-minifier-terser@7.2.0)(lightningcss@1.32.0)(postcss@8.5.14):
+  webpack@5.106.2(@swc/core@1.15.33)(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.14))(esbuild@0.28.1)(html-minifier-terser@7.2.0)(postcss@8.5.14):
     dependencies:
       '@types/eslint-scope': 3.7.7
       '@types/estree': 1.0.8
@@ -19640,7 +19318,7 @@ snapshots:
       neo-async: 2.6.2
       schema-utils: 4.3.3
       tapable: 2.3.3
-      terser-webpack-plugin: 5.6.0(@swc/core@1.15.33)(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.14))(html-minifier-terser@7.2.0)(lightningcss@1.32.0)(postcss@8.5.14)(webpack@5.106.2(@swc/core@1.15.33)(lightningcss@1.32.0)(postcss@8.5.14))
+      terser-webpack-plugin: 5.6.0(@swc/core@1.15.33)(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.14))(esbuild@0.28.1)(html-minifier-terser@7.2.0)(postcss@8.5.14)(webpack@5.106.2(@swc/core@1.15.33)(esbuild@0.28.1)(postcss@8.5.14))
       watchpack: 2.5.1
       webpack-sources: 3.4.1
     transitivePeerDependencies:
@@ -19657,7 +19335,7 @@ snapshots:
       - postcss
       - uglify-js
 
-  webpack@5.106.2(@swc/core@1.15.33)(lightningcss@1.32.0)(postcss@8.5.14):
+  webpack@5.106.2(@swc/core@1.15.33)(esbuild@0.28.1)(postcss@8.5.14):
     dependencies:
       '@types/eslint-scope': 3.7.7
       '@types/estree': 1.0.8
@@ -19680,7 +19358,7 @@ snapshots:
       neo-async: 2.6.2
       schema-utils: 4.3.3
       tapable: 2.3.3
-      terser-webpack-plugin: 5.6.0(@swc/core@1.15.33)(lightningcss@1.32.0)(postcss@8.5.14)(webpack@5.106.2(@swc/core@1.15.33)(lightningcss@1.32.0)(postcss@8.5.14))
+      terser-webpack-plugin: 5.6.0(@swc/core@1.15.33)(esbuild@0.28.1)(postcss@8.5.14)(webpack@5.106.2(@swc/core@1.15.33)(esbuild@0.28.1)(postcss@8.5.14))
       watchpack: 2.5.1
       webpack-sources: 3.4.1
     transitivePeerDependencies:
@@ -19697,7 +19375,7 @@ snapshots:
       - postcss
       - uglify-js
 
-  webpackbar@7.0.0(@rspack/core@1.7.11)(webpack@5.106.2(@swc/core@1.15.33)(lightningcss@1.32.0)(postcss@8.5.14)):
+  webpackbar@7.0.0(@rspack/core@1.7.11)(webpack@5.106.2(@swc/core@1.15.33)(esbuild@0.28.1)(postcss@8.5.14)):
     dependencies:
       ansis: 3.17.0
       consola: 3.4.2
@@ -19705,7 +19383,7 @@ snapshots:
       std-env: 3.10.0
     optionalDependencies:
       '@rspack/core': 1.7.11
-      webpack: 5.106.2(@swc/core@1.15.33)(lightningcss@1.32.0)(postcss@8.5.14)
+      webpack: 5.106.2(@swc/core@1.15.33)(esbuild@0.28.1)(postcss@8.5.14)
 
   websocket-driver@0.7.4:
     dependencies:
@@ -19782,9 +19460,7 @@ snapshots:
       signal-exit: 3.0.7
       typedarray-to-buffer: 3.1.5
 
-  ws@7.5.10: {}
-
-  ws@8.20.0: {}
+  ws@8.21.0: {}
 
   wsl-utils@0.1.0:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -38,6 +38,9 @@ importers:
       '@tailwindcss/vite':
         specifier: ^4.2.4
         version: 4.2.4(vite@7.3.2(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.47.1)(yaml@2.8.3))
+      '@types/chrome':
+        specifier: ^0.1.43
+        version: 0.1.43
       '@types/node':
         specifier: ^25.6.0
         version: 25.6.0
@@ -96,6 +99,12 @@ importers:
         specifier: ^7.3.2
         version: 7.3.2(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.47.1)(yaml@2.8.3)
 
+  apps/extension:
+    dependencies:
+      '@package/platform-adapters':
+        specifier: workspace:*
+        version: link:../../packages/platform-adapters
+
   apps/main-processor:
     dependencies:
       '@package/shared-constants':
@@ -144,6 +153,9 @@ importers:
 
   apps/renderer:
     dependencies:
+      '@package/platform-adapters':
+        specifier: workspace:*
+        version: link:../../packages/platform-adapters
       '@package/shared-constants':
         specifier: workspace:*
         version: link:../../packages/shared-constants
@@ -245,6 +257,31 @@ importers:
       typescript:
         specifier: ~6.0.2
         version: 6.0.3
+
+  packages/platform-adapters:
+    dependencies:
+      '@package/shared-types':
+        specifier: workspace:*
+        version: link:../shared-types
+    devDependencies:
+      '@testing-library/jest-dom':
+        specifier: ^6.9.1
+        version: 6.9.1
+      '@testing-library/react':
+        specifier: ^16.3.2
+        version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@testing-library/user-event':
+        specifier: ^14.6.1
+        version: 14.6.1(@testing-library/dom@10.4.1)
+      '@vitest/coverage-v8':
+        specifier: ^4.1.5
+        version: 4.1.5(vitest@4.1.5)
+      jsdom:
+        specifier: ^29.1.1
+        version: 29.1.1
+      vitest:
+        specifier: ^4.1.5
+        version: 4.1.5(@types/node@25.6.0)(@vitest/coverage-v8@4.1.5)(jsdom@29.1.1)(vite@7.3.2(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.47.1)(yaml@2.8.3))
 
   packages/shared-constants: {}
 
@@ -3241,6 +3278,9 @@ packages:
   '@types/chai@5.2.3':
     resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
 
+  '@types/chrome@0.1.43':
+    resolution: {integrity: sha512-ukH/HhmR6ht+UTX3PLUWJxgJ/RQcK2Foj4lBzsF24SIWsXgqhGuXqjd8FFuwioPP7d/JUKLM4g8GZxw3F4HTcA==}
+
   '@types/connect-history-api-fallback@1.5.4':
     resolution: {integrity: sha512-n6Cr2xS1h4uAulPRdlw6Jl6s1oG8KrVilPN2yUITEs+K48EzMJJ3W1xy8K5eWuFvjp3R74AOIGSmp2UfBJ8HFw==}
 
@@ -3367,6 +3407,12 @@ packages:
   '@types/express@4.17.25':
     resolution: {integrity: sha512-dVd04UKsfpINUnK0yBoYHDF3xu7xVH4BuDotC/xGuycx4CgbP48X/KF/586bcObxT0HENHXEU8Nqtu6NR+eKhw==}
 
+  '@types/filesystem@0.0.36':
+    resolution: {integrity: sha512-vPDXOZuannb9FZdxgHnqSwAG/jvdGM8Wq+6N4D/d80z+D4HWH+bItqsZaVRQykAn6WEVeEkLm2oQigyHtgb0RA==}
+
+  '@types/filewriter@0.0.33':
+    resolution: {integrity: sha512-xFU8ZXTw4gd358lb2jw25nxY9QAgqn2+bKKjKOYfNCzN4DKCFetK7sPtrlpg66Ywe3vWY9FNxprZawAh9wfJ3g==}
+
   '@types/fs-extra@9.0.13':
     resolution: {integrity: sha512-nEnwB++1u5lVDM2UI4c1+5R+FYaKfaAzS4OococimjVm3nQw3TuzH5UNsocrcTBbhnerblyHj4A49qXbIiZdpA==}
 
@@ -3375,6 +3421,9 @@ packages:
 
   '@types/gtag.js@0.0.20':
     resolution: {integrity: sha512-wwAbk3SA2QeU67unN7zPxjEHmPmlXwZXZvQEpbEUQuMCRGgKyE1m6XDuTUA9b6pCGb/GqJmdfMOY5LuDjJSbbg==}
+
+  '@types/har-format@1.2.16':
+    resolution: {integrity: sha512-fluxdy7ryD3MV6h8pTfTYpy/xQzCFC7m89nOH9y94cNqJ1mDIDPut7MnRHI3F6qRmh/cT2fUjG1MLdCNb4hE9A==}
 
   '@types/hast@3.0.4':
     resolution: {integrity: sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==}
@@ -12969,7 +13018,7 @@ snapshots:
 
   '@testing-library/react@16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
     dependencies:
-      '@babel/runtime': 7.29.2
+      '@babel/runtime': 7.29.7
       '@testing-library/dom': 10.4.1
       react: 19.2.5
       react-dom: 19.2.5(react@19.2.5)
@@ -13029,6 +13078,11 @@ snapshots:
     dependencies:
       '@types/deep-eql': 4.0.2
       assertion-error: 2.0.1
+
+  '@types/chrome@0.1.43':
+    dependencies:
+      '@types/filesystem': 0.0.36
+      '@types/har-format': 1.2.16
 
   '@types/connect-history-api-fallback@1.5.4':
     dependencies:
@@ -13194,6 +13248,12 @@ snapshots:
       '@types/qs': 6.15.1
       '@types/serve-static': 1.15.10
 
+  '@types/filesystem@0.0.36':
+    dependencies:
+      '@types/filewriter': 0.0.33
+
+  '@types/filewriter@0.0.33': {}
+
   '@types/fs-extra@9.0.13':
     dependencies:
       '@types/node': 25.6.0
@@ -13201,6 +13261,8 @@ snapshots:
   '@types/geojson@7946.0.16': {}
 
   '@types/gtag.js@0.0.20': {}
+
+  '@types/har-format@1.2.16': {}
 
   '@types/hast@3.0.4':
     dependencies:


### PR DESCRIPTION
## Description

This PR adds chrome extension feature by creating platform adapters for both chrome and electron

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor (no functional change)
- [ ] Documentation update
- [ ] Style / UI change
- [ ] Build / CI change

## Related Issue

Closes #99, #100

## Changes Made

- Created platform adapters package and defined adapters for both electron and chrome.
- Created extension files.
- Modified renderer to use adapter instead of direct electron api

## Checklist

- [x] My code follows the project's coding guidelines
- [x] I have tested my changes locally
- [x] I have used [conventional commit](https://www.conventionalcommits.org/) messages
- [ ] I have updated documentation if needed
- [x] My changes do not introduce new warnings or errors


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Electron main/preload
- Introduced a shared **platform adapter layer** so the renderer no longer calls Electron preload (`window.api`) directly.
- Added **`ElectronAdapter`** in `@package/platform-adapters`, delegating core operations to the Electron preload bridge (and throwing if the bridge API is unavailable).
- Marked Electron messaging (`sendMessage`) as unsupported in `ElectronAdapter` (adapter-helper provides a consistent “not supported” error helper).

## Renderer UI
- Added **`PlatformInitializer`** to detect runtime (Electron vs Chrome extension) and initialize the proper adapter.
- Added **`PlatformProvider`** + **`usePlatformAPI()`** to supply a typed `PlatformAdapter` to the renderer.
- Refactored platform-dependent hooks/components to use `usePlatformAPI()` with method presence guards:
  - `useFile`, `useFileActions`, `useFolderSearch`, `useMenuEvents`, `useOpenFilePath`, `useSettings`, `useWatcher`, `useExport`, `useDragDrop`
- Updated `App.tsx`, `UpdateBanner.tsx`, and the drag/drop helper so app version and update/export/file operations come from the adapter instead of `window.api`.
- Updated renderer entrypoint (`main.tsx`) to wrap the app with `PlatformInitializer` inside `ErrorBoundary`.

## Markdown rendering
- Markdown-to-HTML rendering logic remains in the renderer, but file loading now flows through the adapter (e.g., `useFile` reads/sanitizes and extracts TOC using adapter-provided file content and recent-file updates).
- Chrome extension **viewer** reuses the renderer main bundle (`viewer.ts` imports `../../../renderer/src/main`) to keep markdown rendering consistent across platforms.

## Shared packages
- Added new **`@package/platform-adapters`** package with unified interfaces and constants:
  - Core types: `PlatformAdapter`, `PlatformMessage`, `StorageAdapter`, `PlatformKind`
  - Constants: `PLATFORM_KIND`, `STORAGE_KEYS`, `CHROME_MESSAGE_TYPES`, `DEFAULT_APP_VERSION`
  - Helpers: `isElectronRuntime()`, `isChromeExtensionRuntime()`, `getElectronApi()`, `getChromeApi()`, `createUnsupportedPlatformMethod()`, `toErrorMessage()`
- Implemented **`ChromeAdapter`** with Chrome-extension-specific behaviors:
  - File reads: in-memory cache preferred; fallback to `chrome.storage.local` and then extension messaging.
  - File dialog/folder dialog: supports both non-DOM and DOM contexts; persists selected file content to storage with quota-error handling (so caching/persistence failures don’t block file operations).
  - Settings/version/update: settings merge/persist; `getAppVersion()` reads dynamically from `chrome.runtime.getManifest().version` (fallback included).
  - Recent files, search, listener wiring/removal, and export/update flows via typed runtime messaging.
- Added an explicit Chrome vs Electron adapter boundary in renderer through the platform initializer and context.

## Chrome extension (packaging + extension UI)
- Added **Manifest V3** extension scaffold:
  - `apps/extension/manifest.json` (action popup, background service worker, storage permission, icons)
  - `apps/extension/src/background.ts`: validates and routes UI messages, opens `viewer.html` on action click, returns typed error responses on invalid/unsupported messages.
  - `apps/extension/viewer.html` + `apps/extension/src/viewer/viewer.ts` (reuses renderer main bundle).
  - `apps/extension/popup.html` + `apps/extension/src/popup/popup.ts` and popup styling.
- Added extension messaging types and guards:
  - `apps/extension/src/types.ts`
  - `apps/extension/src/utils/helpers/message-handler.ts` (`isExtensionMessage`, `handleExtensionMessage`)
- Added Chrome extension build wiring:
  - `apps/extension/vite.config.ts`: builds `popup.html`, `viewer.html`, and `background.js`; copies `manifest.json` and icons into the extension output; hashes assets; handles missing icons gracefully.
  - `apps/extension/package.json` + `tsconfig.json` for a dedicated extension workspace package.
- Extended monorepo packaging:
  - `apps/renderer/package.json` now depends on `@package/platform-adapters`.
  - Root `.gitignore` updated to ignore nested `node_modules/` via `**/node_modules/`.

## Tests
- Added comprehensive platform adapter test coverage:
  - `packages/platform-adapters/__tests__/chrome-adapter.test.ts`
  - `packages/platform-adapters/__tests__/electron-adapter.test.ts`
  - `packages/platform-adapters/__tests__/helper.test.ts`
  - `packages/platform-adapters/__tests__/test-utils.ts` (Chrome/Electron API mocks)
- Updated renderer tests/utilities:
  - Added renderer test utilities `apps/renderer/__tests__/test-utils.tsx` (`createMockPlatform`, `createPlatformWrapper`)
  - Updated `useSettings` tests to use the new platform wrapper and async `waitFor` initialization.

## Tooling/CI
- Added Vitest configuration for the adapters package:
  - `packages/platform-adapters/vitest.config.ts` (jsdom, setup file, coverage exclusions, path alias)
  - `packages/platform-adapters/setup.ts` (jest-dom + mock/global cleanup)
- Added TypeScript configs for the new packages/apps:
  - `packages/platform-adapters/tsconfig.json`
  - `apps/extension/tsconfig.json`
- Root dependency stability:
  - Updated `package.json` `pnpm.overrides` with additional min-version constraints.

Breaking changes: None
<!-- end of auto-generated comment: release notes by coderabbit.ai -->