### PR TITLE
Feature/electron log

### DIFF
--- a/apps/main-processor/src/index.ts
+++ b/apps/main-processor/src/index.ts
@@ -9,11 +9,9 @@ import { setupAutoUpdater } from './updater';
 import { resolveMarkdownFilePath } from './utils/helper/ipc-path-resolver';
 import log from 'electron-log/main';
 
-log.initialize();
+log.initialize({ preload: false });
 Object.assign(console, log.functions);
-process.on('uncaughtException', (err) => {
-  log.error('Uncaught Exception:', err);
-});
+log.errorHandler.startCatching();
 
 let mainWindow: BrowserWindow | null = null;
 let pendingFilePath: string | null = null;

--- a/apps/main-processor/src/index.ts
+++ b/apps/main-processor/src/index.ts
@@ -7,6 +7,13 @@ import { registerMenu } from './register-menu';
 import { parseFilePathFromArgv } from './cli';
 import { setupAutoUpdater } from './updater';
 import { resolveMarkdownFilePath } from './utils/helper/ipc-path-resolver';
+import log from 'electron-log/main';
+
+log.initialize();
+Object.assign(console, log.functions);
+process.on('uncaughtException', (err) => {
+  log.error('Uncaught Exception:', err);
+});
 
 let mainWindow: BrowserWindow | null = null;
 let pendingFilePath: string | null = null;

