### PR TITLE
Feature/mind map generation

### DIFF
--- a/apps/renderer/__tests__/components/MarkmapViewer.test.tsx
+++ b/apps/renderer/__tests__/components/MarkmapViewer.test.tsx
@@ -1,33 +1,52 @@
-import { render } from '@testing-library/react';
-import { describe, it, expect, vi } from 'vitest';
+import { render, waitFor } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { MarkmapViewer } from '../../src/components/MarkmapViewer';
 
 // mocked the dynamic imports of markmap libraries
+const mockTransform = vi.fn().mockReturnValue({ root: {} });
+const mockSetData = vi.fn();
+const mockFit = vi.fn();
+const mockCreate = vi.fn().mockReturnValue({
+  setData: mockSetData,
+  fit: mockFit,
+  destroy: vi.fn(),
+});
+
 vi.mock('markmap-lib', () => ({
-  Transformer: vi.fn().mockImplementation(() => ({
-    transform: vi.fn().mockReturnValue({ root: {} }),
-  })),
+  Transformer: vi.fn().mockImplementation(function() {
+    return {
+      transform: mockTransform,
+    };
+  }),
 }));
 
 vi.mock('markmap-view', () => ({
   Markmap: {
-    create: vi.fn().mockReturnValue({
-      setData: vi.fn(),
-      fit: vi.fn(),
-    }),
+    create: mockCreate,
   },
 }));
 