--- a/apps/main-processor/src/ipc.ts
+++ b/apps/main-processor/src/ipc.ts
@@ -31,10 +31,18 @@ export function registerIPCHandlers(): void {
   // log messages from renderer
   ipcMain.on(
     IPC_CONSTANTS.LOG_MESSAGE,
-    (_event, level: string, message: string, ...args: unknown[]) => {
-      if (level === 'info') log.info(message, ...args);
-      else if (level === 'error') log.error(message, ...args);
-      else if (level === 'warn') log.warn(message, ...args);
+    (event, level: string, message: string, ...args: unknown[]) => {
+      if (!validateSender(event)) return;
+
+      const validLevels = ['info', 'error', 'warn'];
+      if (!validLevels.includes(level)) return;
+
+      const safeMessage = String(message).slice(0, 5000);
+      const safeArgs = args.slice(0, 5);
+
+      if (level === 'info') log.info(safeMessage, ...safeArgs);
+      else if (level === 'error') log.error(safeMessage, ...safeArgs);
+      else if (level === 'warn') log.warn(safeMessage, ...safeArgs);
     }
   );
 

--- a/apps/main-processor/src/ipc.ts
+++ b/apps/main-processor/src/ipc.ts
@@ -38,7 +38,10 @@ export function registerIPCHandlers(): void {
       if (!validLevels.includes(level)) return;
 
       const safeMessage = String(message).slice(0, 5000);
-      const safeArgs = args.slice(0, 5);
+      const safeArgs = args.slice(0, 5).map((a) => {
+        const s = typeof a === 'string' ? a : JSON.stringify(a);
+        return s && s.length > 2000 ? s.slice(0, 2000) : a;
+      });
 
       if (level === 'info') log.info(safeMessage, ...safeArgs);
       else if (level === 'error') log.error(safeMessage, ...safeArgs);

--- a/apps/main-processor/src/ipc.ts
+++ b/apps/main-processor/src/ipc.ts
@@ -24,9 +24,20 @@ import { searchFolder } from './folder-search';
 import { AppSettings } from '@package/shared-types';
 import { getSettings } from './settings/get-settings';
 import { saveSettings } from './settings/save-settings';
+import log from 'electron-log/main';
 
 //registers all IPC handlers for main process
 export function registerIPCHandlers(): void {
+  // log messages from renderer
+  ipcMain.on(
+    IPC_CONSTANTS.LOG_MESSAGE,
+    (_event, level: string, message: string, ...args: unknown[]) => {
+      if (level === 'info') log.info(message, ...args);
+      else if (level === 'error') log.error(message, ...args);
+      else if (level === 'warn') log.warn(message, ...args);
+    }
+  );
+
   //returns text content of the file
   ipcMain.handle(IPC_CONSTANTS.READ_FILE, async (event, filePath: string) => {
     if (!validateSender(event)) {

--- a/apps/preload/src/index.ts
+++ b/apps/preload/src/index.ts
@@ -61,6 +61,14 @@ const apiContract: MarkdownReaderAPI = {
     };
   },
   downloadUpdate: () => ipcRenderer.send(IPC_CONSTANTS.DOWNLOAD_UPDATE),
+  log: {
+    info: (message: string, ...args: unknown[]) =>
+      ipcRenderer.send(IPC_CONSTANTS.LOG_MESSAGE, 'info', message, ...args),
+    error: (message: string, ...args: unknown[]) =>
+      ipcRenderer.send(IPC_CONSTANTS.LOG_MESSAGE, 'error', message, ...args),
+    warn: (message: string, ...args: unknown[]) =>
+      ipcRenderer.send(IPC_CONSTANTS.LOG_MESSAGE, 'warn', message, ...args),
+  },
 };
 
 // bridge between renderer and main

--- a/apps/renderer/src/components/ErrorBoundary.tsx
+++ b/apps/renderer/src/components/ErrorBoundary.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { logger } from '../utils/helpers/logger';
 import { ErrorBoundaryState } from '../types/component-types';
 
 
@@ -9,8 +10,8 @@ export class ErrorBoundary extends React.Component<React.PropsWithChildren, Erro
     return { hasError: true, error };
   }
 
-  componentDidCatch(error: unknown): void {
-    console.error('Renderer error boundary caught an error:', error);
+  componentDidCatch(error: Error, errorInfo: React.ErrorInfo) {
+    logger.error('Renderer error boundary caught an error:', error instanceof Error ? error.message : String(error), errorInfo);
   }
 
   render(): React.ReactNode {

--- a/apps/renderer/src/components/ErrorBoundary.tsx
+++ b/apps/renderer/src/components/ErrorBoundary.tsx
@@ -11,7 +11,7 @@ export class ErrorBoundary extends React.Component<React.PropsWithChildren, Erro
   }
 
   componentDidCatch(error: Error, errorInfo: React.ErrorInfo) {
-    logger.error('Renderer error boundary caught an error:', error instanceof Error ? error.message : String(error), errorInfo);
+    logger.error('Renderer error boundary caught an error:', error, errorInfo);
   }
 
   render(): React.ReactNode {

--- a/apps/renderer/src/components/MarkmapViewer.tsx
+++ b/apps/renderer/src/components/MarkmapViewer.tsx
@@ -3,6 +3,7 @@ import type { Markmap } from 'markmap-view';
 import { MarkmapViewerProps } from "../types/component-types";
 import { Icons } from "../utils/constants/icon-contants";
 import { browserDownload } from "../utils/helpers/extension-export-helper";
+import { logger } from "../utils/helpers/logger";
 
 // It converts the markdown content to a map using markmap library dynamically
 export function MarkmapViewer({ markdown }: MarkmapViewerProps) {
@@ -67,7 +68,7 @@ export function MarkmapViewer({ markdown }: MarkmapViewerProps) {
         markmapRef.current.setData(root);
         markmapRef.current.fit();
       } catch (e) {
-        console.error('Failed to render markmap', e);
+        logger.error('Failed to render markmap:', e instanceof Error ? e.message : String(e));
         if (isMounted) {
           setHasError(true);
         }

--- a/apps/renderer/src/components/MarkmapViewer.tsx
+++ b/apps/renderer/src/components/MarkmapViewer.tsx
@@ -68,7 +68,7 @@ export function MarkmapViewer({ markdown }: MarkmapViewerProps) {
         markmapRef.current.setData(root);
         markmapRef.current.fit();
       } catch (e) {
-        logger.error('Failed to render markmap:', e instanceof Error ? e.message : String(e));
+        logger.error('Failed to render markmap:', e);
         if (isMounted) {
           setHasError(true);
         }

--- a/apps/renderer/src/components/ReaderToolbar.tsx
+++ b/apps/renderer/src/components/ReaderToolbar.tsx
@@ -1,4 +1,5 @@
 import { useState, useRef, useEffect } from 'react';
+import { logger } from '../utils/helpers/logger';
 import { Icons } from '../utils/constants/icon-contants';
 import { ReaderToolbarProps } from '../types/component-types';
 import { ICON_TITLE, MARKDOWN_TOGGLE } from '../utils/constants/markdown-constants';
@@ -146,7 +147,7 @@ export function ReaderToolbar({
                       type="button"
                       onClick={() => {
                         setExportOpen(false);
-                        void Promise.resolve(onExportHtml()).catch((e) => console.error('Export HTML failed:', e));
+                        void Promise.resolve(onExportHtml()).catch((e) => logger.error('Export HTML failed:', e instanceof Error ? e.message : String(e)));
                       }}
                       className="w-full text-left px-3 py-1.5 text-sm text-text-base hover:bg-accent-bg hover:text-accent transition-colors"
                     >
@@ -159,7 +160,7 @@ export function ReaderToolbar({
                       type="button"
                       onClick={() => {
                         setExportOpen(false);
-                        void Promise.resolve(onExportPdf()).catch((e) => console.error('Export PDF failed:', e));
+                        void Promise.resolve(onExportPdf()).catch((e) => logger.error('Export PDF failed:', e instanceof Error ? e.message : String(e)));
                       }}
                       className="w-full text-left px-3 py-1.5 text-sm text-text-base hover:bg-accent-bg hover:text-accent transition-colors"
                     >
@@ -172,7 +173,7 @@ export function ReaderToolbar({
                       type="button"
                       onClick={() => {
                         setExportOpen(false);
-                        void Promise.resolve(onExportDocx()).catch((e) => console.error('Export DOCX failed:', e));
+                        void Promise.resolve(onExportDocx()).catch((e) => logger.error('Export DOCX failed:', e instanceof Error ? e.message : String(e)));
                       }}
                       className="w-full text-left px-3 py-1.5 text-sm text-text-base hover:bg-accent-bg hover:text-accent transition-colors"
                     >
@@ -214,7 +215,7 @@ export function ReaderToolbar({
                       type="button"
                       onClick={() => {
                         setCopyOpen(false);
-                        void Promise.resolve(onCopyMd()).catch((e) => console.error('Copy MD failed:', e));
+                        void Promise.resolve(onCopyMd()).catch((e) => logger.error('Copy MD failed:', e instanceof Error ? e.message : String(e)));
                       }}
                       className="w-full text-left px-3 py-1.5 text-sm text-text-base hover:bg-accent-bg hover:text-accent transition-colors"
                     >
@@ -227,7 +228,7 @@ export function ReaderToolbar({
                       type="button"
                       onClick={() => {
                         setCopyOpen(false);
-                        void Promise.resolve(onCopyText()).catch((e) => console.error('Copy Text failed:', e));
+                        void Promise.resolve(onCopyText()).catch((e) => logger.error('Copy Text failed:', e instanceof Error ? e.message : String(e)));
                       }}
                       className="w-full text-left px-3 py-1.5 text-sm text-text-base hover:bg-accent-bg hover:text-accent transition-colors"
                     >

--- a/apps/renderer/src/components/ReaderToolbar.tsx
+++ b/apps/renderer/src/components/ReaderToolbar.tsx
@@ -147,7 +147,7 @@ export function ReaderToolbar({
                       type="button"
                       onClick={() => {
                         setExportOpen(false);
-                        void Promise.resolve(onExportHtml()).catch((e) => logger.error('Export HTML failed:', e instanceof Error ? e.message : String(e)));
+                        void Promise.resolve(onExportHtml()).catch((e) => logger.error('Export HTML failed:', e));
                       }}
                       className="w-full text-left px-3 py-1.5 text-sm text-text-base hover:bg-accent-bg hover:text-accent transition-colors"
                     >
@@ -160,7 +160,7 @@ export function ReaderToolbar({
                       type="button"
                       onClick={() => {
                         setExportOpen(false);
-                        void Promise.resolve(onExportPdf()).catch((e) => logger.error('Export PDF failed:', e instanceof Error ? e.message : String(e)));
+                        void Promise.resolve(onExportPdf()).catch((e) => logger.error('Export PDF failed:', e));
                       }}
                       className="w-full text-left px-3 py-1.5 text-sm text-text-base hover:bg-accent-bg hover:text-accent transition-colors"
                     >
@@ -173,7 +173,7 @@ export function ReaderToolbar({
                       type="button"
                       onClick={() => {
                         setExportOpen(false);
-                        void Promise.resolve(onExportDocx()).catch((e) => logger.error('Export DOCX failed:', e instanceof Error ? e.message : String(e)));
+                        void Promise.resolve(onExportDocx()).catch((e) => logger.error('Export DOCX failed:', e));
                       }}
                       className="w-full text-left px-3 py-1.5 text-sm text-text-base hover:bg-accent-bg hover:text-accent transition-colors"
                     >
@@ -215,7 +215,7 @@ export function ReaderToolbar({
                       type="button"
                       onClick={() => {
                         setCopyOpen(false);
-                        void Promise.resolve(onCopyMd()).catch((e) => logger.error('Copy MD failed:', e instanceof Error ? e.message : String(e)));
+                        void Promise.resolve(onCopyMd()).catch((e) => logger.error('Copy MD failed:', e));
                       }}
                       className="w-full text-left px-3 py-1.5 text-sm text-text-base hover:bg-accent-bg hover:text-accent transition-colors"
                     >
@@ -228,7 +228,7 @@ export function ReaderToolbar({
                       type="button"
                       onClick={() => {
                         setCopyOpen(false);
-                        void Promise.resolve(onCopyText()).catch((e) => logger.error('Copy Text failed:', e instanceof Error ? e.message : String(e)));
+                        void Promise.resolve(onCopyText()).catch((e) => logger.error('Copy Text failed:', e));
                       }}
                       className="w-full text-left px-3 py-1.5 text-sm text-text-base hover:bg-accent-bg hover:text-accent transition-colors"
                     >

--- a/apps/renderer/src/hooks/useExport.ts
+++ b/apps/renderer/src/hooks/useExport.ts
@@ -20,7 +20,7 @@ export function useExport(activeTab: ActiveTab) {
         await api.exportHTML(activeTab.html, css, '');
       }
     } catch (err) {
-      logger.error('Failed to export HTML:', err instanceof Error ? err.message : String(err));
+      logger.error('Failed to export HTML:', err);
     }
   }, [activeTab, api]);
 
@@ -37,7 +37,7 @@ export function useExport(activeTab: ActiveTab) {
         await api.exportPDF(activeTab.html, css, '');
       }
     } catch (err) {
-      logger.error('Failed to export PDF:', err instanceof Error ? err.message : String(err));
+      logger.error('Failed to export PDF:', err);
     }
   }, [activeTab, api]);
 
@@ -54,7 +54,7 @@ export function useExport(activeTab: ActiveTab) {
         await api.exportDOCX(activeTab.html, css, '');
       }
     } catch (err) {
-      logger.error('Failed to export DOCX:', err instanceof Error ? err.message : String(err));
+      logger.error('Failed to export DOCX:', err);
     }
   }, [activeTab, api]);
 

--- a/apps/renderer/src/hooks/useExport.ts
+++ b/apps/renderer/src/hooks/useExport.ts
@@ -1,4 +1,5 @@
 import { useCallback } from 'react';
+import { logger } from '../utils/helpers/logger';
 import { ActiveTab } from '../types/component-types';
 import exportCss from '../styles/export.css?raw';
 import { usePlatformAPI } from '../hooks/usePlatform';
@@ -19,7 +20,7 @@ export function useExport(activeTab: ActiveTab) {
         await api.exportHTML(activeTab.html, css, '');
       }
     } catch (err) {
-      console.error('Failed to export HTML', err);
+      logger.error('Failed to export HTML:', err instanceof Error ? err.message : String(err));
     }
   }, [activeTab, api]);
 
@@ -36,7 +37,7 @@ export function useExport(activeTab: ActiveTab) {
         await api.exportPDF(activeTab.html, css, '');
       }
     } catch (err) {
-      console.error('Failed to export PDF', err);
+      logger.error('Failed to export PDF:', err instanceof Error ? err.message : String(err));
     }
   }, [activeTab, api]);
 
@@ -53,7 +54,7 @@ export function useExport(activeTab: ActiveTab) {
         await api.exportDOCX(activeTab.html, css, '');
       }
     } catch (err) {
-      console.error('Failed to export DOCX', err);
+      logger.error('Failed to export DOCX:', err instanceof Error ? err.message : String(err));
     }
   }, [activeTab, api]);
 

--- a/apps/renderer/src/hooks/useFile.ts
+++ b/apps/renderer/src/hooks/useFile.ts
@@ -22,10 +22,7 @@ export function useFile() {
       .getRecentFiles()
       .then(setRecentFiles)
       .catch((error) => {
-        logger.error(
-          'Failed to get recent files:',
-          error instanceof Error ? error.message : String(error)
-        );
+        logger.error('Failed to get recent files:', error);
       });
   }, [api]);
 
@@ -52,7 +49,8 @@ export function useFile() {
         };
       } catch (error: unknown) {
         const raw = error instanceof Error ? error.message : String(error);
-        logger.error(`Failed to load file ${path}:`, raw);
+        const redactedPath = path.split(/[\\/]/).pop() || path;
+        logger.error(`Failed to load file ${redactedPath}:`, error);
         setError(ErrorMessage(raw, path));
       } finally {
         setIsLoading(false);

--- a/apps/renderer/src/hooks/useFile.ts
+++ b/apps/renderer/src/hooks/useFile.ts
@@ -1,4 +1,5 @@
 import { useState, useCallback, useEffect } from 'react';
+import { logger } from '../utils/helpers/logger';
 import DOMpurify from 'dompurify';
 import { renderMarkdown } from '../renderer/markdown';
 import { extractTOC } from '../renderer/toc';
@@ -20,7 +21,12 @@ export function useFile() {
     api
       .getRecentFiles()
       .then(setRecentFiles)
-      .catch(() => {});
+      .catch((error) => {
+        logger.error(
+          'Failed to get recent files:',
+          error instanceof Error ? error.message : String(error)
+        );
+      });
   }, [api]);
 
   const loadFile = useCallback(
@@ -46,6 +52,7 @@ export function useFile() {
         };
       } catch (error: unknown) {
         const raw = error instanceof Error ? error.message : String(error);
+        logger.error(`Failed to load file ${path}:`, raw);
         setError(ErrorMessage(raw, path));
       } finally {
         setIsLoading(false);

--- a/apps/renderer/src/hooks/useFileActions.ts
+++ b/apps/renderer/src/hooks/useFileActions.ts
@@ -18,10 +18,7 @@ export function useFileActions({ loadFile, dispatch }: FileActionProps) {
       setFolderTree(tree);
       setFolderPath(folderPath);
     } catch (error) {
-      logger.error(
-        'Failed to open folder:',
-        error instanceof Error ? error.message : String(error)
-      );
+      logger.error('Failed to open folder:', error);
     }
   }, [api]);
 
@@ -49,18 +46,12 @@ export function useFileActions({ loadFile, dispatch }: FileActionProps) {
       .then((chosenPath) => {
         if (chosenPath) {
           void loadFileInTab(chosenPath).catch((err) =>
-            logger.error(
-              'Failed to load file in tab:',
-              err instanceof Error ? err.message : String(err)
-            )
+            logger.error('Failed to load file in tab:', err)
           );
         }
       })
       .catch((error) => {
-        logger.error(
-          'Failed to open file dialog:',
-          error instanceof Error ? error.message : String(error)
-        );
+        logger.error('Failed to open file dialog:', error);
       });
   }, [loadFileInTab, api]);
 

--- a/apps/renderer/src/hooks/useFileActions.ts
+++ b/apps/renderer/src/hooks/useFileActions.ts
@@ -1,4 +1,5 @@
 import { useCallback, useState } from 'react';
+import { logger } from '../utils/helpers/logger';
 import { FileType } from '@package/shared-types';
 import { FileActionProps } from '../types/hook-types';
 import { usePlatformAPI } from '../hooks/usePlatform';
@@ -17,7 +18,10 @@ export function useFileActions({ loadFile, dispatch }: FileActionProps) {
       setFolderTree(tree);
       setFolderPath(folderPath);
     } catch (error) {
-      console.error('Failed to open folder:', error);
+      logger.error(
+        'Failed to open folder:',
+        error instanceof Error ? error.message : String(error)
+      );
     }
   }, [api]);
 
@@ -45,12 +49,18 @@ export function useFileActions({ loadFile, dispatch }: FileActionProps) {
       .then((chosenPath) => {
         if (chosenPath) {
           void loadFileInTab(chosenPath).catch((err) =>
-            console.error('Failed to load file in tab:', err)
+            logger.error(
+              'Failed to load file in tab:',
+              err instanceof Error ? err.message : String(err)
+            )
           );
         }
       })
       .catch((error) => {
-        console.error('Failed to open file dialog:', error);
+        logger.error(
+          'Failed to open file dialog:',
+          error instanceof Error ? error.message : String(error)
+        );
       });
   }, [loadFileInTab, api]);
 

--- a/apps/renderer/src/hooks/useSettings.ts
+++ b/apps/renderer/src/hooks/useSettings.ts
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useState } from 'react';
+import { logger } from '../utils/helpers/logger';
 import { FONT_SIZE, WIDTH_MAP } from '../types/component-types';
 import { AppSettings, DEFAULT_SETTINGS } from '@package/shared-types';
 import { usePlatformAPI } from '../hooks/usePlatform';
@@ -18,7 +19,10 @@ export function useSettings() {
         setSettings(savedSettings);
       })
       .catch((error) => {
-        console.error('Failed to load settings using defaults', error);
+        logger.error(
+          'Failed to load settings using defaults:',
+          error instanceof Error ? error.message : String(error)
+        );
       });
   }, [api]);
 
@@ -55,7 +59,10 @@ export function useSettings() {
         const next = await api.saveSettings(partial);
         setSettings(next);
       } catch (error) {
-        console.error('Failed to save settings:', error);
+        logger.error(
+          'Failed to save settings:',
+          error instanceof Error ? error.message : String(error)
+        );
         throw error;
       }
     },

--- a/apps/renderer/src/hooks/useSettings.ts
+++ b/apps/renderer/src/hooks/useSettings.ts
@@ -59,10 +59,7 @@ export function useSettings() {
         const next = await api.saveSettings(partial);
         setSettings(next);
       } catch (error) {
-        logger.error(
-          'Failed to save settings:',
-          error instanceof Error ? error.message : String(error)
-        );
+        logger.error('Failed to save settings:', error);
         throw error;
       }
     },

--- a/apps/renderer/src/utils/helpers/clipboard-helper.ts
+++ b/apps/renderer/src/utils/helpers/clipboard-helper.ts
@@ -1,3 +1,5 @@
+import { logger } from './logger';
+
 export const copyToClipboard = async (content: string, mimeType: string): Promise<boolean> => {
   try {
     if (!navigator?.clipboard) {
@@ -17,7 +19,7 @@ export const copyToClipboard = async (content: string, mimeType: string): Promis
       throw new Error('Clipboard API write methods not available');
     }
   } catch (err) {
-    console.error('Failed to copy text: ', err);
+    logger.error('Failed to copy text: ', err instanceof Error ? err.message : String(err));
     return false;
   }
 };