-describe('Markmap viwer component tests',()=>{
-    it('should render an SVG container for the markmap',()=>{
-        const {container}=render(<MarkmapViewer markdown="# Hello"/>);
-        const svgElement=container.querySelector('svg');
-        expect(svgElement).toBeInTheDocument();
+describe('Markmap viwer component tests', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+  it('should render an SVG container for the markmap', async () => {
+    const {container}=render(<MarkmapViewer markdown="# Hello"/>);
+    const svgElement=container.querySelector('svg');
+    expect(svgElement).toBeInTheDocument();
+    await waitFor(() => {
+      expect(mockTransform).toHaveBeenCalledWith('# Hello');
+      expect(mockCreate).toHaveBeenCalled();
+      expect(mockSetData).toHaveBeenCalled();
+      expect(mockFit).toHaveBeenCalled();
     });
-
-    it('should not crash when markdown is undefined',()=>{
-        const {container} =render(<MarkmapViewer markdown={undefined}/>);
-        const svgElement=container.querySelector('svg');
-        expect(svgElement).toBeInTheDocument();
-    })
-})
+  });
+  
+  it('should not crash when markdown is undefined', async () => {
+    const { container } = render(<MarkmapViewer markdown={undefined} />);
+    expect(container).toHaveTextContent('No content to display in Mind Map');
+    await new Promise((r) => setTimeout(r, 0));
+    expect(mockTransform).not.toHaveBeenCalled();
+    expect(mockCreate).not.toHaveBeenCalled();
+  });
+});

--- a/apps/renderer/__tests__/components/MarkmapViewer.test.tsx
+++ b/apps/renderer/__tests__/components/MarkmapViewer.test.tsx
@@ -1,0 +1,33 @@
+import { render } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import { MarkmapViewer } from '../../src/components/MarkmapViewer';
+
+// mocked the dynamic imports of markmap libraries
+vi.mock('markmap-lib', () => ({
+  Transformer: vi.fn().mockImplementation(() => ({
+    transform: vi.fn().mockReturnValue({ root: {} }),
+  })),
+}));
+
+vi.mock('markmap-view', () => ({
+  Markmap: {
+    create: vi.fn().mockReturnValue({
+      setData: vi.fn(),
+      fit: vi.fn(),
+    }),
+  },
+}));
+
+describe('Markmap viwer component tests',()=>{
+    it('should render an SVG container for the markmap',()=>{
+        const {container}=render(<MarkmapViewer markdown="# Hello"/>);
+        const svgElement=container.querySelector('svg');
+        expect(svgElement).toBeInTheDocument();
+    });
+
+    it('should not crash when markdown is undefined',()=>{
+        const {container} =render(<MarkmapViewer markdown={undefined}/>);
+        const svgElement=container.querySelector('svg');
+        expect(svgElement).toBeInTheDocument();
+    })
+})

--- a/apps/renderer/__tests__/hooks/useViewMode.test.ts
+++ b/apps/renderer/__tests__/hooks/useViewMode.test.ts
@@ -21,7 +21,7 @@ describe('use view mode hook test', () => {
     expect(result.current.viewMode).toBe('rendered');
   });
 
-  it('should toggle between mindmap and redered content', () => {
+  it('should toggle between mindmap and rendered content', () => {
     const { result } = renderHook(() => useViewMode());
     act(() => {
       result.current.toggleMindMap();

--- a/apps/renderer/__tests__/hooks/useViewMode.test.ts
+++ b/apps/renderer/__tests__/hooks/useViewMode.test.ts
@@ -1,0 +1,36 @@
+import { renderHook, act } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import { useViewMode } from '../../src/hooks/useViewMode';
+
+describe('use view mode hook test', () => {
+  it('should initialize with rendered mode by default', () => {
+    const { result } = renderHook(() => useViewMode());
+    expect(result.current.viewMode).toBe('rendered');
+  });
+
+  it('should toggle between raw and rendered', () => {
+    const { result } = renderHook(() => useViewMode());
+    act(() => {
+      result.current.toggleRawText();
+    });
+    expect(result.current.viewMode).toBe('raw');
+
+    act(() => {
+      result.current.toggleRawText();
+    });
+    expect(result.current.viewMode).toBe('rendered');
+  });
+
+  it('should toggle between mindmap and redered content', () => {
+    const { result } = renderHook(() => useViewMode());
+    act(() => {
+      result.current.toggleMindMap();
+    });
+    expect(result.current.viewMode).toBe('mindmap');
+
+    act(() => {
+      result.current.toggleMindMap();
+    });
+    expect(result.current.viewMode).toBe('rendered');
+  });
+});

--- a/apps/renderer/package.json
+++ b/apps/renderer/package.json
@@ -16,13 +16,15 @@
   "license": "ISC",
   "packageManager": "pnpm@10.33.0",
   "dependencies": {
+    "@package/platform-adapters": "workspace:*",
     "@package/shared-constants": "workspace:*",
     "@package/shared-types": "workspace:*",
-    "@package/platform-adapters": "workspace:*",
     "dompurify": "^3.4.0",
     "katex": "^0.16.45",
     "marked": "^18.0.0",
     "marked-highlight": "^2.2.4",
+    "markmap-lib": "^0.18.12",
+    "markmap-view": "^0.18.12",
     "mermaid": "^11.14.0",
     "shiki": "^4.0.2"
   },

--- a/apps/renderer/src/App.tsx
+++ b/apps/renderer/src/App.tsx
@@ -38,6 +38,8 @@ import { RawTextViewer } from './components/RawTextViewer';
 import { MarkmapViewer } from './components/MarkmapViewer';
 import { MARKDOWN_TOGGLE } from './utils/constants/markdown-constants';
 
+const arrow = () => {};
+
 export default function App() {
   const api = usePlatformAPI();
   const {  error, isLoading, openFile, toc,recentFiles,loadFile } =useFile();
@@ -94,7 +96,7 @@ export default function App() {
   useMenuEvents({
   onOpenFile: openFileDialog,
   onOpenFolder: openFolder,
-  onSearchDocument: viewMode === MARKDOWN_TOGGLE.MINDMAP ? () => {} : openSearch,
+  onSearchDocument: viewMode === MARKDOWN_TOGGLE.MINDMAP ? arrow : openSearch,
   onSearchFolder: openFolderSearch,
   onToggleToc: toggleSidebar,
   onToggleBrowser: toggleFileBrowser,
@@ -118,7 +120,7 @@ useShortcuts({
   onOpenFolder: openFolder,
   onToggleFocusMode: toggleFocusMode,
   onToggleTheme: toggleTheme,
-  onOpenSearch: viewMode === MARKDOWN_TOGGLE.MINDMAP ? () => {} : openSearch,
+  onOpenSearch: viewMode === MARKDOWN_TOGGLE.MINDMAP ? arrow : openSearch,
   onOpenFolderSearch: openFolderSearch,
   onCloseSearch: closeSearch,
   onZoomIn: increaseFontSize,
@@ -233,7 +235,7 @@ useShortcuts({
                 isExtension={api.kind === 'chrome'}
                 onOpenFile={openFileDialog}
                 onOpenSettings={() => setSettingsOpen(true)}
-                onOpenSearch={viewMode===MARKDOWN_TOGGLE.MINDMAP?()=>{}:openSearch}
+                onOpenSearch={viewMode === MARKDOWN_TOGGLE.MINDMAP ? arrow : openSearch}
                 updateVersion={updateVersion}
                 onDownloadUpdate={() => api.downloadUpdate?.()}
                 onExportHtml={exportHtml}

--- a/apps/renderer/src/App.tsx
+++ b/apps/renderer/src/App.tsx
@@ -35,6 +35,8 @@ import { usePlatformAPI } from './hooks/usePlatform';
 import { ReaderStats } from './components/ReaderStats';
 import { useViewMode } from './hooks/useViewMode';
 import { RawTextViewer } from './components/RawTextViewer';
+import { MarkmapViewer } from './components/MarkmapViewer';
+import { MARKDOWN_TOGGLE } from './utils/constants/markdown-constants';
 
 export default function App() {
   const api = usePlatformAPI();
@@ -59,7 +61,7 @@ export default function App() {
   const [settingsOpen, setSettingsOpen] = useState(false);
   const [appVersion, setAppVersion] = useState('');
   const [updateVersion, setUpdateVersion] = useState<string | null>(null);
-  const { viewMode, toggleRawText } = useViewMode();
+  const { viewMode, toggleRawText, toggleMindMap } = useViewMode();
 
   useEffect(()=>{
     if(!api.getAppVersion) return;
@@ -239,6 +241,7 @@ useShortcuts({
                 onExportDocx={exportDocx}
                 viewMode={viewMode}
                 onToggleRawText={toggleRawText}
+                onToggleMindMap={toggleMindMap}
               />
             )}
             <main 
@@ -246,8 +249,10 @@ useShortcuts({
             className="flex-1 overflow-y-auto" 
             onScroll={scroll}
             >
-              {viewMode === 'raw' ? (
+              {viewMode === MARKDOWN_TOGGLE.RAW ? (
                 <RawTextViewer markdown={activeTab.markdown} />
+              ) : viewMode === MARKDOWN_TOGGLE.MINDMAP ? (
+                <MarkmapViewer markdown={activeTab.markdown} />
               ) : (
                 <Reader html={activeTab.html} getHiglightedHtml={getHiglightedHtml} />
               )}

--- a/apps/renderer/src/App.tsx
+++ b/apps/renderer/src/App.tsx
@@ -94,7 +94,7 @@ export default function App() {
   useMenuEvents({
   onOpenFile: openFileDialog,
   onOpenFolder: openFolder,
-  onSearchDocument: openSearch,
+  onSearchDocument: viewMode === MARKDOWN_TOGGLE.MINDMAP ? () => {} : openSearch,
   onSearchFolder: openFolderSearch,
   onToggleToc: toggleSidebar,
   onToggleBrowser: toggleFileBrowser,
@@ -118,7 +118,7 @@ useShortcuts({
   onOpenFolder: openFolder,
   onToggleFocusMode: toggleFocusMode,
   onToggleTheme: toggleTheme,
-  onOpenSearch: openSearch,
+  onOpenSearch: viewMode === MARKDOWN_TOGGLE.MINDMAP ? () => {} : openSearch,
   onOpenFolderSearch: openFolderSearch,
   onCloseSearch: closeSearch,
   onZoomIn: increaseFontSize,
@@ -137,7 +137,7 @@ useShortcuts({
           <DragDrop/>
         )}
         {isLoading && <Loading />}
-        {isSearchOpen && (
+        {isSearchOpen && viewMode!==MARKDOWN_TOGGLE.MINDMAP && (
           <SearchBar
             query={query}
             matchCount={matchCount}
@@ -233,7 +233,7 @@ useShortcuts({
                 isExtension={api.kind === 'chrome'}
                 onOpenFile={openFileDialog}
                 onOpenSettings={() => setSettingsOpen(true)}
-                onOpenSearch={openSearch}
+                onOpenSearch={viewMode===MARKDOWN_TOGGLE.MINDMAP?()=>{}:openSearch}
                 updateVersion={updateVersion}
                 onDownloadUpdate={() => api.downloadUpdate?.()}
                 onExportHtml={exportHtml}

--- a/apps/renderer/src/components/MarkmapViewer.tsx
+++ b/apps/renderer/src/components/MarkmapViewer.tsx
@@ -1,23 +1,38 @@
-import { useEffect, useRef } from "react";
+import { useEffect, useRef, useState } from "react";
+import type { Markmap } from 'markmap-view';
 import { MarkmapViewerProps } from "../types/component-types";
 
 // It converts the markdown content to a map using markmap library dynamically
 export function MarkmapViewer({ markdown }: MarkmapViewerProps) {
   const svgRef = useRef<SVGSVGElement>(null);
-  const markmapRef = useRef<any>(null);
+  const markmapRef = useRef<Markmap | null>(null);
+  const [hasError, setHasError] = useState(false);
 
   useEffect(() => {
-    const svgElement = svgRef.current;
-    if (!svgElement) return;
+    return () => {
+      if (markmapRef.current) {
+        markmapRef.current.destroy();
+        markmapRef.current = null;
+      }
+    };
+  }, []);
+
+  useEffect(() => {
+    setHasError(false);
 
     if (!markdown) {
       if (markmapRef.current) {
         markmapRef.current.destroy();
         markmapRef.current = null;
       }
-      svgElement.innerHTML = '';
+      if (svgRef.current) {
+        svgRef.current.innerHTML = '';
+      }
       return;
     }
+
+    const svgElement = svgRef.current;
+    if (!svgElement) return;
 
     let isMounted = true;
 
@@ -43,6 +58,9 @@ export function MarkmapViewer({ markdown }: MarkmapViewerProps) {
         markmapRef.current.fit();
       } catch (e) {
         console.error('Failed to render markmap', e);
+        if (isMounted) {
+          setHasError(true);
+        }
       }
     };
 
@@ -52,6 +70,14 @@ export function MarkmapViewer({ markdown }: MarkmapViewerProps) {
       isMounted = false;
     };
   }, [markdown]);
+
+  if (hasError) {
+    return (
+      <div className="w-full h-full min-h-[70vh] flex flex-col items-center justify-center bg-surface p-4 text-text-muted">
+        <p className="text-error">Failed to load mindmap view</p>
+      </div>
+    );
+  }
 
   if (!markdown) {
     return (
@@ -63,24 +89,9 @@ export function MarkmapViewer({ markdown }: MarkmapViewerProps) {
 
   return (
     <div className="w-full h-full min-h-[70vh] flex flex-col items-center justify-center bg-surface p-4 text-text-base markmap-wrapper">
-      <style>{`
-        .markmap-wrapper svg text {
-          fill: var(--color-text) !important;
-        }
-        .markmap-wrapper svg foreignObject,
-        .markmap-wrapper svg foreignObject * {
-          color: var(--color-text) !important;
-        }
-        .markmap-wrapper svg foreignObject pre,
-        .markmap-wrapper svg foreignObject code {
-          background-color: var(--color-surface) !important;
-          color: var(--color-text) !important;
-          text-shadow: none !important;
-        }
-      `}</style>
       <svg 
         ref={svgRef} 
-        className="w-full h-full flex-1" 
+        className="w-full h-full flex-1 markmap-svg" 
         style={{ minHeight: '600px' }} 
       />
     </div>

--- a/apps/renderer/src/components/MarkmapViewer.tsx
+++ b/apps/renderer/src/components/MarkmapViewer.tsx
@@ -8,7 +8,16 @@ export function MarkmapViewer({ markdown }: MarkmapViewerProps) {
 
   useEffect(() => {
     const svgElement = svgRef.current;
-    if (!svgElement || !markdown) return;
+    if (!svgElement) return;
+
+    if (!markdown) {
+      if (markmapRef.current) {
+        markmapRef.current.destroy();
+        markmapRef.current = null;
+      }
+      svgElement.innerHTML = '';
+      return;
+    }
 
     let isMounted = true;
 
@@ -16,11 +25,13 @@ export function MarkmapViewer({ markdown }: MarkmapViewerProps) {
       try {
         const { Transformer } = await import('markmap-lib');
         const { Markmap } = await import('markmap-view');
+        const DOMPurify = (await import('dompurify')).default;
 
         if (!isMounted) return;
 
         const transformer = new Transformer();
-        const { root } = transformer.transform(markdown);
+        const sanitizedMarkdown = DOMPurify.sanitize(markdown);
+        const { root } = transformer.transform(sanitizedMarkdown);
 
         if (!markmapRef.current) {
           markmapRef.current = Markmap.create(svgElement, {
@@ -41,6 +52,14 @@ export function MarkmapViewer({ markdown }: MarkmapViewerProps) {
       isMounted = false;
     };
   }, [markdown]);
+
+  if (!markdown) {
+    return (
+      <div className="w-full h-full min-h-[70vh] flex flex-col items-center justify-center bg-surface p-4 text-text-muted">
+        <p>No content to display in Mind Map</p>
+      </div>
+    );
+  }
 
   return (
     <div className="w-full h-full min-h-[70vh] flex flex-col items-center justify-center bg-surface p-4 text-text-base markmap-wrapper">

--- a/apps/renderer/src/components/MarkmapViewer.tsx
+++ b/apps/renderer/src/components/MarkmapViewer.tsx
@@ -45,8 +45,16 @@ export function MarkmapViewer({ markdown }: MarkmapViewerProps) {
         if (!isMounted) return;
 
         const transformer = new Transformer();
-        const sanitizedMarkdown = DOMPurify.sanitize(markdown);
-        const { root } = transformer.transform(sanitizedMarkdown);
+        const { root } = transformer.transform(markdown);
+        const walkAndSanitize = (node: any) => {
+          if (node.content) {
+            node.content = DOMPurify.sanitize(node.content);
+          }
+          if (node.children) {
+            node.children.forEach(walkAndSanitize);
+          }
+        };
+        walkAndSanitize(root);
 
         if (!markmapRef.current) {
           markmapRef.current = Markmap.create(svgElement, {

--- a/apps/renderer/src/components/MarkmapViewer.tsx
+++ b/apps/renderer/src/components/MarkmapViewer.tsx
@@ -1,0 +1,69 @@
+import { useEffect, useRef } from "react";
+import { MarkmapViewerProps } from "../types/component-types";
+
+// It converts the markdown content to a map using markmap library dynamically
+export function MarkmapViewer({ markdown }: MarkmapViewerProps) {
+  const svgRef = useRef<SVGSVGElement>(null);
+  const markmapRef = useRef<any>(null);
+
+  useEffect(() => {
+    const svgElement = svgRef.current;
+    if (!svgElement || !markdown) return;
+
+    let isMounted = true;
+
+    const renderMarkmap = async () => {
+      try {
+        const { Transformer } = await import('markmap-lib');
+        const { Markmap } = await import('markmap-view');
+
+        if (!isMounted) return;
+
+        const transformer = new Transformer();
+        const { root } = transformer.transform(markdown);
+
+        if (!markmapRef.current) {
+          markmapRef.current = Markmap.create(svgElement, {
+            scrollForPan: true
+          });
+        }
+        
+        markmapRef.current.setData(root);
+        markmapRef.current.fit();
+      } catch (e) {
+        console.error('Failed to render markmap', e);
+      }
+    };
+
+    void renderMarkmap();
+
+    return () => {
+      isMounted = false;
+    };
+  }, [markdown]);
+
+  return (
+    <div className="w-full h-full min-h-[70vh] flex flex-col items-center justify-center bg-surface p-4 text-text-base markmap-wrapper">
+      <style>{`
+        .markmap-wrapper svg text {
+          fill: var(--color-text) !important;
+        }
+        .markmap-wrapper svg foreignObject,
+        .markmap-wrapper svg foreignObject * {
+          color: var(--color-text) !important;
+        }
+        .markmap-wrapper svg foreignObject pre,
+        .markmap-wrapper svg foreignObject code {
+          background-color: var(--color-surface) !important;
+          color: var(--color-text) !important;
+          text-shadow: none !important;
+        }
+      `}</style>
+      <svg 
+        ref={svgRef} 
+        className="w-full h-full flex-1" 
+        style={{ minHeight: '600px' }} 
+      />
+    </div>
+  );
+}

--- a/apps/renderer/src/components/ReaderToolbar.tsx
+++ b/apps/renderer/src/components/ReaderToolbar.tsx
@@ -185,6 +185,7 @@ export function ReaderToolbar({
           className={`rounded-md p-2 transition-colors hover:bg-accent-bg ${viewMode === MARKDOWN_TOGGLE.RAW ? 'text-accent bg-accent-bg' : 'text-text-muted hover:text-text-base'}`}
           aria-label={viewMode === MARKDOWN_TOGGLE.RAW ? ICON_TITLE.SHOW_RENDERED_TEXT : ICON_TITLE.SHOW_RAW_TEXT}
           title={viewMode === MARKDOWN_TOGGLE.RAW ? ICON_TITLE.SHOW_RENDERED_TEXT : ICON_TITLE.SHOW_RAW_TEXT}
+          aria-pressed={viewMode===MARKDOWN_TOGGLE.RAW}
         >
           <Icons.Code size={17} />
         </button>
@@ -198,6 +199,7 @@ export function ReaderToolbar({
           className={`rounded-md p-2 transition-colors hover:bg-accent-bg ${viewMode === MARKDOWN_TOGGLE.MINDMAP ? 'text-accent bg-accent-bg' : 'text-text-muted hover:text-text-base'}`}
           aria-label={viewMode === MARKDOWN_TOGGLE.MINDMAP ? ICON_TITLE.SHOW_RENDERED_TEXT : ICON_TITLE.SHOW_MIND_MAP}
           title={viewMode === MARKDOWN_TOGGLE.MINDMAP ? ICON_TITLE.SHOW_RENDERED_TEXT : ICON_TITLE.SHOW_MIND_MAP}
+          aria-pressed={viewMode===MARKDOWN_TOGGLE.MINDMAP}
         >
           <Icons.MindMap size={17} />
         </button>

--- a/apps/renderer/src/components/ReaderToolbar.tsx
+++ b/apps/renderer/src/components/ReaderToolbar.tsx
@@ -1,6 +1,7 @@
 import { useState, useRef, useEffect } from 'react';
 import { Icons } from '../utils/constants/icon-contants';
 import { ReaderToolbarProps } from '../types/component-types';
+import { ICON_TITLE, MARKDOWN_TOGGLE } from '../utils/constants/markdown-constants';
 
 /* toolbar component to show zoom controls and theme toggle on UI */
 export function ReaderToolbar({
@@ -20,6 +21,7 @@ export function ReaderToolbar({
   onExportDocx,
   viewMode,
   onToggleRawText,
+  onToggleMindMap,
 }: ReaderToolbarProps) {
   const [exportOpen, setExportOpen] = useState(false);
   const [collapsed, setCollapsed] = useState(false);
@@ -180,11 +182,24 @@ export function ReaderToolbar({
         <button
           type="button"
           onClick={onToggleRawText}
-          className={`rounded-md p-2 transition-colors hover:bg-accent-bg ${viewMode === 'raw' ? 'text-accent bg-accent-bg' : 'text-text-muted hover:text-text-base'}`}
-          aria-label={viewMode === 'raw' ? "Show rendered text" : "Show raw text"}
-          title={viewMode === 'raw' ? "Show rendered text" : "Show raw text"}
+          className={`rounded-md p-2 transition-colors hover:bg-accent-bg ${viewMode === MARKDOWN_TOGGLE.RAW ? 'text-accent bg-accent-bg' : 'text-text-muted hover:text-text-base'}`}
+          aria-label={viewMode === MARKDOWN_TOGGLE.RAW ? ICON_TITLE.SHOW_RENDERED_TEXT : ICON_TITLE.SHOW_RAW_TEXT}
+          title={viewMode === MARKDOWN_TOGGLE.RAW ? ICON_TITLE.SHOW_RENDERED_TEXT : ICON_TITLE.SHOW_RAW_TEXT}
         >
           <Icons.Code size={17} />
+        </button>
+      )}
+
+      {/* Mind Map Toggle */}
+      {onToggleMindMap && (
+        <button
+          type="button"
+          onClick={onToggleMindMap}
+          className={`rounded-md p-2 transition-colors hover:bg-accent-bg ${viewMode === MARKDOWN_TOGGLE.MINDMAP ? 'text-accent bg-accent-bg' : 'text-text-muted hover:text-text-base'}`}
+          aria-label={viewMode === MARKDOWN_TOGGLE.MINDMAP ? ICON_TITLE.SHOW_RENDERED_TEXT : ICON_TITLE.SHOW_MIND_MAP}
+          title={viewMode === MARKDOWN_TOGGLE.MINDMAP ? ICON_TITLE.SHOW_RENDERED_TEXT : ICON_TITLE.SHOW_MIND_MAP}
+        >
+          <Icons.MindMap size={17} />
         </button>
       )}
 

--- a/apps/renderer/src/hooks/useViewMode.ts
+++ b/apps/renderer/src/hooks/useViewMode.ts
@@ -1,15 +1,25 @@
 import { useCallback, useState } from 'react';
 import { ViewMode } from '../types/component-types';
+import { MARKDOWN_TOGGLE } from '../utils/constants/markdown-constants';
 
-export function useViewMode(initialMode: ViewMode = 'rendered') {
+export function useViewMode(initialMode: ViewMode = MARKDOWN_TOGGLE.RENDERED) {
   const [viewMode, setViewMode] = useState<ViewMode>(initialMode);
   const toggleRawText = useCallback(() => {
-    setViewMode((prev) => (prev === 'raw' ? 'rendered' : 'raw'));
+    setViewMode((prev) =>
+      prev === MARKDOWN_TOGGLE.RAW ? MARKDOWN_TOGGLE.RENDERED : MARKDOWN_TOGGLE.RAW
+    );
+  }, []);
+
+  const toggleMindMap = useCallback(() => {
+    setViewMode((prev) =>
+      prev === MARKDOWN_TOGGLE.MINDMAP ? MARKDOWN_TOGGLE.RENDERED : MARKDOWN_TOGGLE.MINDMAP
+    );
   }, []);
 
   return {
     viewMode,
     setViewMode,
     toggleRawText,
+    toggleMindMap,
   };
 }

--- a/apps/renderer/src/index.css
+++ b/apps/renderer/src/index.css
@@ -218,6 +218,16 @@ body {
   overflow-x: auto;
 }
 
+/*dark mode colors for markmap svg's */
+.markmap-svg text {
+  fill: var(--color-text) !important;
+}
+
+.markmap-svg foreignObject,
+.markmap-svg foreignObject * {
+  color: var(--color-text) !important;
+}
+
 .mermaid-error,
 .katex-error {
   color: var(--color-error);

--- a/apps/renderer/src/types/component-types.ts
+++ b/apps/renderer/src/types/component-types.ts
@@ -183,9 +183,10 @@ export interface ReaderToolbarProps {
   onExportDocx?: (() => void) | undefined;
   viewMode?: ViewMode;
   onToggleRawText?: () => void;
+  onToggleMindMap?: () => void;
 }
 
-export type ViewMode = 'rendered' | 'raw';
+export type ViewMode = 'rendered' | 'raw' | 'mindmap';
 
 export interface RawTextViewerProps {
   markdown?: string | undefined;
@@ -206,4 +207,8 @@ export type ErrorBoundaryState = {
 
 export interface ReaderStatsProps {
   markdown: string | undefined;
+}
+
+export interface MarkmapViewerProps {
+  markdown?: string | undefined;
 }

--- a/apps/renderer/src/utils/constants/icon-contants.tsx
+++ b/apps/renderer/src/utils/constants/icon-contants.tsx
@@ -242,7 +242,18 @@ const Code=({size=20,...props}:IconProps)=>(
     <polyline points="16 18 22 12 16 6"/>
     <polyline points="8 6 2 12 8 18"/>
   </svg>
-)
+);
+
+const MindMap = ({ size = 20, ...props }: IconProps) => (
+  <svg width={size} height={size} viewBox="0 0 24 24" {...defaultProps} {...props}>
+    <rect x="16" y="16" width="6" height="6" rx="1" />
+    <rect x="2" y="16" width="6" height="6" rx="1" />
+    <rect x="9" y="2" width="6" height="6" rx="1" />
+    <path d="M5 16v-3a1 1 0 0 1 1-1h12a1 1 0 0 1 1 1v3" />
+    <path d="M12 12V8" />
+  </svg>
+);
+
 export const Icons = {
-X,Hamburger,ZoomIn,ZoomOut,Sun,Moon,Folder,ChevronRight,ChevronDown,ArrowUp,ArrowDown,Plus,Settings,Search,FileText,Sparkles,Download,Code
+X,Hamburger,ZoomIn,ZoomOut,Sun,Moon,Folder,ChevronRight,ChevronDown,ArrowUp,ArrowDown,Plus,Settings,Search,FileText,Sparkles,Download,Code,MindMap
 };

--- a/apps/renderer/src/utils/constants/markdown-constants.ts
+++ b/apps/renderer/src/utils/constants/markdown-constants.ts
@@ -2,3 +2,15 @@ export const MARKDOWN_LANGUAGES = {
   MERMAID: 'mermaid',
   TEXT: 'text',
 } as const;
+
+export const MARKDOWN_TOGGLE = {
+  RAW: 'raw',
+  RENDERED: 'rendered',
+  MINDMAP: 'mindmap',
+} as const;
+
+export const ICON_TITLE = {
+  SHOW_RENDERED_TEXT: 'Show rendered text',
+  SHOW_RAW_TEXT: 'Show raw text',
+  SHOW_MIND_MAP: 'Show mind map',
+} as const;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -177,6 +177,12 @@ importers:
       marked-highlight:
         specifier: ^2.2.4
         version: 2.2.4(marked@18.0.2)
+      markmap-lib:
+        specifier: ^0.18.12
+        version: 0.18.12(markmap-common@0.18.9)
+      markmap-view:
+        specifier: ^0.18.12
+        version: 0.18.12(markmap-common@0.18.9)
       mermaid:
         specifier: ^11.14.0
         version: 11.14.0
@@ -986,10 +992,6 @@ packages:
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
-
-  '@babel/runtime@7.29.2':
-    resolution: {integrity: sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==}
-    engines: {node: '>=6.9.0'}
 
   '@babel/runtime@7.29.7':
     resolution: {integrity: sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==}
@@ -1983,6 +1985,9 @@ packages:
     peerDependenciesMeta:
       '@noble/hashes':
         optional: true
+
+  '@gera2ld/jsx-dom@2.2.2':
+    resolution: {integrity: sha512-EOqf31IATRE6zS1W1EoWmXZhGfLAoO9FIlwTtHduSrBdud4npYBxYAkv8dZ5hudDPwJeeSjn40kbCL4wAzr8dA==}
 
   '@hapi/hoek@9.3.0':
     resolution: {integrity: sha512-/c6rf4UJlmHlC9b5BaNvzAcFv7HZ2QHaV0D4/HNlBdvFnvQq8RI4kYdhyPCl7Xj+oWvTWQ8ujhqS53LIgAe6KQ==}
@@ -3475,6 +3480,9 @@ packages:
   '@vitest/utils@4.1.5':
     resolution: {integrity: sha512-76wdkrmfXfqGjueGgnb45ITPyUi1ycZ4IHgC2bhPDUfWHklY/q3MdLOAB+TF1e6xfl8NxNY0ZYaPCFNWSsw3Ug==}
 
+  '@vscode/markdown-it-katex@1.1.2':
+    resolution: {integrity: sha512-+4IIv5PgrmhKvW/3LpkpkGg257OViEhXkOOgCyj5KMsjsOfnRXkni8XAuuF9Ui5p3B8WnUovlDXAQNb8RJ/RaQ==}
+
   '@webassemblyjs/ast@1.14.1':
     resolution: {integrity: sha512-nuBEDgQfm1ccRp/8bCQrx1frohyufl4JlbMMZ4P1wpeOfDhF6FQkxZJ1b/e+PLwr6X1Nhw6OLme5usuBWYBvuQ==}
 
@@ -3964,6 +3972,10 @@ packages:
 
   cheerio-select@2.1.0:
     resolution: {integrity: sha512-9v9kG0LvzrlcungtnJtpGNxY+fzECQKhK4EGJX2vByejiMX84MFNQw4UxPJl3bFbTMw+Dfs37XaIkCwTZfLh4g==}
+
+  cheerio@1.0.0:
+    resolution: {integrity: sha512-quS9HgjQpdaXOvsZz82Oz7uxtXiy6UIsIQcpBj7HRw2M63Skasm9qlDocAM7jNuaxdhpPU7c4kJN+gA5MCu4ww==}
+    engines: {node: '>=18.17'}
 
   cheerio@1.0.0-rc.12:
     resolution: {integrity: sha512-VqR8m68vM46BNnuZ5NtnGBKIE/DfN0cRIzg9n40EIq9NOv90ayxLBXA8fXC5gquFRGJSTRqBq25Jt2ECLR431Q==}
@@ -4814,6 +4826,9 @@ packages:
     resolution: {integrity: sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==}
     engines: {node: '>= 0.8'}
 
+  encoding-sniffer@0.2.1:
+    resolution: {integrity: sha512-5gvq20T6vfpekVtqrYQsSCFZ1wEg5+wW0/QaZMWkFr6BqD3NfKs0rLCx4rrVlSWJeZb5NBJgVLswK/w2MWU+Gw==}
+
   end-of-stream@1.4.5:
     resolution: {integrity: sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==}
 
@@ -5420,6 +5435,10 @@ packages:
     resolution: {integrity: sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==}
     hasBin: true
 
+  highlight.js@11.11.1:
+    resolution: {integrity: sha512-Xwwo44whKBVCYoliBQwaPvtd/2tYFkRQtXDWj1nackaV2JPXx3L0+Jvd8/qCJ2p+ML0/XVkJ2q+Mr+UVdpJK5w==}
+    engines: {node: '>=12.0.0'}
+
   history@4.10.1:
     resolution: {integrity: sha512-36nwAD620w12kuzPAsyINPWJqlNbij+hpK1k9XRloDtym8mxzGYl2c17LnV6IAGB2Dmg4tEa7G7DlawS0+qjew==}
 
@@ -5486,6 +5505,9 @@ packages:
 
   htmlparser2@8.0.2:
     resolution: {integrity: sha512-GYdjWKDkbRLkZ5geuHs5NY1puJ+PXwP7+fHPRz06Eirsb9ugf6d8kkXav6ADhcODhFFPMIXyxkxSuMf3D6NCFA==}
+
+  htmlparser2@9.1.0:
+    resolution: {integrity: sha512-5zfg6mHUoaer/97TxnGpxmbR7zJtPwIYFMZ/H5ucTlPZhKvtum05yiPK3Mgai3a0DyVxv7qYqoweaEd2nrYQzQ==}
 
   http-cache-semantics@4.2.0:
     resolution: {integrity: sha512-dTxcvPXqPvXBQpq5dUr6mEMJX4oIEFv6bwom3FDwKRDsuIjjJGANqhBuoAn9c1RQJIdAKav33ED65E2ys+87QQ==}
@@ -6067,6 +6089,9 @@ packages:
   lines-and-columns@1.2.4:
     resolution: {integrity: sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==}
 
+  linkify-it@5.0.1:
+    resolution: {integrity: sha512-wVoTjP4Q6R0NW5hiZkVJaFZPWgtXfoGF+6LucL3/FtiNjmcHhYjEr5f1Kqjirc1nBW07J/ZuRFumqr2oqccEWg==}
+
   lint-staged@16.4.0:
     resolution: {integrity: sha512-lBWt8hujh/Cjysw5GYVmZpFHXDCgZzhrOm8vbcUdobADZNOK/bRshr2kM3DfgrrtR1DQhfupW9gnIXOfiFi+bw==}
     engines: {node: '>=20.17'}
@@ -6177,6 +6202,22 @@ packages:
     resolution: {integrity: sha512-o5vL7aDWatOTX8LzaS1WMoaoxIiLRQJuIKKe2wAw6IeULDHaqbiqiggmx+pKvZDb1Sj+pE46Sn1T7lCqfFtg1Q==}
     engines: {node: '>=16'}
 
+  markdown-it-ins@4.0.0:
+    resolution: {integrity: sha512-sWbjK2DprrkINE4oYDhHdCijGT+MIDhEupjSHLXe5UXeVr5qmVxs/nTUVtgi0Oh/qtF+QKV0tNWDhQBEPxiMew==}
+
+  markdown-it-mark@4.0.0:
+    resolution: {integrity: sha512-YLhzaOsU9THO/cal0lUjfMjrqSMPjjyjChYM7oyj4DnyaXEzA8gnW6cVJeyCrCVeyesrY2PlEdUYJSPFYL4Nkg==}
+
+  markdown-it-sub@2.0.0:
+    resolution: {integrity: sha512-iCBKgwCkfQBRg2vApy9vx1C1Tu6D8XYo8NvevI3OlwzBRmiMtsJ2sXupBgEA7PPxiDwNni3qIUkhZ6j5wofDUA==}
+
+  markdown-it-sup@2.0.0:
+    resolution: {integrity: sha512-5VgmdKlkBd8sgXuoDoxMpiU+BiEt3I49GItBzzw7Mxq9CxvnhE/k09HFli09zgfFDRixDQDfDxi0mgBCXtaTvA==}
+
+  markdown-it@14.2.0:
+    resolution: {integrity: sha512-1TGiQiJVRQ3NPmZH6sx5Cfnmg6GQm9jvC1ch4TK511NjSJvjzKLzn5pPfZRNZkRPZP0HqCioSndqH8v2nRaWVQ==}
+    hasBin: true
+
   markdown-table@3.0.4:
     resolution: {integrity: sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw==}
 
@@ -6194,6 +6235,24 @@ packages:
     resolution: {integrity: sha512-NsmlUYBS/Zg57rgDWMYdnre6OTj4e+qq/JS2ot3KrYLSoHLw+sDu0Nm1ZGpRgYAq6c+b1ekaY5NzVchMCQnzcg==}
     engines: {node: '>= 20'}
     hasBin: true
+
+  markmap-common@0.18.9:
+    resolution: {integrity: sha512-MV2HQO7IGIm3jWEJXSG8vmdpqf4WIDXcEyAEN52lrWR1qD53Zg5l81JwjXoZ2l0rY5mofKYqUFlmdM2fqTGMVg==}
+
+  markmap-html-parser@0.18.11:
+    resolution: {integrity: sha512-+kC5C4sCGntGUhGvTa5VIb5rtM75cSy/VCy3tzZoNAcn2qZGdgYvljN0WvjsOzrEzp+V6XKgwzO0u2TdzNAiOg==}
+    peerDependencies:
+      markmap-common: '*'
+
+  markmap-lib@0.18.12:
+    resolution: {integrity: sha512-WCA4OT+b71jYg0e4PS/6NRKqihod5OpPsvw1jEGHQwCtqQrY/yXXCeRyuL3axOS5cMy5pV8BSl4CwKfJU1LxJg==}
+    peerDependencies:
+      markmap-common: '*'
+
+  markmap-view@0.18.12:
+    resolution: {integrity: sha512-D8bzT1YwIC/8rkbwm6WzigVUrpOAGv7ioEGTi1Lj+Oo8gO5sAm6hhli27jvTgUcZ9TwBeIWZ+dSUP+AupYUGlQ==}
+    peerDependencies:
+      markmap-common: '*'
 
   matcher@3.0.0:
     resolution: {integrity: sha512-OkeDaAZ/bQCxeFAozM55PKcKU0yJMPGifLwV4Qgjitu+5MoAfSQN4lsLJeXZ1b8w0x+/Emda6MZgXS1jvsapng==}
@@ -6265,6 +6324,9 @@ packages:
 
   mdn-data@2.27.1:
     resolution: {integrity: sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==}
+
+  mdurl@2.0.0:
+    resolution: {integrity: sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w==}
 
   media-typer@0.3.0:
     resolution: {integrity: sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==}
@@ -6632,6 +6694,9 @@ packages:
     resolution: {integrity: sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==}
     engines: {node: '>=8'}
 
+  npm2url@0.2.4:
+    resolution: {integrity: sha512-arzGp/hQz0Ey+ZGhF64XVH7Xqwd+1Q/po5uGiBbzph8ebX6T0uvt3N7c1nBHQNsQVykQgHhqoRTX7JFcHecGuw==}
+
   nprogress@0.2.0:
     resolution: {integrity: sha512-I19aIingLgR1fmhftnbWWO3dXc0hSxqHQHQb3H8m+K3TnEn/iSeTZZOyvKXWqQESMwuUVnatlCnZdLBZZt2VSA==}
 
@@ -6806,6 +6871,9 @@ packages:
 
   parse5-htmlparser2-tree-adapter@7.1.0:
     resolution: {integrity: sha512-ruw5xyKs6lrpo9x9rCZqZZnIUntICjQAd0Wsmp396Ul9lN/h+ifgVV1x1gZHi8euej6wTfpqX8j+BFQxF0NS/g==}
+
+  parse5-parser-stream@7.1.2:
+    resolution: {integrity: sha512-JyeQc9iwFLn5TbvvqACIF/VXG6abODeB3Fwmv/TGdLk2LfbWkaySGY72at4+Ty7EkPZj854u4CrICqNk2qIbow==}
 
   parse5@7.3.0:
     resolution: {integrity: sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==}
@@ -7397,6 +7465,10 @@ packages:
 
   pump@3.0.4:
     resolution: {integrity: sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==}
+
+  punycode.js@2.3.1:
+    resolution: {integrity: sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA==}
+    engines: {node: '>=6'}
 
   punycode@1.4.1:
     resolution: {integrity: sha512-jmYNElW7yvO7TV33CjSmvSiE2yco3bV2czu/OzDKdMNVZQWfxCblURLhf+47syQRBntjfLdd/H0egrzIG+oaFQ==}
@@ -8326,6 +8398,9 @@ packages:
     engines: {node: '>=14.17'}
     hasBin: true
 
+  uc.micro@2.1.0:
+    resolution: {integrity: sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==}
+
   ufo@1.6.4:
     resolution: {integrity: sha512-JFNbkD1Svwe0KvGi8GOeLcP4kAWQ609twvCdcHxq1oSL8svv39ZuSvajcD8B+5D0eL4+s1Is2D/O6KN3qcTeRA==}
 
@@ -8661,6 +8736,15 @@ packages:
   websocket-extensions@0.1.4:
     resolution: {integrity: sha512-OqedPIGOfsDlo31UNwYbCFMSaO9m9G/0faIHj5/dZFDMFqPTcx6UwqyOy3COEaEOg/9VsGIpdqn62W5KhoKSpg==}
     engines: {node: '>=0.8.0'}
+
+  whatwg-encoding@3.1.1:
+    resolution: {integrity: sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==}
+    engines: {node: '>=18'}
+    deprecated: Use @exodus/bytes instead for a more spec-conformant and faster implementation
+
+  whatwg-mimetype@4.0.0:
+    resolution: {integrity: sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==}
+    engines: {node: '>=18'}
 
   whatwg-mimetype@5.0.0:
     resolution: {integrity: sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==}
@@ -9727,8 +9811,6 @@ snapshots:
       '@babel/plugin-transform-typescript': 7.28.6(@babel/core@7.29.0)
     transitivePeerDependencies:
       - supports-color
-
-  '@babel/runtime@7.29.2': {}
 
   '@babel/runtime@7.29.7': {}
 
@@ -11692,6 +11774,10 @@ snapshots:
 
   '@exodus/bytes@1.15.0': {}
 
+  '@gera2ld/jsx-dom@2.2.2':
+    dependencies:
+      '@babel/runtime': 7.29.7
+
   '@hapi/hoek@9.3.0': {}
 
   '@hapi/topo@5.1.0':
@@ -11921,7 +12007,7 @@ snapshots:
 
   '@manypkg/get-packages@1.1.3':
     dependencies:
-      '@babel/runtime': 7.29.2
+      '@babel/runtime': 7.29.7
       '@changesets/types': 4.1.0
       '@manypkg/find-root': 1.1.0
       fs-extra: 8.1.0
@@ -13279,6 +13365,10 @@ snapshots:
       convert-source-map: 2.0.0
       tinyrainbow: 3.1.0
 
+  '@vscode/markdown-it-katex@1.1.2':
+    dependencies:
+      katex: 0.16.45
+
   '@webassemblyjs/ast@1.14.1':
     dependencies:
       '@webassemblyjs/helper-numbers': 1.13.2
@@ -13865,6 +13955,20 @@ snapshots:
       domelementtype: 2.3.0
       domhandler: 5.0.3
       domutils: 3.2.2
+
+  cheerio@1.0.0:
+    dependencies:
+      cheerio-select: 2.1.0
+      dom-serializer: 2.0.0
+      domhandler: 5.0.3
+      domutils: 3.2.2
+      encoding-sniffer: 0.2.1
+      htmlparser2: 9.1.0
+      parse5: 7.3.0
+      parse5-htmlparser2-tree-adapter: 7.1.0
+      parse5-parser-stream: 7.1.2
+      undici: 7.28.0
+      whatwg-mimetype: 4.0.0
 
   cheerio@1.0.0-rc.12:
     dependencies:
@@ -14806,6 +14910,11 @@ snapshots:
 
   encodeurl@2.0.0: {}
 
+  encoding-sniffer@0.2.1:
+    dependencies:
+      iconv-lite: 0.6.3
+      whatwg-encoding: 3.1.1
+
   end-of-stream@1.4.5:
     dependencies:
       once: 1.4.0
@@ -15606,6 +15715,8 @@ snapshots:
 
   he@1.2.0: {}
 
+  highlight.js@11.11.1: {}
+
   history@4.10.1:
     dependencies:
       '@babel/runtime': 7.29.7
@@ -15715,6 +15826,13 @@ snapshots:
       entities: 2.2.0
 
   htmlparser2@8.0.2:
+    dependencies:
+      domelementtype: 2.3.0
+      domhandler: 5.0.3
+      domutils: 3.2.2
+      entities: 4.5.0
+
+  htmlparser2@9.1.0:
     dependencies:
       domelementtype: 2.3.0
       domhandler: 5.0.3
@@ -16231,6 +16349,10 @@ snapshots:
 
   lines-and-columns@1.2.4: {}
 
+  linkify-it@5.0.1:
+    dependencies:
+      uc.micro: 2.1.0
+
   lint-staged@16.4.0:
     dependencies:
       commander: 14.0.3
@@ -16339,6 +16461,23 @@ snapshots:
 
   markdown-extensions@2.0.0: {}
 
+  markdown-it-ins@4.0.0: {}
+
+  markdown-it-mark@4.0.0: {}
+
+  markdown-it-sub@2.0.0: {}
+
+  markdown-it-sup@2.0.0: {}
+
+  markdown-it@14.2.0:
+    dependencies:
+      argparse: 2.0.1
+      entities: 4.5.0
+      linkify-it: 5.0.1
+      mdurl: 2.0.0
+      punycode.js: 2.3.1
+      uc.micro: 2.1.0
+
   markdown-table@3.0.4: {}
 
   marked-highlight@2.2.4(marked@18.0.2):
@@ -16348,6 +16487,41 @@ snapshots:
   marked@16.4.2: {}
 
   marked@18.0.2: {}
+
+  markmap-common@0.18.9:
+    dependencies:
+      '@babel/runtime': 7.29.7
+      '@gera2ld/jsx-dom': 2.2.2
+      npm2url: 0.2.4
+
+  markmap-html-parser@0.18.11(markmap-common@0.18.9):
+    dependencies:
+      '@babel/runtime': 7.29.7
+      cheerio: 1.0.0
+      markmap-common: 0.18.9
+
+  markmap-lib@0.18.12(markmap-common@0.18.9):
+    dependencies:
+      '@babel/runtime': 7.29.7
+      '@vscode/markdown-it-katex': 1.1.2
+      highlight.js: 11.11.1
+      katex: 0.16.45
+      markdown-it: 14.2.0
+      markdown-it-ins: 4.0.0
+      markdown-it-mark: 4.0.0
+      markdown-it-sub: 2.0.0
+      markdown-it-sup: 2.0.0
+      markmap-common: 0.18.9
+      markmap-html-parser: 0.18.11(markmap-common@0.18.9)
+      markmap-view: 0.18.12(markmap-common@0.18.9)
+      prismjs: 1.30.0
+      yaml: 2.8.3
+
+  markmap-view@0.18.12(markmap-common@0.18.9):
+    dependencies:
+      '@babel/runtime': 7.29.7
+      d3: 7.9.0
+      markmap-common: 0.18.9
 
   matcher@3.0.0:
     dependencies:
@@ -16549,6 +16723,8 @@ snapshots:
   mdn-data@2.0.30: {}
 
   mdn-data@2.27.1: {}
+
+  mdurl@2.0.0: {}
 
   media-typer@0.3.0: {}
 
@@ -17073,6 +17249,8 @@ snapshots:
     dependencies:
       path-key: 3.1.1
 
+  npm2url@0.2.4: {}
+
   nprogress@0.2.0: {}
 
   nth-check@2.1.1:
@@ -17259,6 +17437,10 @@ snapshots:
   parse5-htmlparser2-tree-adapter@7.1.0:
     dependencies:
       domhandler: 5.0.3
+      parse5: 7.3.0
+
+  parse5-parser-stream@7.1.2:
+    dependencies:
       parse5: 7.3.0
 
   parse5@7.3.0:
@@ -17888,6 +18070,8 @@ snapshots:
     dependencies:
       end-of-stream: 1.4.5
       once: 1.4.0
+
+  punycode.js@2.3.1: {}
 
   punycode@1.4.1: {}
 
@@ -18931,6 +19115,8 @@ snapshots:
 
   typescript@6.0.3: {}
 
+  uc.micro@2.1.0: {}
+
   ufo@1.6.4: {}
 
   undici-types@7.16.0: {}
@@ -19387,6 +19573,12 @@ snapshots:
       websocket-extensions: 0.1.4
 
   websocket-extensions@0.1.4: {}
+
+  whatwg-encoding@3.1.1:
+    dependencies:
+      iconv-lite: 0.6.3
+
+  whatwg-mimetype@4.0.0: {}
 
   whatwg-mimetype@5.0.0: {}
 


### PR DESCRIPTION
## Description

This PR uses Mark map library to generate map from raw markdown content.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor (no functional change)
- [ ] Documentation update
- [ ] Style / UI change
- [ ] Build / CI change

## Related Issue

Closes #126 

## Changes Made

- Added mark map viewer component which dynamically load mark map library to convert raw markdown into a map like structure
- Added toggle button in reader toolbar to toggle to map from rendered content
- Added tests for the component and hook.

## Screenshots (if applicable)

<img width="1366" height="720" alt="image" src="https://github.com/user-attachments/assets/bcdb76f3-b232-427f-b921-43bd45a5d011" />

## Checklist

- [x] My code follows the project's coding guidelines
- [x] I have tested my changes locally
- [x] I have used [conventional commit](https://www.conventionalcommits.org/) messages
- [ ] I have updated documentation if needed
- [x] My changes do not introduce new warnings or errors


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
- **Electron main/preload**
  - No changes.

- **Renderer UI**
  - Added a **Mind Map** toggle button to `ReaderToolbar` (alongside **Raw text**), driven by the new `onToggleMindMap` prop and `mindmap` view mode.
  - Updated `App.tsx` to render one of: raw text (`RAW`), rendered HTML (default), or the **mind map** (`MINDMAP`), and to suppress search UI/actions while in mind-map mode.
  - Added a new **MindMap** SVG icon and wired UI titles/ARIA state via `ICON_TITLE`.

- **Markdown rendering**
  - Introduced `MarkmapViewer` to convert provided markdown into a Markmap-rendered **SVG** by dynamically importing `markmap-lib`, `markmap-view`, and `dompurify`.
  - Sanitizes markdown with `DOMPurify`, transforms it via `Transformer.transform`, then updates the viewer using `setData(root)` and `fit()`.
  - Adds empty/loading/error handling (empty-state when markdown is missing; error state when rendering fails) and destroys/clears the viewer when markdown becomes falsy.
  - Added dark-mode CSS overrides for Markmap SVG text (including `foreignObject` content).

- **Shared packages**
  - No changes.

- **Tests**
  - Added Vitest coverage for `MarkmapViewer` (mocking `markmap-lib`/`markmap-view`) to verify SVG rendering/pipeline calls and the empty-state behavior.
  - Added Vitest coverage for `useViewMode` to verify toggling between `rendered`, `raw`, and the new `mindmap` mode.

- **Tooling/CI**
  - No changes.

- **Docs**
  - No changes.

- **Packaging**
  - Added `markmap-lib` and `markmap-view` to `apps/renderer/package.json` dependencies.

Breaking changes: None
<!-- end of auto-generated comment: release notes by coderabbit.ai -->