--- a/apps/renderer/src/utils/helpers/clipboard-helper.ts
+++ b/apps/renderer/src/utils/helpers/clipboard-helper.ts
@@ -19,7 +19,7 @@ export const copyToClipboard = async (content: string, mimeType: string): Promis
       throw new Error('Clipboard API write methods not available');
     }
   } catch (err) {
-    logger.error('Failed to copy text: ', err instanceof Error ? err.message : String(err));
+    logger.error('Failed to copy text: ', err);
     return false;
   }
 };

--- a/apps/renderer/src/utils/helpers/logger.ts
+++ b/apps/renderer/src/utils/helpers/logger.ts
@@ -1,0 +1,23 @@
+export const logger = {
+  info: (message: string, ...args: unknown[]) => {
+    if (window.api && window.api.log) {
+      window.api.log.info(message, ...args);
+    } else {
+      console.info(message, ...args);
+    }
+  },
+  error: (message: string, ...args: unknown[]) => {
+    if (window.api && window.api.log) {
+      window.api.log.error(message, ...args);
+    } else {
+      console.error(message, ...args);
+    }
+  },
+  warn: (message: string, ...args: unknown[]) => {
+    if (window.api && window.api.log) {
+      window.api.log.warn(message, ...args);
+    } else {
+      console.warn(message, ...args);
+    }
+  },
+};

--- a/apps/renderer/src/utils/helpers/logger.ts
+++ b/apps/renderer/src/utils/helpers/logger.ts
@@ -1,23 +1,28 @@
+import { normalizeArgs } from './normalize-args';
+
 export const logger = {
   info: (message: string, ...args: unknown[]) => {
+    const normalized = normalizeArgs(args);
     if (window.api && window.api.log) {
-      window.api.log.info(message, ...args);
+      window.api.log.info(message, ...normalized);
     } else {
-      console.info(message, ...args);
+      console.info(message, ...normalized);
     }
   },
   error: (message: string, ...args: unknown[]) => {
+    const normalized = normalizeArgs(args);
     if (window.api && window.api.log) {
-      window.api.log.error(message, ...args);
+      window.api.log.error(message, ...normalized);
     } else {
-      console.error(message, ...args);
+      console.error(message, ...normalized);
     }
   },
   warn: (message: string, ...args: unknown[]) => {
+    const normalized = normalizeArgs(args);
     if (window.api && window.api.log) {
-      window.api.log.warn(message, ...args);
+      window.api.log.warn(message, ...normalized);
     } else {
-      console.warn(message, ...args);
+      console.warn(message, ...normalized);
     }
   },
 };

--- a/apps/renderer/src/utils/helpers/normalize-args.ts
+++ b/apps/renderer/src/utils/helpers/normalize-args.ts
@@ -1,0 +1,8 @@
+export const normalizeArgs = (args: unknown[]) => {
+  return args.map((arg) => {
+    if (arg instanceof Error) {
+      return { message: arg.message, stack: arg.stack, name: arg.name };
+    }
+    return arg;
+  });
+};

--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
     ]
   },
   "dependencies": {
+    "electron-log": "^5.4.4",
     "react": "^19.2.5",
     "react-dom": "^19.2.5"
   },

--- a/packages/shared-constants/src/ipc-constants.ts
+++ b/packages/shared-constants/src/ipc-constants.ts
@@ -23,4 +23,5 @@ export const IPC_CONSTANTS = {
   UPDATE_AVAILABLE: 'update-available',
   DOWNLOAD_UPDATE: 'download-update',
   UPDATE_DOWNLOADED: 'update-downloaded',
+  LOG_MESSAGE: 'log-message',
 } as const;

--- a/packages/shared-types/src/markdown-type.ts
+++ b/packages/shared-types/src/markdown-type.ts
@@ -31,4 +31,9 @@ export type MarkdownReaderAPI = {
   getPathForFile(file: File): string;
   onUpdateAvailable: (callback: (version: string) => void) => () => void;
   downloadUpdate: () => void;
+  log: {
+    info(message: string, ...args: unknown[]): void;
+    error(message: string, ...args: unknown[]): void;
+    warn(message: string, ...args: unknown[]): void;
+  };
 };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -19,6 +19,9 @@ importers:
 
   .:
     dependencies:
+      electron-log:
+        specifier: ^5.4.4
+        version: 5.4.4
       react:
         specifier: ^19.2.5
         version: 19.2.5
@@ -4891,6 +4894,10 @@ packages:
     engines: {node: '>=14.0.0'}
     hasBin: true
 
+  electron-log@5.4.4:
+    resolution: {integrity: sha512-istWgaXjBfURBSS8LWVW9C3jsc6+ac+tY1lXrQEOTp0lVj+a4OlO1Tmqb36GgnEUDv92DGC9VI1HNXwJinWpgA==}
+    engines: {node: '>= 14'}
+
   electron-publish@26.8.1:
     resolution: {integrity: sha512-q+jrSTIh/Cv4eGZa7oVR+grEJo/FoLMYBAnSL5GCtqwUpr1T+VgKB/dn1pnzxIxqD8S/jP1yilT9VrwCqINR4w==}
 
@@ -5352,8 +5359,8 @@ packages:
     resolution: {integrity: sha512-CTXd6rk/M3/ULNQj8FBqBWHYBVYybQ3VPBw0xGKFe3tuH7ytT6ACnvzpIQ3UZtB8yvUKC2cXn1a+x+5EVQLovA==}
     engines: {node: '>=14.14'}
 
-  fs-extra@11.3.5:
-    resolution: {integrity: sha512-eKpRKAovdpZtR1WopLHxlBWvAgPny3c4gX1G5Jhwmmw4XJj0ifSD5qB5TOo8hmA0wlRKDAOAhEE1yVPgs6Fgcg==}
+  fs-extra@11.3.6:
+    resolution: {integrity: sha512-w8ZNZr2mKIc7qeNaQ9AVPT1+iFaI+Avd4xudVOvdDJ8VytREi1Ft5Ih7hd9jjehod8vAM5GMsfQ/TpPf4EyoEA==}
     engines: {node: '>=14.14'}
 
   fs-extra@7.0.1:
@@ -11913,7 +11920,7 @@ snapshots:
     dependencies:
       cross-dirname: 0.1.0
       debug: 4.4.3
-      fs-extra: 11.3.5
+      fs-extra: 11.3.6
       minimist: 1.2.8
       postject: 1.0.0-alpha.6
     transitivePeerDependencies:
@@ -15264,6 +15271,8 @@ snapshots:
       - electron-builder-squirrel-windows
       - supports-color
 
+  electron-log@5.4.4: {}
+
   electron-publish@26.8.1:
     dependencies:
       '@types/fs-extra': 9.0.13
@@ -15836,7 +15845,7 @@ snapshots:
       jsonfile: 6.2.1
       universalify: 2.0.1
 
-  fs-extra@11.3.5:
+  fs-extra@11.3.6:
     dependencies:
       graceful-fs: 4.2.11
       jsonfile: 6.2.1


### PR DESCRIPTION
## Description

This PR adds electron log library to the codebase for tracking error in production

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [x] Refactor (no functional change)
- [ ] Documentation update
- [ ] Style / UI change
- [ ] Build / CI change

## Related Issue

Closes #138

## Checklist

- [x] My code follows the project's coding guidelines
- [x] I have tested my changes locally
- [x] I have used [conventional commit](https://www.conventionalcommits.org/) messages
- [ ] I have updated documentation if needed
- [x] My changes do not introduce new warnings or errors


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
- Electron main/preload
  - Added `electron-log` as a runtime logger: initialized `electron-log/main`, remapped `console` to use `electron-log` functions, and started error catching.
  - Implemented a main-process IPC listener for centralized renderer logging (`IPC_CONSTANTS.LOG_MESSAGE`), including sender validation, log-level allowlisting (`info`/`warn`/`error`), and truncation/argument limits before forwarding to `electron-log`.
  - Exposed `window.api.log.{info,error,warn}` from the preload (`contextBridge`) to allow renderer code to send log messages to the main process.

- Renderer UI
  - Introduced a shared `logger` utility that normalizes arguments (including `Error` objects) and uses `window.api.log.*` when available, otherwise falls back to `console`.
  - Replaced multiple `console.error` usages with `logger.error` across renderer error paths, including `ErrorBoundary`, Markmap rendering failures, export/copy handlers (`ReaderToolbar`), export hook (`useExport`), recent file/loading errors (`useFile`), file dialog flows (`useFileActions`), settings load/save (`useSettings`), and clipboard copy failures.
  - Updated `ErrorBoundary`’s `componentDidCatch` handler signature to accept `(error: Error, errorInfo: React.ErrorInfo)` and pass both into `logger.error`.

- Markdown rendering
  - Extended the renderer-facing `MarkdownReaderAPI` to include a `log` object (`info`, `error`, `warn`) so markdown-related code can emit logs via the same channel.
  
- Shared packages
  - Added `LOG_MESSAGE: 'log-message'` to shared IPC constants.

- Tests / tooling/CI / docs
  - No test, tooling/CI, or documentation changes reflected in this diff.

- Packaging
  - Added `electron-log` (`^5.4.4`) to `package.json` dependencies.

Breaking changes: None
<!-- end of auto-generated comment: release notes by coderabbit.ai -->